### PR TITLE
fix(react): keep data renderers with chain-of-thought grouping

### DIFF
--- a/.changeset/web-part-renderer-data.md
+++ b/.changeset/web-part-renderer-data.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: keep inline data renderers in MessagePrimitive.Parts when ChainOfThought is active.

--- a/packages/react/src/primitives/message/MessageParts.tsx
+++ b/packages/react/src/primitives/message/MessageParts.tsx
@@ -56,7 +56,6 @@ export const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props> = (
           ? { ChainOfThought: components.ChainOfThought }
           : {
               tools: components.tools,
-              data: components.data,
               ToolGroup:
                 components.ToolGroup ?? messagePartsDefaultComponents.ToolGroup,
               ReasoningGroup:
@@ -65,6 +64,7 @@ export const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props> = (
             }),
         Empty: components.Empty,
         Quote: components.Quote,
+        data: components.data,
         generativeUI: components.generativeUI,
       }
     : webDefaultComponents;

--- a/packages/react/src/tests/DataRenderers.test.tsx
+++ b/packages/react/src/tests/DataRenderers.test.tsx
@@ -3,9 +3,10 @@
 // Data part rendering contract: global renderers > global fallbacks >
 // inline `components.data` config, exercised through the real store.
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import {
   useEffect,
+  useState,
   type FC,
   type PropsWithChildren,
   type ReactNode,
@@ -95,6 +96,55 @@ describe("data part rendering", () => {
     await waitFor(() => {
       expect(screen.getByTestId("inline").textContent).toBe("chart:42");
     });
+  });
+
+  it("keeps inline data renderers when chain-of-thought grouping changes", async () => {
+    const data = {
+      by_name: { chart: labeled("named") },
+      Fallback: labeled("fallback"),
+    };
+    const ChainOfThought = () => <span>Thought group</span>;
+    const Message: FC = () => {
+      const [grouped, setGrouped] = useState(false);
+      return (
+        <>
+          <button onClick={() => setGrouped(!grouped)}>Toggle grouping</button>
+          <MessagePrimitive.Parts
+            components={grouped ? { data, ChainOfThought } : { data }}
+          />
+        </>
+      );
+    };
+
+    renderThread(
+      [
+        {
+          role: "assistant",
+          content: [
+            { type: "reasoning", text: "Thinking" },
+            { type: "data", name: "chart", data: { value: 42 } },
+            { type: "data", name: "other", data: { value: 7 } },
+          ],
+          status: { type: "complete", reason: "stop" },
+        },
+      ],
+      Message,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("named").textContent).toBe("chart:42");
+      expect(screen.getByTestId("fallback").textContent).toBe("other:7");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle grouping" }));
+    expect(screen.getByText("Thought group")).toBeTruthy();
+    expect(screen.getByTestId("named").textContent).toBe("chart:42");
+    expect(screen.getByTestId("fallback").textContent).toBe("other:7");
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle grouping" }));
+    expect(screen.queryByText("Thought group")).toBeNull();
+    expect(screen.getByTestId("named").textContent).toBe("chart:42");
+    expect(screen.getByTestId("fallback").textContent).toBe("other:7");
   });
 
   it("uses the inline Fallback for unmatched names and renders nothing without one", async () => {


### PR DESCRIPTION
## Problem

Inline data content disappears from web `MessagePrimitive.Parts` when `ChainOfThought` is active. Named renderers and the inline fallback are affected.

Reproduction on `@assistant-ui/react` 0.15.18 at base `3a5cf41bbfabf885cdeefa62407d26f42322be08`: render this configuration inside an assistant message scope:

```tsx
<MessagePrimitive.Parts
  components={{
    ChainOfThought: () => <span>Thought group</span>,
    data: {
      by_name: { chart: ({ data }) => <span>{String(data)}</span> },
      Fallback: ({ name }) => <span>{name}</span>,
    },
  }}
/>
```

For message content `[{ type: "data", name: "chart", data: 42 }]`, the renderer shows nothing. Without `ChainOfThought`, it shows `42`.

## Root cause

The web wrapper copies `data` only in the standard grouping branch. The shared renderer therefore receives no inline data configuration in `ChainOfThought` mode.

## Change

Data configuration remains available in each grouping mode. Web already retains `generativeUI`; that path stays unchanged.

This PR is independent of the native correction and targets `main`.

Related: #6983

## Verification

- The new regression fails before the correction and passes afterward. It covers named and fallback data output through grouping changes in each direction.
- `pnpm --filter @assistant-ui/react test src/tests/DataRenderers.test.tsx src/tests/generative-ui.primitive.test.tsx src/tests/MessageParts.loading.test.tsx`: 13 tests pass, with no type errors.
- The web package build and scoped Oxlint pass.
- The real browser component retains data through mouse and keyboard changes. Desktop and 390px views show complete long fallback content without clipping.

## Public surface

`@assistant-ui/react` receives a patch changeset. Exports, signatures, native code, and documentation contracts stay unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.6eqdbZTLTw1BDC3zEBD-KK9-iEWHYpGWSrqi00mQIUnVafPutU85VNcw7TU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->