### PR TITLE
fix: forward every part renderer option through MessagePrimitive.Parts

### DIFF
--- a/.changeset/ink-part-renderer-options.md
+++ b/.changeset/ink-part-renderer-options.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix: forward every part renderer option through `MessagePrimitive.Parts`, so configured generative UI renders

--- a/.changeset/native-part-renderer-options.md
+++ b/.changeset/native-part-renderer-options.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-native": patch
+---
+
+fix: render configured generative UI in MessagePrimitive.Parts and keep data renderers when ChainOfThought is active.

--- a/.changeset/native-part-renderer-options.md
+++ b/.changeset/native-part-renderer-options.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-native": patch
 ---
 
-fix: render configured generative UI in MessagePrimitive.Parts and keep data renderers when ChainOfThought is active.
+fix: forward every part renderer option through `MessagePrimitive.Parts`, so configured generative UI renders and data renderers survive `ChainOfThought`

--- a/.changeset/web-part-renderer-options.md
+++ b/.changeset/web-part-renderer-options.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: forward every part renderer option through `MessagePrimitive.Parts`, so data renderers survive `ChainOfThought`

--- a/packages/react-ink/src/primitives/message/MessageParts.tsx
+++ b/packages/react-ink/src/primitives/message/MessageParts.tsx
@@ -33,35 +33,28 @@ export namespace MessagePrimitiveParts {
 const mergeWithInkDefaults = (
   components: NonNullable<MessagePrimitiveParts.Props["components"]>,
 ): NonNullable<MessagePrimitiveParts.Props["components"]> => {
-  const shared = {
+  const inkOverrides = {
     Text: components.Text ?? inkDefaultComponents.Text,
     Image: components.Image ?? inkDefaultComponents.Image,
     Source: components.Source ?? inkDefaultComponents.Source,
     File: components.File ?? inkDefaultComponents.File,
-    Unstable_Audio:
-      components.Unstable_Audio ?? messagePartsDefaultComponents.Unstable_Audio,
     data: components.data
       ? {
-          by_name: components.data.by_name,
+          ...components.data,
           Fallback:
             components.data.Fallback ?? inkDefaultComponents.data.Fallback,
         }
       : inkDefaultComponents.data,
-    Quote: components.Quote,
-    Empty: components.Empty,
   };
 
   if ("ChainOfThought" in components) {
-    return { ...shared, ChainOfThought: components.ChainOfThought };
+    return { ...components, ...inkOverrides };
   }
 
   return {
-    ...shared,
+    ...components,
+    ...inkOverrides,
     Reasoning: components.Reasoning ?? inkDefaultComponents.Reasoning,
-    tools: components.tools,
-    ToolGroup: components.ToolGroup ?? messagePartsDefaultComponents.ToolGroup,
-    ReasoningGroup:
-      components.ReasoningGroup ?? messagePartsDefaultComponents.ReasoningGroup,
   };
 };
 

--- a/packages/react-ink/src/tests/MessageParts.test.tsx
+++ b/packages/react-ink/src/tests/MessageParts.test.tsx
@@ -88,6 +88,20 @@ describe("MessagePrimitive.Parts", () => {
     expect(components.ChainOfThought).toBeUndefined();
   });
 
+  it("forwards generativeUI in both grouping modes", async () => {
+    const generativeUI = { components: { Card: () => null } };
+
+    await renderFrame(<MessagePrimitive.Parts components={{ generativeUI }} />);
+    expect(lastComponents().generativeUI).toBe(generativeUI);
+
+    await renderFrame(
+      <MessagePrimitive.Parts
+        components={{ generativeUI, ChainOfThought: () => null }}
+      />,
+    );
+    expect(lastComponents().generativeUI).toBe(generativeUI);
+  });
+
   it("injects ink data.Fallback when components is omitted", async () => {
     await renderFrame(<MessagePrimitive.Parts />);
 

--- a/packages/react-native/src/primitives/message/MessageParts.test.tsx
+++ b/packages/react-native/src/primitives/message/MessageParts.test.tsx
@@ -95,17 +95,22 @@ describe("MessagePrimitiveParts", () => {
     );
   });
 
-  it("keeps data renderers when chain-of-thought grouping changes", async () => {
-    const dataComponents = { data: components.data };
-    await act(async () => root.render(<App components={dataComponents} />));
-    expect(container.textContent).toBe("AnswerChart: 42Data: 7");
+  it("keeps data and generative UI when chain-of-thought grouping changes", async () => {
+    await act(async () => root.render(<App components={components} />));
+    expect(container.textContent).toBe(
+      "AnswerResultUnavailable: UnknownChart: 42Data: 7",
+    );
 
     await act(async () =>
-      root.render(<App components={{ ...dataComponents, ChainOfThought }} />),
+      root.render(<App components={{ ...components, ChainOfThought }} />),
     );
-    expect(container.textContent).toBe("AnswerThought groupChart: 42Data: 7");
+    expect(container.textContent).toBe(
+      "AnswerThought groupResultUnavailable: UnknownChart: 42Data: 7",
+    );
 
-    await act(async () => root.render(<App components={dataComponents} />));
-    expect(container.textContent).toBe("AnswerChart: 42Data: 7");
+    await act(async () => root.render(<App components={components} />));
+    expect(container.textContent).toBe(
+      "AnswerResultUnavailable: UnknownChart: 42Data: 7",
+    );
   });
 });

--- a/packages/react-native/src/primitives/message/MessageParts.test.tsx
+++ b/packages/react-native/src/primitives/message/MessageParts.test.tsx
@@ -1,0 +1,111 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Text } from "react-native";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ThreadMessageLike } from "@assistant-ui/core";
+import {
+  AssistantRuntimeProvider,
+  MessageByIndexProvider,
+  useExternalStoreRuntime,
+} from "@assistant-ui/core/react";
+import { MessagePrimitiveParts } from "./MessageParts";
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const messages: ThreadMessageLike[] = [
+  {
+    role: "assistant",
+    content: [
+      { type: "text", text: "Answer" },
+      { type: "reasoning", text: "Thinking" },
+      {
+        type: "generative-ui",
+        spec: {
+          root: [
+            { component: "Card", props: { title: "Result" } },
+            { component: "Unknown" },
+          ],
+        },
+      },
+      { type: "data", name: "chart", data: 42 },
+      { type: "data", name: "other", data: 7 },
+    ],
+  },
+];
+
+const components = {
+  generativeUI: {
+    components: {
+      Card: ({ title }: { title: string }) => <Text>{title}</Text>,
+    },
+    Fallback: ({ component }: { component: string }) => (
+      <Text>Unavailable: {component}</Text>
+    ),
+  },
+  data: {
+    by_name: {
+      chart: ({ data }: { data: unknown }) => (
+        <Text>Chart: {String(data)}</Text>
+      ),
+    },
+    Fallback: ({ data }: { data: unknown }) => (
+      <Text>Data: {String(data)}</Text>
+    ),
+  },
+};
+
+const App = (props: MessagePrimitiveParts.Props) => {
+  const runtime = useExternalStoreRuntime({
+    messages,
+    convertMessage: (message) => message,
+    onNew: async () => {
+      throw new Error("This thread is read-only");
+    },
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <MessageByIndexProvider index={0}>
+        <MessagePrimitiveParts {...props} />
+      </MessageByIndexProvider>
+    </AssistantRuntimeProvider>
+  );
+};
+
+const ChainOfThought = () => <Text>Thought group</Text>;
+
+describe("MessagePrimitiveParts", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("renders generative UI and its fallback beside native text", async () => {
+    await act(async () => root.render(<App components={components} />));
+    expect(container.textContent).toBe(
+      "AnswerResultUnavailable: UnknownChart: 42Data: 7",
+    );
+  });
+
+  it("keeps data renderers when chain-of-thought grouping changes", async () => {
+    const dataComponents = { data: components.data };
+    await act(async () => root.render(<App components={dataComponents} />));
+    expect(container.textContent).toBe("AnswerChart: 42Data: 7");
+
+    await act(async () =>
+      root.render(<App components={{ ...dataComponents, ChainOfThought }} />),
+    );
+    expect(container.textContent).toBe("AnswerThought groupChart: 42Data: 7");
+
+    await act(async () => root.render(<App components={dataComponents} />));
+    expect(container.textContent).toBe("AnswerChart: 42Data: 7");
+  });
+});

--- a/packages/react-native/src/primitives/message/MessageParts.tsx
+++ b/packages/react-native/src/primitives/message/MessageParts.tsx
@@ -31,6 +31,7 @@ export const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props> = (
   const { components, ...rest } = props;
   const merged = components
     ? {
+        ...components,
         Text: components.Text ?? rnDefaultComponents.Text,
         Image: components.Image ?? messagePartsDefaultComponents.Image,
         Reasoning:
@@ -41,19 +42,14 @@ export const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props> = (
           components.Unstable_Audio ??
           messagePartsDefaultComponents.Unstable_Audio,
         ...("ChainOfThought" in components
-          ? { ChainOfThought: components.ChainOfThought }
+          ? {}
           : {
-              tools: components.tools,
               ToolGroup:
                 components.ToolGroup ?? messagePartsDefaultComponents.ToolGroup,
               ReasoningGroup:
                 components.ReasoningGroup ??
                 messagePartsDefaultComponents.ReasoningGroup,
             }),
-        Empty: components.Empty,
-        Quote: components.Quote,
-        data: components.data,
-        generativeUI: components.generativeUI,
       }
     : rnDefaultComponents;
 

--- a/packages/react-native/src/primitives/message/MessageParts.tsx
+++ b/packages/react-native/src/primitives/message/MessageParts.tsx
@@ -30,27 +30,7 @@ export const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props> = (
 
   const { components, ...rest } = props;
   const merged = components
-    ? {
-        ...components,
-        Text: components.Text ?? rnDefaultComponents.Text,
-        Image: components.Image ?? messagePartsDefaultComponents.Image,
-        Reasoning:
-          components.Reasoning ?? messagePartsDefaultComponents.Reasoning,
-        Source: components.Source ?? messagePartsDefaultComponents.Source,
-        File: components.File ?? messagePartsDefaultComponents.File,
-        Unstable_Audio:
-          components.Unstable_Audio ??
-          messagePartsDefaultComponents.Unstable_Audio,
-        ...("ChainOfThought" in components
-          ? {}
-          : {
-              ToolGroup:
-                components.ToolGroup ?? messagePartsDefaultComponents.ToolGroup,
-              ReasoningGroup:
-                components.ReasoningGroup ??
-                messagePartsDefaultComponents.ReasoningGroup,
-            }),
-      }
+    ? { ...components, Text: components.Text ?? rnDefaultComponents.Text }
     : rnDefaultComponents;
 
   return <MessagePrimitivePartsBase components={merged as any} {...rest} />;

--- a/packages/react-native/src/primitives/message/MessageParts.tsx
+++ b/packages/react-native/src/primitives/message/MessageParts.tsx
@@ -44,7 +44,6 @@ export const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props> = (
           ? { ChainOfThought: components.ChainOfThought }
           : {
               tools: components.tools,
-              data: components.data,
               ToolGroup:
                 components.ToolGroup ?? messagePartsDefaultComponents.ToolGroup,
               ReasoningGroup:
@@ -53,6 +52,8 @@ export const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props> = (
             }),
         Empty: components.Empty,
         Quote: components.Quote,
+        data: components.data,
+        generativeUI: components.generativeUI,
       }
     : rnDefaultComponents;
 

--- a/packages/react/src/primitives/message/MessageParts.tsx
+++ b/packages/react/src/primitives/message/MessageParts.tsx
@@ -43,29 +43,9 @@ export const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props> = (
   const { components, ...rest } = props;
   const merged = components
     ? {
+        ...components,
         Text: components.Text ?? webDefaultComponents.Text,
         Image: components.Image ?? webDefaultComponents.Image,
-        Reasoning:
-          components.Reasoning ?? messagePartsDefaultComponents.Reasoning,
-        Source: components.Source ?? messagePartsDefaultComponents.Source,
-        File: components.File ?? messagePartsDefaultComponents.File,
-        Unstable_Audio:
-          components.Unstable_Audio ??
-          messagePartsDefaultComponents.Unstable_Audio,
-        ...("ChainOfThought" in components
-          ? { ChainOfThought: components.ChainOfThought }
-          : {
-              tools: components.tools,
-              data: components.data,
-              ToolGroup:
-                components.ToolGroup ?? messagePartsDefaultComponents.ToolGroup,
-              ReasoningGroup:
-                components.ReasoningGroup ??
-                messagePartsDefaultComponents.ReasoningGroup,
-            }),
-        Empty: components.Empty,
-        Quote: components.Quote,
-        generativeUI: components.generativeUI,
       }
     : webDefaultComponents;
 

--- a/packages/react/src/tests/MessageParts.rendererOptions.test.tsx
+++ b/packages/react/src/tests/MessageParts.rendererOptions.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  AssistantRuntimeProvider,
+  MessageByIndexProvider,
+  useExternalStoreRuntime,
+} from "@assistant-ui/core/react";
+import type { ThreadMessageLike } from "@assistant-ui/core";
+import { MessagePrimitiveParts } from "../primitives/message/MessageParts";
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const messages: ThreadMessageLike[] = [
+  {
+    role: "assistant",
+    content: [
+      { type: "text", text: "Answer" },
+      { type: "reasoning", text: "Thinking" },
+      {
+        type: "generative-ui",
+        spec: {
+          root: [
+            { component: "Card", props: { title: "Result" } },
+            { component: "Unknown" },
+          ],
+        },
+      },
+      { type: "data", name: "chart", data: 42 },
+      { type: "data", name: "other", data: 7 },
+    ],
+  },
+];
+
+const components = {
+  generativeUI: {
+    components: {
+      Card: ({ title }: { title: string }) => <span>{title}</span>,
+    },
+    Fallback: ({ component }: { component: string }) => (
+      <span>Unavailable: {component}</span>
+    ),
+  },
+  data: {
+    by_name: {
+      chart: ({ data }: { data: unknown }) => (
+        <span>Chart: {String(data)}</span>
+      ),
+    },
+    Fallback: ({ data }: { data: unknown }) => (
+      <span>Data: {String(data)}</span>
+    ),
+  },
+};
+
+const App = (props: MessagePrimitiveParts.Props) => {
+  const runtime = useExternalStoreRuntime({
+    messages,
+    convertMessage: (message) => message,
+    onNew: async () => {
+      throw new Error("This thread is read-only");
+    },
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <MessageByIndexProvider index={0}>
+        <MessagePrimitiveParts {...props} />
+      </MessageByIndexProvider>
+    </AssistantRuntimeProvider>
+  );
+};
+
+const ChainOfThought = () => <span>Thought group</span>;
+
+describe("MessagePrimitiveParts", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("renders generative UI and its fallback beside web text", async () => {
+    await act(async () => root.render(<App components={components} />));
+    expect(container.textContent).toBe(
+      "AnswerResultUnavailable: UnknownChart: 42Data: 7",
+    );
+  });
+
+  it("keeps data and generative UI when chain-of-thought grouping changes", async () => {
+    await act(async () => root.render(<App components={components} />));
+    expect(container.textContent).toBe(
+      "AnswerResultUnavailable: UnknownChart: 42Data: 7",
+    );
+
+    await act(async () =>
+      root.render(<App components={{ ...components, ChainOfThought }} />),
+    );
+    expect(container.textContent).toBe(
+      "AnswerThought groupResultUnavailable: UnknownChart: 42Data: 7",
+    );
+
+    await act(async () => root.render(<App components={components} />));
+    expect(container.textContent).toBe(
+      "AnswerResultUnavailable: UnknownChart: 42Data: 7",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`MessagePrimitive.Parts` silently drops part renderer options the caller configured. Each of the three distributions drops a different subset, so the same `components` object renders differently depending on which package you import from.

| | `generativeUI` | `data` under `ChainOfThought` |
|---|---|---|
| `@assistant-ui/react` | forwarded | **dropped** |
| `@assistant-ui/react-native` | **dropped** | **dropped** |
| `@assistant-ui/react-ink` | **dropped** | forwarded |

Reproduction, against an assistant message carrying a `generative-ui` part and two `data` parts:

```tsx
<MessagePrimitive.Parts
  components={{
    generativeUI: { components: { Card } },
    data: { by_name: { chart: Chart } },
    // and, for the second column, ChainOfThought
  }}
/>
```

On `@assistant-ui/react` before this change, turning on `ChainOfThought` renders `AnswerThought groupResult` where `AnswerThought groupResultChart: 42` is expected: the chart renderer is gone. On `@assistant-ui/react-native` the same message renders `AnswerChart: 42Data: 7` with the generative UI missing in both grouping modes. On `@assistant-ui/react-ink` the wrapper never puts `generativeUI` on the map at all.

## Root cause

Each platform wrapper rebuilds the component map key by key before handing it to the shared `MessagePrimitiveParts`, so a key that nobody remembered to re-add is dropped. `generativeUI` was added to `BaseComponents` in #3967 and only `@assistant-ui/react` was updated. The `ChainOfThought` branch made it worse by enumerating a second, shorter key list, which is where `data` fell out on web and native even though `data` lives on `BaseComponents` and is valid in both grouping modes.

## Change

The wrappers now spread the caller's `components` and only layer the platform defaults on top, so the grouping branch decides *which defaults get injected* rather than *which keys survive*. Anything core adds to `BaseComponents` later reaches the shared renderer without a wrapper edit.

That also removes a pile of no-op injections: `messagePartsDefaultComponents` is core's own `defaultComponents` (aliased at `core/src/react/index.ts:284`), and core already destructures those same fallbacks itself (`MessageParts.tsx:407-412`) plus `components?.ToolGroup ?? defaultComponents.ToolGroup` and the `ReasoningGroup` equivalent. Re-supplying identical references from each wrapper did nothing. What is left is genuinely platform-specific:

- `@assistant-ui/react`: `Text`, `Image`
- `@assistant-ui/react-native`: `Text`
- `@assistant-ui/react-ink`: `Text`, `Image`, `Source`, `File`, the terminal-safe `data.Fallback`, and `Reasoning` in the standard branch

Ink keeps its early return so `Reasoning` stays off the map under `ChainOfThought`, which is what its existing contract test asserts and what core's `ChainOfThoughtComponents` type requires.

## Verification

- `packages/react/src/tests/MessageParts.rendererOptions.test.tsx` (new) and `packages/react-native/src/primitives/message/MessageParts.test.tsx` (new) render a message with `generative-ui` and `data` parts through both grouping modes and back. `packages/react-ink/src/tests/MessageParts.test.tsx` gains a `generativeUI` forwarding case in both modes.
- Each new test fails on the pre-change wrapper and passes after: web `AnswerThought groupResultUnavailable: Unknown` vs the expected string, native `AnswerChart: 42Data: 7` vs the expected string, ink `expected undefined to be { Object (components) }`.
- Full suites pass: `@assistant-ui/react` 570, `@assistant-ui/react-native` 256, `@assistant-ui/react-ink` 282.
- `pnpm lint`, `pnpm changesets:check`, `pnpm build`, and `pnpm size:check` pass. `tsc --noEmit` on the three packages reports only errors that are pre-existing on `main` in unrelated test files.

## Public surface

No export, signature, or type changes. Patch changesets for `@assistant-ui/react`, `@assistant-ui/react-native`, and `@assistant-ui/react-ink`. Every size budget stays within tolerance, so `size-budgets.json` is untouched. No documentation or API-reference impact.
