### PR TITLE
fix(react): keep parent ids distinct from ungrouped parts

### DIFF
--- a/.changeset/distinct-parent-groups.md
+++ b/.changeset/distinct-parent-groups.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: keep parent IDs separate from ungrouped message parts

--- a/apps/docs/content/docs/guides/part-grouping.mdx
+++ b/apps/docs/content/docs/guides/part-grouping.mdx
@@ -496,17 +496,17 @@ Use `MessagePrimitive.Unstable_PartsGrouped` only when you need to collect non-a
 ```tsx
 <MessagePrimitive.Unstable_PartsGrouped
   groupingFunction={(parts) => {
-    const groups = new Map<string, number[]>();
+    const groups = new Map<string | number, number[]>();
 
     parts.forEach((part, index) => {
-      const key = part.parentId ?? `__ungrouped_${index}`;
+      const key = part.parentId ?? index;
       const indices = groups.get(key) ?? [];
       indices.push(index);
       groups.set(key, indices);
     });
 
     return Array.from(groups.entries()).map(([key, indices]) => ({
-      groupKey: key.startsWith("__ungrouped_") ? undefined : key,
+      groupKey: typeof key === "string" ? key : undefined,
       indices,
     }));
   }}

--- a/packages/react/src/primitives/message/MessagePartsGrouped.test.tsx
+++ b/packages/react/src/primitives/message/MessagePartsGrouped.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ThreadMessageLike } from "@assistant-ui/core";
+import {
+  AssistantRuntimeProvider,
+  useExternalStoreRuntime,
+} from "@assistant-ui/core/react";
+import { ThreadPrimitiveMessageByIndex } from "../thread/ThreadMessages";
+import { MessagePrimitiveUnstable_PartsGroupedByParentId } from "./MessagePartsGrouped";
+
+const Message = () => (
+  <MessagePrimitiveUnstable_PartsGroupedByParentId
+    components={{
+      Text: ({ text }) => <span>{text}</span>,
+      Group: ({ groupKey, indices, children }) => (
+        <section
+          data-testid="group"
+          data-parent={groupKey}
+          data-indices={indices.join(",")}
+        >
+          {children}
+        </section>
+      ),
+    }}
+  />
+);
+
+const Example = ({ content }: { content: ThreadMessageLike["content"] }) => {
+  const messages: ThreadMessageLike[] = [
+    { id: "message", role: "assistant", content },
+  ];
+  const runtime = useExternalStoreRuntime({
+    messages,
+    convertMessage: (message) => message,
+    onNew: async () => {},
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ThreadPrimitiveMessageByIndex index={0} components={{ Message }} />
+    </AssistantRuntimeProvider>
+  );
+};
+
+describe("MessagePrimitive.Unstable_PartsGroupedByParentId", () => {
+  it("keeps parent IDs separate from ungrouped parts across content updates", () => {
+    const { rerender } = render(
+      <Example
+        content={[
+          { type: "text", text: "standalone" },
+          { type: "text", text: "child", parentId: "__ungrouped_0" },
+        ]}
+      />,
+    );
+    expect(
+      screen.getAllByTestId("group").map((group) => ({
+        parent: group.getAttribute("data-parent"),
+        indices: group.getAttribute("data-indices"),
+        text: group.textContent,
+      })),
+    ).toEqual([
+      { parent: null, indices: "0", text: "standalone" },
+      { parent: "__ungrouped_0", indices: "1", text: "child" },
+    ]);
+
+    rerender(
+      <Example
+        content={[
+          { type: "text", text: "first", parentId: "__ungrouped_parent" },
+          { type: "text", text: "standalone" },
+          { type: "text", text: "last", parentId: "__ungrouped_parent" },
+          { type: "text", text: "numeric", parentId: "1" },
+          { type: "text", text: "empty", parentId: "" },
+          { type: "text", text: "trailing" },
+        ]}
+      />,
+    );
+    expect(
+      screen.getAllByTestId("group").map((group) => ({
+        parent: group.getAttribute("data-parent"),
+        indices: group.getAttribute("data-indices"),
+        text: group.textContent,
+      })),
+    ).toEqual([
+      { parent: "__ungrouped_parent", indices: "0,2", text: "firstlast" },
+      { parent: null, indices: "1", text: "standalone" },
+      { parent: "1", indices: "3", text: "numeric" },
+      { parent: "", indices: "4", text: "empty" },
+      { parent: null, indices: "5", text: "trailing" },
+    ]);
+  });
+});

--- a/packages/react/src/primitives/message/MessagePartsGrouped.tsx
+++ b/packages/react/src/primitives/message/MessagePartsGrouped.tsx
@@ -44,7 +44,7 @@ const groupMessagePartsByParentId: GroupingFunction = (
   parts: readonly any[],
 ): MessagePartGroup[] => {
   // Map maintains insertion order, so groups appear in order of first occurrence
-  const groupMap = new Map<string, number[]>();
+  const groupMap = new Map<string | number, number[]>();
 
   // Process each part in order
   for (let i = 0; i < parts.length; i++) {
@@ -52,7 +52,7 @@ const groupMessagePartsByParentId: GroupingFunction = (
     const parentId = part?.parentId as string | undefined;
 
     // For parts without parentId, assign a unique group ID to maintain their position
-    const groupId = parentId ?? `__ungrouped_${i}`;
+    const groupId = parentId ?? i;
 
     // Get or create the indices array for this group
     const indices = groupMap.get(groupId) ?? [];
@@ -64,7 +64,7 @@ const groupMessagePartsByParentId: GroupingFunction = (
   const groups: MessagePartGroup[] = [];
   for (const [groupId, indices] of groupMap) {
     // Extract parentId (undefined for ungrouped parts)
-    const groupKey = groupId.startsWith("__ungrouped_") ? undefined : groupId;
+    const groupKey = typeof groupId === "string" ? groupId : undefined;
     groups.push({ groupKey, indices });
   }
 
@@ -94,15 +94,15 @@ export namespace MessagePrimitiveUnstable_PartsGrouped {
      * ```tsx
      * // Group by parent ID (default behavior)
      * groupingFunction={(parts) => {
-     *   const groups = new Map<string, number[]>();
+     *   const groups = new Map<string | number, number[]>();
      *   parts.forEach((part, i) => {
-     *     const key = part.parentId ?? `__ungrouped_${i}`;
+     *     const key = part.parentId ?? i;
      *     const indices = groups.get(key) ?? [];
      *     indices.push(i);
      *     groups.set(key, indices);
      *   });
      *   return Array.from(groups.entries()).map(([key, indices]) => ({
-     *     key: key.startsWith("__ungrouped_") ? undefined : key,
+     *     groupKey: typeof key === "string" ? key : undefined,
      *     indices
      *   }));
      * }}


### PR DESCRIPTION
## Problem

`Unstable_PartsGroupedByParentId` can combine unrelated text parts into one group. It also removes parent IDs that start with `__ungrouped_`.

This reproduces on `@assistant-ui/react` 0.15.18 at base `98010f17b4a8d4bc506a6084007ecdaf4a823503`:

```tsx
import {
  AssistantRuntimeProvider,
  MessagePrimitive,
  ThreadPrimitive,
  useExternalStoreRuntime,
  type ThreadMessageLike,
} from "@assistant-ui/react";

const messages: ThreadMessageLike[] = [{
  id: "message",
  role: "assistant",
  content: [
    { type: "text", text: "standalone" },
    { type: "text", text: "child", parentId: "__ungrouped_0" },
  ],
}];

function Message() {
  return <MessagePrimitive.Unstable_PartsGroupedByParentId components={{
    Text: ({ text }) => <span>{text}</span>,
    Group: ({ groupKey, indices, children }) => (
      <section>
        <header>{JSON.stringify({ groupKey, indices })}</header>
        {children}
      </section>
    ),
  }} />;
}

export default function Example() {
  const runtime = useExternalStoreRuntime({
    messages,
    convertMessage: (message) => message,
    onNew: async () => {},
  });
  return <AssistantRuntimeProvider runtime={runtime}>
    <ThreadPrimitive.MessageByIndex index={0} components={{ Message }} />
  </AssistantRuntimeProvider>;
}
```

Before: one group with indices `[0, 1]` and no parent ID. After: separate groups with indices `[0]` and `[1]`, with the second parent ID intact.

## Root cause

Generated ungrouped keys share the string namespace with parent IDs. A prefix check also treats valid parent IDs as ungrouped keys.

## Change

Ungrouped parts use numeric indices as internal keys. Parent IDs remain strings. Group order and public signatures stay unchanged.

## Verification

- The real-runtime regression failed before the correction and passed afterward with the same command: `pnpm --filter @assistant-ui/react test src/primitives/message/MessagePartsGrouped.test.tsx`.
- The regression and adjacent `MessagePartText.test.tsx` passed together: three tests.
- Browser checks covered the collision and content updates with non-adjacent groups, prefix IDs, numeric-string IDs, and empty IDs.
- The React package build, scoped Oxlint check, and `pnpm changesets:check` passed.
- API-reference generation completed with no tracked changes.

## Public surface

`@assistant-ui/react` receives a patch changeset. The grouping guide and source example use the corrected keys. Exports and public types stay unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.c9PJ3dBiotiQoEaS8DRKnWi-320QSfdwma3QnXOOd3FTmXo_TJEW-8AYRyc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->