### PR TITLE
fix(ci): stop the semver check from grading deleted heads

### DIFF
--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -3,7 +3,7 @@ name: Changeset Semver Check
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -16,8 +16,6 @@ concurrency:
 jobs:
   analyze:
     name: Semver Check
-    # actions/checkout diverts a fork PR to the base branch, so the runner never holds the PR's tree or its head commit.
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 2
     steps:

--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Check changeset bump types against package versions
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # The payload head sha is not in the object store on fork PRs; the checked-out merge ref's parents always resolve.
+          BASE_REV: HEAD^1
+          HEAD_REV: HEAD^2
         run: node scripts/check-changeset-semver.mjs

--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   analyze:
     name: Semver Check
+    # actions/checkout diverts a fork PR to the base branch, so the runner never holds the PR's tree or its head commit.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 2
     steps:
@@ -41,7 +43,6 @@ jobs:
 
       - name: Check changeset bump types against package versions
         env:
-          # The payload head sha is not in the object store on fork PRs; the checked-out merge ref's parents always resolve.
-          BASE_REV: HEAD^1
-          HEAD_REV: HEAD^2
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/check-changeset-semver.mjs

--- a/scripts/check-changeset-semver.mjs
+++ b/scripts/check-changeset-semver.mjs
@@ -232,7 +232,15 @@ export function runCheck(root = repoRoot, changedFiles = null) {
 }
 
 function annotate(level, message) {
-  console.log(process.env.GITHUB_ACTIONS ? `::${level}::${message}` : message);
+  if (!process.env.GITHUB_ACTIONS) {
+    console.log(message);
+    return;
+  }
+  const data = message
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A");
+  console.log(`::${level}::${data}`);
 }
 
 function writeSummary(summary) {

--- a/scripts/check-changeset-semver.mjs
+++ b/scripts/check-changeset-semver.mjs
@@ -258,11 +258,7 @@ function diffChangesetFiles(root, baseSha, headSha) {
     ).trim();
     return new Set(diff ? diff.split("\n").map((f) => path.basename(f)) : []);
   } catch {
-    annotate(
-      "error",
-      `Could not diff ${baseSha.slice(0, 12)}..${headSha.slice(0, 12)} — the base or head commit is not fetchable (a rerun against a deleted branch?). Failing instead of grading every changeset in the tree.`,
-    );
-    process.exit(1);
+    return undefined;
   }
 }
 
@@ -271,6 +267,14 @@ function main() {
   const { BASE_SHA, HEAD_SHA } = process.env;
   const changedFiles =
     BASE_SHA && HEAD_SHA ? diffChangesetFiles(root, BASE_SHA, HEAD_SHA) : null;
+  if (changedFiles === undefined) {
+    annotate(
+      "error",
+      `Could not diff ${BASE_SHA.slice(0, 12)}..${HEAD_SHA.slice(0, 12)} — the base or head commit is not fetchable (a rerun against a deleted branch?). Failing instead of grading every changeset in the tree.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
 
   const { files, bumps, violations, cascade } = runCheck(root, changedFiles);
 

--- a/scripts/check-changeset-semver.mjs
+++ b/scripts/check-changeset-semver.mjs
@@ -259,10 +259,10 @@ function diffChangesetFiles(root, baseSha, headSha) {
     return new Set(diff ? diff.split("\n").map((f) => path.basename(f)) : []);
   } catch {
     annotate(
-      "warning",
-      "Could not diff against base — checking all changeset files",
+      "error",
+      `Could not diff ${baseSha.slice(0, 12)}..${headSha.slice(0, 12)} — the base or head commit is not fetchable (a rerun against a deleted branch?). Failing instead of grading every changeset in the tree.`,
     );
-    return null;
+    process.exit(1);
   }
 }
 

--- a/scripts/check-changeset-semver.mjs
+++ b/scripts/check-changeset-semver.mjs
@@ -241,7 +241,7 @@ function writeSummary(summary) {
   else process.stdout.write(summary);
 }
 
-function diffChangesetFiles(root, baseRev, headRev) {
+function diffChangesetFiles(root, baseSha, headSha) {
   try {
     const diff = execFileSync(
       "git",
@@ -249,7 +249,7 @@ function diffChangesetFiles(root, baseRev, headRev) {
         "diff",
         "--name-only",
         "--diff-filter=ACM",
-        `${baseRev}...${headRev}`,
+        `${baseSha}...${headSha}`,
         "--",
         ".changeset/*.md",
       ],
@@ -264,13 +264,13 @@ function diffChangesetFiles(root, baseRev, headRev) {
 
 function main() {
   const root = process.env.CHANGESET_SEMVER_CHECK_ROOT ?? repoRoot;
-  const { BASE_REV, HEAD_REV } = process.env;
+  const { BASE_SHA, HEAD_SHA } = process.env;
   const changedFiles =
-    BASE_REV && HEAD_REV ? diffChangesetFiles(root, BASE_REV, HEAD_REV) : null;
+    BASE_SHA && HEAD_SHA ? diffChangesetFiles(root, BASE_SHA, HEAD_SHA) : null;
   if (changedFiles && !(changedFiles instanceof Set)) {
     annotate(
       "error",
-      `Could not diff ${BASE_REV}...${HEAD_REV}: ${changedFiles.error}. Failing instead of grading every changeset in the tree.`,
+      `Could not diff ${BASE_SHA}...${HEAD_SHA}: ${changedFiles.error}. Failing instead of grading every changeset in the tree.`,
     );
     process.exitCode = 1;
     return;

--- a/scripts/check-changeset-semver.mjs
+++ b/scripts/check-changeset-semver.mjs
@@ -241,7 +241,7 @@ function writeSummary(summary) {
   else process.stdout.write(summary);
 }
 
-function diffChangesetFiles(root, baseSha, headSha) {
+function diffChangesetFiles(root, baseRev, headRev) {
   try {
     const diff = execFileSync(
       "git",
@@ -249,28 +249,28 @@ function diffChangesetFiles(root, baseSha, headSha) {
         "diff",
         "--name-only",
         "--diff-filter=ACM",
-        baseSha,
-        headSha,
+        `${baseRev}...${headRev}`,
         "--",
         ".changeset/*.md",
       ],
-      { cwd: root, encoding: "utf8" },
+      { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
     ).trim();
     return new Set(diff ? diff.split("\n").map((f) => path.basename(f)) : []);
-  } catch {
-    return undefined;
+  } catch (error) {
+    const stderr = String(error.stderr ?? "").trim();
+    return { error: stderr.split("\n").at(-1) || error.message };
   }
 }
 
 function main() {
   const root = process.env.CHANGESET_SEMVER_CHECK_ROOT ?? repoRoot;
-  const { BASE_SHA, HEAD_SHA } = process.env;
+  const { BASE_REV, HEAD_REV } = process.env;
   const changedFiles =
-    BASE_SHA && HEAD_SHA ? diffChangesetFiles(root, BASE_SHA, HEAD_SHA) : null;
-  if (changedFiles === undefined) {
+    BASE_REV && HEAD_REV ? diffChangesetFiles(root, BASE_REV, HEAD_REV) : null;
+  if (changedFiles && !(changedFiles instanceof Set)) {
     annotate(
       "error",
-      `Could not diff ${BASE_SHA.slice(0, 12)}..${HEAD_SHA.slice(0, 12)} — the base or head commit is not fetchable (a rerun against a deleted branch?). Failing instead of grading every changeset in the tree.`,
+      `Could not diff ${BASE_REV}...${HEAD_REV}: ${changedFiles.error}. Failing instead of grading every changeset in the tree.`,
     );
     process.exitCode = 1;
     return;

--- a/scripts/check-changeset-semver.test.mjs
+++ b/scripts/check-changeset-semver.test.mjs
@@ -623,6 +623,26 @@ test("a range git cannot resolve fails closed instead of grading the tree", () =
   }
 });
 
+test("the annotation escapes what a workflow command cannot carry raw", () => {
+  const root = createWorkspace([{ name: "@fixture/dep", version: "0.12.15" }], {
+    "shy-pots-shave.md": '"@fixture/dep": minor',
+  });
+  try {
+    const result = runExecutable(root, {
+      GITHUB_ACTIONS: "true",
+      BASE_SHA: "100%",
+      HEAD_SHA: "1111111111111111111111111111111111111111",
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /^::error::/m);
+    assert.match(result.stdout, /100%25/);
+    assert.doesNotMatch(result.stdout, /100%[^2]/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("a changeset with no releasable bump ends the run before any summary", () => {
   const root = createWorkspace([{ name: "@fixture/dep", version: "1.0.0" }], {
     "shy-pots-shave.md": '"@fixture/gone": patch',

--- a/scripts/check-changeset-semver.test.mjs
+++ b/scripts/check-changeset-semver.test.mjs
@@ -403,8 +403,8 @@ function runExecutable(root, env = {}) {
       encoding: "utf8",
       env: {
         ...process.env,
-        BASE_REV: "",
-        HEAD_REV: "",
+        BASE_SHA: "",
+        HEAD_SHA: "",
         GITHUB_ACTIONS: "",
         GITHUB_STEP_SUMMARY: "",
         CHANGESET_SEMVER_CHECK_ROOT: root,
@@ -510,7 +510,7 @@ test("the executable analyzes only the changesets the PR range adds", () => {
     );
     const head = commitAll(root, "head");
 
-    const result = runExecutable(root, { BASE_REV: base, HEAD_REV: head });
+    const result = runExecutable(root, { BASE_SHA: base, HEAD_SHA: head });
 
     assert.equal(result.status, 0, result.stdout + result.stderr);
     assert.match(
@@ -540,7 +540,7 @@ test("a PR range that touches no changeset ends the run before any summary", () 
     );
     const head = commitAll(root, "head");
 
-    const result = runExecutable(root, { BASE_REV: base, HEAD_REV: head });
+    const result = runExecutable(root, { BASE_SHA: base, HEAD_SHA: head });
 
     assert.equal(result.status, 0, result.stdout + result.stderr);
     assert.match(result.stdout, /No changeset files changed in this PR\./);
@@ -549,7 +549,7 @@ test("a PR range that touches no changeset ends the run before any summary", () 
   }
 });
 
-test("a merge-ref checkout grades only what the PR itself changed", () => {
+test("the PR range is measured from the fork point, not the base tip", () => {
   const root = createWorkspace([{ name: "@fixture/dep", version: "0.12.15" }], {
     "already-on-base.md": '"@fixture/dep": patch',
   });
@@ -562,14 +562,14 @@ test("a merge-ref checkout grades only what the PR itself changed", () => {
       path.join(root, ".changeset", "added-by-the-pr.md"),
       '---\n"@fixture/dep": patch\n---\n\nfix: fixture\n',
     );
-    commitAll(root, "head");
+    const head = commitAll(root, "head");
 
     git(root, "checkout", "-q", "main");
     writeFileSync(
       path.join(root, ".changeset", "already-on-base.md"),
       '---\n"@fixture/dep": minor\n---\n\nfeat: fixture\n',
     );
-    commitAll(root, "base moves on");
+    const base = commitAll(root, "base moves on");
     git(
       root,
       "-c",
@@ -583,12 +583,8 @@ test("a merge-ref checkout grades only what the PR itself changed", () => {
       "merge",
       "pr",
     );
-    git(root, "branch", "-D", "pr");
 
-    const result = runExecutable(root, {
-      BASE_REV: "HEAD^1",
-      HEAD_REV: "HEAD^2",
-    });
+    const result = runExecutable(root, { BASE_SHA: base, HEAD_SHA: head });
 
     assert.equal(result.status, 0, result.stdout + result.stderr);
     assert.match(result.stdout, /`added-by-the-pr\.md`/);
@@ -608,8 +604,8 @@ test("a range git cannot resolve fails closed instead of grading the tree", () =
   });
   try {
     const result = runExecutable(root, {
-      BASE_REV: "0000000000000000000000000000000000000000",
-      HEAD_REV: "1111111111111111111111111111111111111111",
+      BASE_SHA: "0000000000000000000000000000000000000000",
+      HEAD_SHA: "1111111111111111111111111111111111111111",
     });
 
     assert.equal(result.status, 1);

--- a/scripts/check-changeset-semver.test.mjs
+++ b/scripts/check-changeset-semver.test.mjs
@@ -549,7 +549,7 @@ test("a PR range that touches no changeset ends the run before any summary", () 
   }
 });
 
-test("an unusable base falls back to every changeset and says so", () => {
+test("an unusable base fails closed instead of grading the tree", () => {
   const root = createWorkspace([{ name: "@fixture/dep", version: "0.12.15" }], {
     "shy-pots-shave.md": '"@fixture/dep": minor',
   });
@@ -560,8 +560,9 @@ test("an unusable base falls back to every changeset and says so", () => {
     });
 
     assert.equal(result.status, 1);
-    assert.match(result.stdout, /Could not diff against base/);
-    assert.match(result.stdout, /shy-pots-shave\.md/);
+    assert.match(result.stdout, /not fetchable/);
+    assert.doesNotMatch(result.stdout, /shy-pots-shave\.md/);
+    assert.doesNotMatch(result.stdout, /Semver-breaking/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/check-changeset-semver.test.mjs
+++ b/scripts/check-changeset-semver.test.mjs
@@ -403,8 +403,8 @@ function runExecutable(root, env = {}) {
       encoding: "utf8",
       env: {
         ...process.env,
-        BASE_SHA: "",
-        HEAD_SHA: "",
+        BASE_REV: "",
+        HEAD_REV: "",
         GITHUB_ACTIONS: "",
         GITHUB_STEP_SUMMARY: "",
         CHANGESET_SEMVER_CHECK_ROOT: root,
@@ -510,7 +510,7 @@ test("the executable analyzes only the changesets the PR range adds", () => {
     );
     const head = commitAll(root, "head");
 
-    const result = runExecutable(root, { BASE_SHA: base, HEAD_SHA: head });
+    const result = runExecutable(root, { BASE_REV: base, HEAD_REV: head });
 
     assert.equal(result.status, 0, result.stdout + result.stderr);
     assert.match(
@@ -540,7 +540,7 @@ test("a PR range that touches no changeset ends the run before any summary", () 
     );
     const head = commitAll(root, "head");
 
-    const result = runExecutable(root, { BASE_SHA: base, HEAD_SHA: head });
+    const result = runExecutable(root, { BASE_REV: base, HEAD_REV: head });
 
     assert.equal(result.status, 0, result.stdout + result.stderr);
     assert.match(result.stdout, /No changeset files changed in this PR\./);
@@ -549,18 +549,77 @@ test("a PR range that touches no changeset ends the run before any summary", () 
   }
 });
 
-test("an unusable base fails closed instead of grading the tree", () => {
+test("a merge-ref checkout grades only what the PR itself changed", () => {
+  const root = createWorkspace([{ name: "@fixture/dep", version: "0.12.15" }], {
+    "already-on-base.md": '"@fixture/dep": patch',
+  });
+  try {
+    git(root, "init", "-q", "-b", "main");
+    commitAll(root, "base");
+
+    git(root, "checkout", "-q", "-b", "pr");
+    writeFileSync(
+      path.join(root, ".changeset", "added-by-the-pr.md"),
+      '---\n"@fixture/dep": patch\n---\n\nfix: fixture\n',
+    );
+    commitAll(root, "head");
+
+    git(root, "checkout", "-q", "main");
+    writeFileSync(
+      path.join(root, ".changeset", "already-on-base.md"),
+      '---\n"@fixture/dep": minor\n---\n\nfeat: fixture\n',
+    );
+    commitAll(root, "base moves on");
+    git(
+      root,
+      "-c",
+      "user.name=fixture",
+      "-c",
+      "user.email=fixture@example.com",
+      "merge",
+      "-q",
+      "--no-ff",
+      "-m",
+      "merge",
+      "pr",
+    );
+    git(root, "branch", "-D", "pr");
+
+    const result = runExecutable(root, {
+      BASE_REV: "HEAD^1",
+      HEAD_REV: "HEAD^2",
+    });
+
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.match(result.stdout, /`added-by-the-pr\.md`/);
+    assert.doesNotMatch(
+      result.stdout,
+      /already-on-base/,
+      "a changeset only the base branch changed was graded against the PR",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a range git cannot resolve fails closed instead of grading the tree", () => {
   const root = createWorkspace([{ name: "@fixture/dep", version: "0.12.15" }], {
     "shy-pots-shave.md": '"@fixture/dep": minor',
   });
   try {
     const result = runExecutable(root, {
-      BASE_SHA: "0000000000000000000000000000000000000000",
-      HEAD_SHA: "1111111111111111111111111111111111111111",
+      BASE_REV: "0000000000000000000000000000000000000000",
+      HEAD_REV: "1111111111111111111111111111111111111111",
     });
 
     assert.equal(result.status, 1);
-    assert.match(result.stdout, /not fetchable/);
+    assert.match(result.stdout, /Could not diff 0{40}\.{3}1{40}/);
+    assert.ok(
+      /Could not diff [^:]+: (.+)\. Failing instead of grading/.exec(
+        result.stdout,
+      )?.[1],
+      "the annotation dropped git's own error",
+    );
     assert.doesNotMatch(result.stdout, /shy-pots-shave\.md/);
     assert.doesNotMatch(result.stdout, /Semver-breaking/);
   } finally {


### PR DESCRIPTION
Closes #6744.

## Problem

merging a PR deletes its head branch, then rupic's `stage/merged` label fires the Changeset Semver Check again (the workflow listed `labeled` in its trigger types). that rerun has no `refs/pull/N/merge` left to check out, so checkout falls back to `main` and the payload head commit is not in the object store. `diffChangesetFiles` catches the failed `git diff`, and the fallback widens to every changeset in the tree, grading a merged PR on changesets it never touched.

#6450 carries exactly this: `fatal: bad object`, then a semver verdict about `@assistant-ui/mcp-docs-server` and a react-ink-markdown cascade, neither from that PR. #6949, #6932 and #6921 each carry the same post-merge rerun, seconds after their merge.

## Root cause

two independent ways for the check to answer about changesets the PR never touched.

the reruns are the `labeled` trigger landing on a deleted head, where the fallback turns a missing object into a semver verdict.

the second is quieter and fires on live PRs: `git diff base.sha head.sha` was two-dot, measured against the base *tip*. once a release commit lands on main and rewrites or deletes changesets the PR head still carries, they show up in that diff and get graded against the PR.

## Change

- `labeled` is dropped from the workflow's `types`. the script reads no labels, so the trigger only ever added reruns, and a rerun after merge always lands on a deleted head. this retires every observed failure.
- the range is three-dot, so it is measured from the fork point and a changeset only the base branch touched is no longer graded against the PR.
- the diff failure fails closed. instead of the check-everything fallback, the script relays git's own stderr and exits nonzero, so a real failure reads as a broken checkout rather than a semver verdict on unrelated packages.
- `diffChangesetFiles` returns either a `Set` or an error object, so `undefined` can no longer fall through the `changedFiles === null` default and quietly reinstate the check-everything path.
- `annotate` percent-encodes `%`, CR and LF. it now interpolates git's stderr, and a workflow command drops or truncates that data raw.

the local mode is untouched: running without `BASE_SHA`/`HEAD_SHA` (plain `pnpm changeset-semver:check`) never enters `diffChangesetFiles` and still checks all changeset files.

## Verification

- new test: the PR range is measured from the fork point, not the base tip. the fixture branches, adds a changeset on the PR branch, edits a *different* changeset on `main` after the branch point, merges `--no-ff` so the working tree is the merge commit CI checks out, then runs with the two shas. it exits 0 and grades only the PR's changeset. reverting the range to two-dot fails it: main's `minor` edit is pulled in and the run exits 1.
- the fail-closed test asserts the annotation carries git's own error text rather than a guessed cause; a third test pins the percent-encoding with a `%` in the rev.
- full script suite 23/23, `node --test scripts/check-changesets.test.mjs` 18/18, `pnpm changeset-semver:check` green through the no-sha path, oxlint and oxfmt clean.
- this PR's own Semver Check resolved the range against `refs/remotes/pull/6984/merge` and reported `No changeset files changed in this PR.`

## Public surface

none. workflow and repo scripts only, no changeset.

---

an earlier revision of this PR added an `if:` gating the job to same-repo PRs, on the theory that `actions/checkout@v7`'s `allow-unsafe-pr-checkout` default diverts fork PRs to the base branch. that was wrong on two counts: the default governs `pull_request_target` and `workflow_run`, not `pull_request`, and the fork runs cited as evidence were post-merge reruns that `gh pr checks` surfaced as the latest run per check. the guard and its comment are reverted; #7003 is closed as invalid.
