### PR TITLE
fix: compare arrays with indexed loops in the remaining comparators

### DIFF
--- a/.changeset/comparator-array-holes.md
+++ b/.changeset/comparator-array-holes.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+"@assistant-ui/react-mcp": patch
+---
+
+fix: compare arrays with indexed loops so sparse-array holes cannot read as equal

--- a/.changeset/comparator-array-holes.md
+++ b/.changeset/comparator-array-holes.md
@@ -6,4 +6,4 @@
 "@assistant-ui/react-mcp": patch
 ---
 
-fix: compare arrays with indexed loops so sparse-array holes cannot read as equal
+fix: compare arrays with indexed loops so sparse-array holes cannot read as equal; a sparse suggestions list now compacts to a dense one before it reaches the per-suggestion lookup

--- a/packages/core/src/adapters/attachment.ts
+++ b/packages/core/src/adapters/attachment.ts
@@ -170,7 +170,10 @@ export function attachmentsEqual(
   b: readonly CompleteAttachment[],
 ): boolean {
   if (a.length !== b.length) return false;
-  return a.every((att, i) => att.id === b[i]!.id);
+  for (let i = 0; i < a.length; i++) {
+    if (a[i]?.id !== b[i]?.id) return false;
+  }
+  return true;
 }
 
 export function partToCompleteAttachment(

--- a/packages/core/src/store/clients/model-context-client.ts
+++ b/packages/core/src/store/clients/model-context-client.ts
@@ -3,6 +3,7 @@ import { resource } from "@assistant-ui/tap";
 import type { ClientOutput } from "@assistant-ui/store";
 import { CompositeContextProvider } from "../../utils/composite-context-provider";
 import type { ModelContextState } from "../scopes/model-context";
+import { shallowEqual } from "@assistant-ui/store/internal";
 
 const EMPTY_TOOL_NAMES: readonly string[] = [];
 
@@ -11,17 +12,8 @@ const INITIAL_STATE: ModelContextState = {
   toolNames: EMPTY_TOOL_NAMES,
 };
 
-const toolNamesEqual = (
-  a: readonly string[],
-  b: readonly string[],
-): boolean => {
-  if (a === b) return true;
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-};
+const toolNamesEqual = (a: readonly string[], b: readonly string[]): boolean =>
+  a === b || shallowEqual(a, b);
 
 const deriveState = (
   composite: CompositeContextProvider,

--- a/packages/core/src/store/clients/model-context-client.ts
+++ b/packages/core/src/store/clients/model-context-client.ts
@@ -11,8 +11,17 @@ const INITIAL_STATE: ModelContextState = {
   toolNames: EMPTY_TOOL_NAMES,
 };
 
-const toolNamesEqual = (a: readonly string[], b: readonly string[]): boolean =>
-  a === b || (a.length === b.length && a.every((v, i) => v === b[i]));
+const toolNamesEqual = (
+  a: readonly string[],
+  b: readonly string[],
+): boolean => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+};
 
 const deriveState = (
   composite: CompositeContextProvider,

--- a/packages/core/src/store/clients/suggestions.test.ts
+++ b/packages/core/src/store/clients/suggestions.test.ts
@@ -171,8 +171,21 @@ describe("ThreadSuggestions", () => {
       const expected = { title: "Prompt B", label: "", prompt: "Prompt B" };
       expect(state.suggestions).toEqual([expected]);
       expect(Object.keys(state.suggestions)).toEqual(["0"]);
-      expect(root.getValue().suggestion({ index: 0 }).getState()).toEqual(
-        expected,
+      const firstSuggestion = root
+        .getValue()
+        .suggestion({ index: 0 })
+        .getState();
+      expect(firstSuggestion).toEqual(expected);
+
+      // An equivalent sparse update keeps both identities stable: the reuse
+      // probe reads the compacted destination index, not the sparse source one.
+      const sparseAgain: ThreadSuggestion[] = new Array(2);
+      sparseAgain[1] = { prompt: "Prompt B" };
+      flushTapSync(() => setSuggestions(sparseAgain));
+
+      expect(root.getValue().getState()).toBe(state);
+      expect(root.getValue().suggestion({ index: 0 }).getState()).toBe(
+        firstSuggestion,
       );
     } finally {
       root.unmount();

--- a/packages/core/src/store/clients/suggestions.test.ts
+++ b/packages/core/src/store/clients/suggestions.test.ts
@@ -151,6 +151,34 @@ describe("ThreadSuggestions", () => {
     }
   });
 
+  it("drops sparse holes before the per-suggestion lookup", () => {
+    let setSuggestions!: (suggestions: ThreadSuggestion[]) => void;
+    const root = createTapRoot(function ThreadSuggestionsRoot() {
+      const [suggestions, setValue] = useState<ThreadSuggestion[]>([
+        { prompt: "Prompt A" },
+        { prompt: "Prompt B" },
+      ]);
+      setSuggestions = setValue;
+      return useResource(ThreadSuggestions(suggestions));
+    });
+
+    try {
+      const sparse: ThreadSuggestion[] = new Array(2);
+      sparse[1] = { prompt: "Prompt B" };
+      flushTapSync(() => setSuggestions(sparse));
+
+      const state = root.getValue().getState();
+      const expected = { title: "Prompt B", label: "", prompt: "Prompt B" };
+      expect(state.suggestions).toEqual([expected]);
+      expect(Object.keys(state.suggestions)).toEqual(["0"]);
+      expect(root.getValue().suggestion({ index: 0 }).getState()).toEqual(
+        expected,
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
   it("reuses unchanged suggestion state when one entry changes", () => {
     let setSuggestions!: (suggestions: ThreadSuggestion[]) => void;
     const root = createTapRoot(function ThreadSuggestionsRoot() {

--- a/packages/core/src/store/clients/suggestions.test.ts
+++ b/packages/core/src/store/clients/suggestions.test.ts
@@ -177,8 +177,7 @@ describe("ThreadSuggestions", () => {
         .getState();
       expect(firstSuggestion).toEqual(expected);
 
-      // An equivalent sparse update keeps both identities stable: the reuse
-      // probe reads the compacted destination index, not the sparse source one.
+      // An equivalent sparse update keeps both identities stable.
       const sparseAgain: ThreadSuggestion[] = new Array(2);
       sparseAgain[1] = { prompt: "Prompt B" };
       flushTapSync(() => setSuggestions(sparseAgain));

--- a/packages/core/src/store/clients/suggestions.ts
+++ b/packages/core/src/store/clients/suggestions.ts
@@ -17,11 +17,16 @@ const useStableSuggestionsState = (
   const cell = useMemo(() => ({}) as { state?: SuggestionsState }, []);
   const previous = cell.state;
 
-  const suggestions = next.suggestions.map((suggestion, index) => {
+  // forEach skips array holes, so a sparse caller array normalizes to a dense
+  // list here, before the per-suggestion resource lookup indexes every slot.
+  const suggestions: SuggestionState[] = [];
+  next.suggestions.forEach((suggestion, index) => {
     const previousSuggestion = previous?.suggestions[index];
-    return previousSuggestion && shallowEqual(previousSuggestion, suggestion)
-      ? previousSuggestion
-      : suggestion;
+    suggestions.push(
+      previousSuggestion && shallowEqual(previousSuggestion, suggestion)
+        ? previousSuggestion
+        : suggestion,
+    );
   });
   const state =
     previous && shallowEqual(suggestions, previous.suggestions)

--- a/packages/core/src/store/clients/suggestions.ts
+++ b/packages/core/src/store/clients/suggestions.ts
@@ -4,15 +4,6 @@ import type { ClientOutput } from "@assistant-ui/store";
 import { useClientLookup } from "@assistant-ui/store/client";
 import { shallowEqual } from "@assistant-ui/store/internal";
 import type { SuggestionsState } from "../scopes/suggestions";
-
-const sameEntries = (a: readonly unknown[], b: readonly unknown[]): boolean => {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-};
-
 import type { SuggestionState } from "../scopes/suggestion";
 import type { ThreadSuggestion } from "../../runtime/interfaces/thread-runtime-core";
 
@@ -33,7 +24,7 @@ const useStableSuggestionsState = (
       : suggestion;
   });
   const state =
-    previous && sameEntries(suggestions, previous.suggestions)
+    previous && shallowEqual(suggestions, previous.suggestions)
       ? previous
       : { suggestions };
 

--- a/packages/core/src/store/clients/suggestions.ts
+++ b/packages/core/src/store/clients/suggestions.ts
@@ -4,6 +4,15 @@ import type { ClientOutput } from "@assistant-ui/store";
 import { useClientLookup } from "@assistant-ui/store/client";
 import { shallowEqual } from "@assistant-ui/store/internal";
 import type { SuggestionsState } from "../scopes/suggestions";
+
+const sameEntries = (a: readonly unknown[], b: readonly unknown[]): boolean => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+};
+
 import type { SuggestionState } from "../scopes/suggestion";
 import type { ThreadSuggestion } from "../../runtime/interfaces/thread-runtime-core";
 
@@ -24,11 +33,7 @@ const useStableSuggestionsState = (
       : suggestion;
   });
   const state =
-    previous &&
-    previous.suggestions.length === suggestions.length &&
-    suggestions.every(
-      (suggestion, index) => suggestion === previous.suggestions[index],
-    )
+    previous && sameEntries(suggestions, previous.suggestions)
       ? previous
       : { suggestions };
 

--- a/packages/core/src/store/clients/suggestions.ts
+++ b/packages/core/src/store/clients/suggestions.ts
@@ -20,8 +20,10 @@ const useStableSuggestionsState = (
   // forEach skips array holes, so a sparse caller array normalizes to a dense
   // list here, before the per-suggestion resource lookup indexes every slot.
   const suggestions: SuggestionState[] = [];
-  next.suggestions.forEach((suggestion, index) => {
-    const previousSuggestion = previous?.suggestions[index];
+  next.suggestions.forEach((suggestion) => {
+    // Probed at the compacted destination index, not the sparse source index,
+    // so an equivalent hole-containing update keeps reusing prior identities.
+    const previousSuggestion = previous?.suggestions[suggestions.length];
     suggestions.push(
       previousSuggestion && shallowEqual(previousSuggestion, suggestion)
         ? previousSuggestion

--- a/packages/react-markdown/src/primitives/MarkdownText.tsx
+++ b/packages/react-markdown/src/primitives/MarkdownText.tsx
@@ -87,10 +87,11 @@ const isShallowEqual = (a: unknown, b: unknown, depth = 1): boolean => {
   if (depth <= 0) return false;
 
   if (Array.isArray(a) && Array.isArray(b)) {
-    return (
-      a.length === b.length &&
-      a.every((item, i) => isShallowEqual(item, b[i], depth - 1))
-    );
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!isShallowEqual(a[i], b[i], depth - 1)) return false;
+    }
+    return true;
   }
 
   if (isPlainObject(a) && isPlainObject(b)) {

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -88,9 +88,13 @@ export const getConnectionDependencies = (
 const areConnectionDependenciesEqual = (
   left: readonly unknown[],
   right: readonly unknown[],
-) =>
-  left.length === right.length &&
-  left.every((value, index) => Object.is(value, right[index]));
+) => {
+  if (left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i++) {
+    if (!Object.is(left[i], right[i])) return false;
+  }
+  return true;
+};
 
 const useMcpServerResourceInstance = (
   props: McpServerResourceInstanceProps,

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useEffectEvent } from "react";
 import { resource, useResource, withKey } from "@assistant-ui/tap";
 import type { ClientOutput } from "@assistant-ui/store";
+import { shallowEqual } from "@assistant-ui/store/internal";
 import {
   Client,
   StreamableHTTPClientTransport,
@@ -83,17 +84,6 @@ export const getConnectionDependencies = (
     props.cache?.defaultTtlMs,
     props.elicitation !== false,
   ];
-};
-
-const areConnectionDependenciesEqual = (
-  left: readonly unknown[],
-  right: readonly unknown[],
-) => {
-  if (left.length !== right.length) return false;
-  for (let i = 0; i < left.length; i++) {
-    if (!Object.is(left[i], right[i])) return false;
-  }
-  return true;
 };
 
 const useMcpServerResourceInstance = (
@@ -775,7 +765,7 @@ export const McpServerResource = resource(function useMcpServerResource(
   const dependencies = getConnectionDependencies(props);
   const [connection, setConnection] = useState({ dependencies, generation: 0 });
   let currentConnection = connection;
-  if (!areConnectionDependenciesEqual(connection.dependencies, dependencies)) {
+  if (!shallowEqual(connection.dependencies, dependencies)) {
     currentConnection = {
       dependencies,
       generation: connection.generation + 1,

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -64,10 +64,11 @@ const isShallowEqual = (a: unknown, b: unknown, depth = 1): boolean => {
   if (depth <= 0) return false;
 
   if (Array.isArray(a) && Array.isArray(b)) {
-    return (
-      a.length === b.length &&
-      a.every((item, i) => isShallowEqual(item, b[i], depth - 1))
-    );
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!isShallowEqual(a[i], b[i], depth - 1)) return false;
+    }
+    return true;
   }
 
   const plain = (value: unknown): value is Record<string, unknown> =>

--- a/packages/react/src/mcp-apps/app-frame.test.tsx
+++ b/packages/react/src/mcp-apps/app-frame.test.tsx
@@ -332,6 +332,23 @@ describe("McpAppFrame", () => {
       availableDisplayModes: ["inline", "pip"],
     });
 
+    // A hole is not a value, in either operand order: sparse-to-dense is the
+    // direction Array.prototype.every read as equal by skipping the hole.
+    const sparseModes: ("inline" | "pip")[] = new Array(2);
+    sparseModes[1] = "pip";
+    rendered.rerender(
+      view({ displayMode: "fullscreen", availableDisplayModes: sparseModes }),
+    );
+    expect(bridge.notifyHostContextChanged).toHaveBeenCalledTimes(2);
+
+    rendered.rerender(
+      view({
+        displayMode: "fullscreen",
+        availableDisplayModes: ["inline", "pip"],
+      }),
+    );
+    expect(bridge.notifyHostContextChanged).toHaveBeenCalledTimes(3);
+
     sandboxBridge.dispose();
   });
   it("cancels a queued host context that returns to the delivered value", () => {

--- a/packages/react/src/mcp-apps/app-frame.test.tsx
+++ b/packages/react/src/mcp-apps/app-frame.test.tsx
@@ -332,8 +332,7 @@ describe("McpAppFrame", () => {
       availableDisplayModes: ["inline", "pip"],
     });
 
-    // A hole is not a value, in either operand order: sparse-to-dense is the
-    // direction Array.prototype.every read as equal by skipping the hole.
+    // A hole is not a value, in either operand order.
     const sparseModes: ("inline" | "pip")[] = new Array(2);
     sparseModes[1] = "pip";
     rendered.rerender(

--- a/packages/react/src/mcp-apps/app-frame.tsx
+++ b/packages/react/src/mcp-apps/app-frame.tsx
@@ -42,12 +42,12 @@ const isSameHostContext = (a: unknown, b: unknown, depth = 0): boolean => {
   if (Object.is(a, b)) return true;
   if (depth > 100) return false;
   if (Array.isArray(a) || Array.isArray(b)) {
-    return (
-      Array.isArray(a) &&
-      Array.isArray(b) &&
-      a.length === b.length &&
-      a.every((item, index) => isSameHostContext(item, b[index], depth + 1))
-    );
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length)
+      return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!isSameHostContext(a[i], b[i], depth + 1)) return false;
+    }
+    return true;
   }
   if (!isPlainObject(a) || !isPlainObject(b)) return false;
   const aKeys = Object.keys(a);

--- a/packages/react/src/unstable/webmcp/useWebMcpProvider.ts
+++ b/packages/react/src/unstable/webmcp/useWebMcpProvider.ts
@@ -7,6 +7,7 @@ import type { Tool } from "assistant-stream";
 import { getDefaultWebMcpHost, type WebMcpHost } from "./webmcp-host";
 import { defaultWebMcpFilter, toWebMcpInputSchema } from "./convertTools";
 import { WebMcpRegistrationResource } from "./WebMcpRegistrationResource";
+import { shallowEqual } from "@assistant-ui/store/internal";
 import {
   useModelContextSnapshot,
   type ModelContextSnapshotSource,
@@ -60,19 +61,11 @@ const modelContextToolSource: ModelContextSnapshotSource<
     aui.modelContext.subscribe?.(onChange) ?? NO_SUBSCRIPTION,
 };
 
-const namesEqual = (a: readonly string[], b: readonly string[]): boolean => {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-};
-
 const useStableNames = (names: readonly (string | null)[]) => {
   const [cell] = useState(() => ({ names: EMPTY_NAMES }));
   const next = names.filter((name): name is string => name !== null).sort();
   const previous = cell.names;
-  if (namesEqual(previous, next)) {
+  if (shallowEqual(previous, next)) {
     return previous;
   }
   cell.names = next;

--- a/packages/react/src/unstable/webmcp/useWebMcpProvider.ts
+++ b/packages/react/src/unstable/webmcp/useWebMcpProvider.ts
@@ -60,14 +60,19 @@ const modelContextToolSource: ModelContextSnapshotSource<
     aui.modelContext.subscribe?.(onChange) ?? NO_SUBSCRIPTION,
 };
 
+const namesEqual = (a: readonly string[], b: readonly string[]): boolean => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+};
+
 const useStableNames = (names: readonly (string | null)[]) => {
   const [cell] = useState(() => ({ names: EMPTY_NAMES }));
   const next = names.filter((name): name is string => name !== null).sort();
   const previous = cell.names;
-  if (
-    previous.length === next.length &&
-    previous.every((name, index) => name === next[index])
-  ) {
+  if (namesEqual(previous, next)) {
     return previous;
   }
   cell.names = next;

--- a/packages/ui/src/components/react/assistant-ui/elements/conversation-map.aui.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/conversation-map.aui.tsx
@@ -22,6 +22,14 @@ const TOP_TOLERANCE = 1;
  * of the end can never reach the top, so a fixed line leaves the last screen's
  * worth of ticks permanently unreachable.
  */
+const sameIds = (a: readonly string[], b: readonly string[]): boolean => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+};
+
 const readingLine = (viewport: HTMLElement) => {
   const rect = viewport.getBoundingClientRect();
   const height = viewport.clientHeight;
@@ -183,10 +191,7 @@ export function ConversationMapAui({
 
       setActiveId(current ?? owners.values().next().value);
       setVisibleIds((previous) =>
-        previous.length === onScreen.length &&
-        previous.every((id, index) => id === onScreen[index])
-          ? previous
-          : onScreen,
+        sameIds(previous, onScreen) ? previous : onScreen,
       );
     };
     const schedule = () => {

--- a/packages/ui/src/components/react/assistant-ui/elements/conversation-map.aui.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/conversation-map.aui.tsx
@@ -15,13 +15,6 @@ const PREVIEW_LENGTH = 240;
  */
 const TOP_TOLERANCE = 1;
 
-/**
- * The line a message has to cross to count as the one being read. It sits at
- * the top of the viewport for most of a thread, then slides to the bottom
- * across the final screenful: a message that starts within one viewport height
- * of the end can never reach the top, so a fixed line leaves the last screen's
- * worth of ticks permanently unreachable.
- */
 const sameIds = (a: readonly string[], b: readonly string[]): boolean => {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
@@ -30,6 +23,13 @@ const sameIds = (a: readonly string[], b: readonly string[]): boolean => {
   return true;
 };
 
+/**
+ * The line a message has to cross to count as the one being read. It sits at
+ * the top of the viewport for most of a thread, then slides to the bottom
+ * across the final screenful: a message that starts within one viewport height
+ * of the end can never reach the top, so a fixed line leaves the last screen's
+ * worth of ticks permanently unreachable.
+ */
 const readingLine = (viewport: HTMLElement) => {
   const rect = viewport.getBoundingClientRect();
   const height = viewport.clientHeight;


### PR DESCRIPTION
Closes #6967.

## Problem

`Array.prototype.every` skips empty positions, so a comparator built on `a.every((v, i) => ... b[i])` reads a hole in `a` as nothing-to-check while the matching position in `b` compares as `undefined`, an asymmetric equality where `cmp(new Array(1), [42])` is true but `cmp([42], new Array(1))` is false. #6955 fixed the instance that mattered (the exported `shallowEqual`); this closes the same pattern everywhere else it is still live.

The issue enumerated eight sites and called all eight latent. Both halves of that turned out to be off.

The inventory missed one: `attachmentsEqual` (`packages/core/src/adapters/attachment.ts`), which is the worst of the set, because its `b[i]!.id` non-null assertion makes a hole in `b` throw rather than compare unequal.

And three of the sites take a caller-provided array straight into the comparator, so they are reachable, not latent: the `ThreadSuggestions` / `Suggestions` config path, `McpAppFrame`'s `hostContext` prop, and the `MarkdownText` / `StreamdownText` props comparison.

At the Suggestions seam the comparator fix alone turns a silent wrong answer into a crash. `map` preserves holes, so a sparse caller array survives into the per-suggestion resource lookup, which indexes every slot and dies on `getElementKey(undefined)`; on main the `.every` hole-skip hides that by reading the sparse update as unchanged and reusing the previous dense state. So this PR also normalizes there: sparse caller arrays compact to dense lists at the single construction point, with identity reuse probed at the compacted destination index so repeated equivalent sparse updates stay stable.

## Change

Each `.every`-based comparison becomes an indexed loop in #6955's shape, or delegates to `shallowEqual`, whose array branch already is that loop:

- `core`: `toolNamesEqual` (model-context-client) and the suggestions identity check both delegate to `shallowEqual`; `attachmentsEqual` (adapters/attachment) takes an indexed loop and loses the non-null assertion that made a hole throw
- `react`: `isSameHostContext`'s array branch (mcp-apps app-frame) keeps its own recursive call inside an indexed loop; `useStableNames` (webmcp) delegates to `shallowEqual`
- `react-markdown` / `react-streamdown`: both `isShallowEqual` array branches keep their recursive call inside an indexed loop
- `react-mcp`: `areConnectionDependenciesEqual` was a line-for-line reimplementation of `shallowEqual`'s array branch, so it is deleted and its one call site calls `shallowEqual`
- `ui`: the conversation-map visible-ids check, extracted as a local `sameIds` rather than an import from `@assistant-ui/store/internal`, so the registry item stays self-contained

The sites that moved to `shallowEqual` trade `===` for `Object.is`, which is the same relation on the strings and identity-compared values they hold. No behavior change for dense arrays anywhere.

Regression tests cover the two seams where a hole changes an observable outcome: a sparse Suggestions update compacts, does not crash the lookup, and keeps identities stable across an equivalent repeat; and `McpAppFrame` treats a hole and a value as unequal in both operand orders (sparse-to-dense is the direction main reads as equal). The rest is comparator hygiene with no downstream consumer that could observe it, so it carries no test.

## Verification

Touched packages' suites pass: core 1751, ui 728 (16 skipped), react 568, react-streamdown 223, react-mcp 203, react-markdown 126.

The Suggestions claim was checked against its counterfactual: with only the issue's prescribed comparator fix applied and the compaction left out, the new test fails with `TypeError: Cannot read properties of undefined (reading 'key')`. Both halves are load-bearing.

## Public surface

No API changes. `attachmentsEqual` is exported from its module but reaches no barrel, and `areConnectionDependenciesEqual` was module-private. Patch changesets for the five published packages per the issue; `@assistant-ui/ui` is private and takes none.
<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.cXOrmbpYL8ti0Sm1PoUx33pU2KTW3CzKavSnRrvhTwsdTNsf5e_ggEkHoSc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

