### PR TITLE
fix(react-native): supply status to registered part renderers

### DIFF
--- a/.changeset/native-renderer-part-status.md
+++ b/.changeset/native-renderer-part-status.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-native": patch
+---
+
+fix: supply derived status to registered tool and data renderers

--- a/packages/react-native/src/primitives/message/MessageContent.test.tsx
+++ b/packages/react-native/src/primitives/message/MessageContent.test.tsx
@@ -1,6 +1,7 @@
 import { act, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MessagePartState, ThreadMessageLike } from "@assistant-ui/core";
 import { MessageContent } from "./MessageContent";
 
 type AnyPart = { type: string; [key: string]: unknown };
@@ -10,7 +11,12 @@ const h = vi.hoisted(() => ({
   resumeToolCall: vi.fn(),
   respondToToolApproval: vi.fn(),
   state: {
-    message: { content: [] as AnyPart[] },
+    message: {
+      content: [] as AnyPart[],
+      get parts() {
+        return this.content;
+      },
+    },
     tools: { toolUIs: {} as Record<string, unknown> },
     dataRenderers: { renderers: {} as Record<string, unknown> },
   },
@@ -269,4 +275,84 @@ describe("MessageContent", () => {
 
     expect(container.textContent).toBe("A[tool][data]");
   });
+});
+
+describe("MessageContent with a runtime", () => {
+  it.each(["tool-call", "data"] as const)(
+    "renders derived status for registered %s UIs",
+    async (type) => {
+      vi.doUnmock("@assistant-ui/store");
+      vi.resetModules();
+      // Static imports retain the store mock used by the dispatch tests.
+      const { MessageContent: RuntimeContent } =
+        await import("./MessageContent");
+      const {
+        AssistantRuntimeProvider,
+        MessageByIndexProvider,
+        useExternalStoreRuntime,
+        useAssistantToolUI,
+        useAssistantDataUI,
+      } = await import("@assistant-ui/core/react");
+
+      const Status = ({ status }: Pick<MessagePartState, "status">) => (
+        <span>{status.type}</span>
+      );
+      const Registrations = () => {
+        useAssistantToolUI({ toolName: "search", render: Status });
+        useAssistantDataUI({ name: "chart", render: Status });
+        return <RuntimeContent />;
+      };
+      const App = ({ message }: { message: ThreadMessageLike }) => {
+        const runtime = useExternalStoreRuntime({
+          messages: [message],
+          convertMessage: (value) => value,
+          onNew: async () => {},
+        });
+        return (
+          <AssistantRuntimeProvider runtime={runtime}>
+            <MessageByIndexProvider index={0}>
+              <Registrations />
+            </MessageByIndexProvider>
+          </AssistantRuntimeProvider>
+        );
+      };
+      const container = document.createElement("div");
+      const root = createRoot(container);
+      try {
+        for (const status of [
+          "running",
+          "requires-action",
+          "complete",
+        ] as const) {
+          if (type === "data" && status === "requires-action") continue;
+          const message: ThreadMessageLike = {
+            id: "m1",
+            role: "assistant",
+            status:
+              status === "running"
+                ? { type: status }
+                : status === "complete"
+                  ? { type: status, reason: "stop" }
+                  : { type: status, reason: "tool-calls" },
+            content: [
+              type === "data"
+                ? { type, name: "chart", data: { value: 1 } }
+                : {
+                    type,
+                    toolName: "search",
+                    toolCallId: "c1",
+                    args: {},
+                    argsText: "{}",
+                    ...(status === "complete" ? { result: "done" } : {}),
+                  },
+            ],
+          };
+          await act(async () => root.render(<App message={message} />));
+          expect(container.textContent).toBe(status);
+        }
+      } finally {
+        await act(async () => root.unmount());
+      }
+    },
+  );
 });

--- a/packages/react-native/src/primitives/message/MessageContent.tsx
+++ b/packages/react-native/src/primitives/message/MessageContent.tsx
@@ -3,8 +3,7 @@ import { Text } from "react-native";
 import type {
   ThreadUserMessagePart,
   ThreadAssistantMessagePart,
-  ToolCallMessagePart,
-  DataMessagePart,
+  MessagePartState,
 } from "@assistant-ui/core";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import type {
@@ -13,6 +12,7 @@ import type {
 } from "@assistant-ui/core/react";
 
 type MessageContentPart = ThreadUserMessagePart | ThreadAssistantMessagePart;
+type MessageContentStatePart = MessagePartState;
 
 export type MessageContentProps = {
   renderText?: (props: {
@@ -59,9 +59,12 @@ const ToolUIDisplay = ({
   index,
 }: {
   Fallback:
-    | ((props: { part: ToolCallMessagePart; index: number }) => ReactElement)
+    | ((props: {
+        part: Extract<MessageContentPart, { type: "tool-call" }>;
+        index: number;
+      }) => ReactElement)
     | undefined;
-  part: ToolCallMessagePart;
+  part: Extract<MessageContentStatePart, { type: "tool-call" }>;
   index: number;
 }) => {
   const aui = useAui();
@@ -91,9 +94,12 @@ const DataUIDisplay = ({
   index,
 }: {
   Fallback:
-    | ((props: { part: DataMessagePart; index: number }) => ReactElement)
+    | ((props: {
+        part: Extract<MessageContentPart, { type: "data" }>;
+        index: number;
+      }) => ReactElement)
     | undefined;
-  part: DataMessagePart;
+  part: Extract<MessageContentStatePart, { type: "data" }>;
   index: number;
 }) => {
   const Render = useAuiState((s) => {

--- a/packages/react-native/src/primitives/message/MessageContent.tsx
+++ b/packages/react-native/src/primitives/message/MessageContent.tsx
@@ -115,7 +115,7 @@ export const MessageContent = ({
   renderFile,
   renderData,
 }: MessageContentProps) => {
-  const content = useAuiState((s) => s.message.content);
+  const content = useAuiState((s) => s.message.parts);
 
   return (
     <>


### PR DESCRIPTION
## Problem

Registered tool and data renderers can crash when they read `status.type`. They receive no status, even when the runtime has one.

The affected checkout is `98010f17b4a8d4bc506a6084007ecdaf4a823503`, where `@assistant-ui/react-native` is version `0.1.40`.

<details>
<summary>Minimal reproduction</summary>

In that checkout, mount this component from `packages/react-native`. The tool renderer throws instead of displaying `running`.

```tsx
import { Text } from "react-native";
import type { ThreadMessageLike } from "@assistant-ui/core";
import {
  AssistantRuntimeProvider,
  MessageByIndexProvider,
  useAssistantToolUI,
  useExternalStoreRuntime,
} from "@assistant-ui/core/react";
import { MessageContent } from "./src/primitives/message/MessageContent";

const message: ThreadMessageLike = {
  id: "m1",
  role: "assistant",
  status: { type: "running" },
  content: [{
    type: "tool-call",
    toolName: "search",
    toolCallId: "c1",
    args: {},
    argsText: "{}",
  }],
};

function Content() {
  useAssistantToolUI({
    toolName: "search",
    render: ({ status }) => <Text>{status.type}</Text>,
  });
  return <MessageContent />;
}

export default function Repro() {
  const runtime = useExternalStoreRuntime({
    messages: [message],
    convertMessage: (value) => value,
    onNew: async () => {},
  });
  return (
    <AssistantRuntimeProvider runtime={runtime}>
      <MessageByIndexProvider index={0}>
        <Content />
      </MessageByIndexProvider>
    </AssistantRuntimeProvider>
  );
}
```

</details>

## Root cause

`MessageContent` reads raw `message.content`. Registered renderer props require the derived status that the runtime supplies through `message.parts`.

## Change

Select `message.parts` so registered tool and data renderers receive their status. Keep renderer selection, fallback renderers, and tool callbacks unchanged.

## Verification

- The real-runtime regression produced two `status.type` crashes before the correction. The same command passes all 16 tests afterward: `pnpm --filter @assistant-ui/react-native test src/primitives/message/MessageContent.test.tsx`.
- A browser preview reproduced the crashes and then displayed tool `running`, `requires-action`, and `complete` states, plus data `running` and `complete` states. This check used React Native Web, not a device simulator.
- The native package build, scoped Oxlint checks, TypeScript diagnostics, and `pnpm changesets:check` pass.

## Public surface

`@assistant-ui/react-native` receives a patch changeset. Public exports and signatures stay unchanged. Documentation and generated API output need no changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5Qa793-FhJviMj2VDwoOvNSozpq8ma5bFVBrf4f0nua2wwdVvEMmeFUasmA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->