### PR TITLE
fix(react-opencode): cancel pending new-thread sends on teardown

### DIFF
--- a/.changeset/quiet-tools-rest.md
+++ b/.changeset/quiet-tools-rest.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: cancel pending new-thread sends when the runtime is torn down

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -36,6 +36,7 @@ import { useOpenCodeStreamingTiming } from "./useOpenCodeStreamingTiming";
 type OpenCodeControllerRegistry = {
   getEventSource(): OpenCodeEventSource;
   controllers: Map<string, OpenCodeThreadController>;
+  generation: number;
   dispose(): void;
 };
 
@@ -44,6 +45,7 @@ const createRegistry = (
 ): OpenCodeControllerRegistry => {
   let eventSource: OpenCodeEventSource | null = null;
   const controllers = new Map<string, OpenCodeThreadController>();
+  let generation = 0;
 
   const getEventSource = () => {
     eventSource ??= new OpenCodeEventSource(client);
@@ -53,7 +55,11 @@ const createRegistry = (
   return {
     getEventSource,
     controllers,
+    get generation() {
+      return generation;
+    },
     dispose() {
+      generation += 1;
       eventSource?.dispose();
       eventSource = null;
       for (const controller of controllers.values()) {
@@ -276,6 +282,7 @@ const useNewOpenCodeThreadStore = (
       extras,
       ...(options.adapters && { adapters: options.adapters }),
       onNew: async (message: AppendMessage) => {
+        const generation = registry.generation;
         const optimistic = toOptimisticThreadMessage(
           message,
           optimisticMessageIndexRef.current++,
@@ -283,6 +290,7 @@ const useNewOpenCodeThreadStore = (
         setOptimisticMessages((messages) => [...messages, optimistic]);
 
         const task = sendQueueRef.current.then(async () => {
+          if (registry.generation !== generation) return;
           let initialization:
             | Promise<{
                 remoteId: string;
@@ -294,6 +302,7 @@ const useNewOpenCodeThreadStore = (
               initializationRef.current ??
               (initializationRef.current = aui.threadListItem.initialize());
             const { remoteId, externalId } = await initialization;
+            if (registry.generation !== generation) return;
             const sessionId = externalId ?? remoteId;
             const controller = getController(registry, client, sessionId);
             const dispatch = sendOpenCodeMessage(controller, message, options);

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -36,7 +36,8 @@ import { useOpenCodeStreamingTiming } from "./useOpenCodeStreamingTiming";
 type OpenCodeControllerRegistry = {
   getEventSource(): OpenCodeEventSource;
   controllers: Map<string, OpenCodeThreadController>;
-  readonly generation: number;
+  readonly disposed: boolean;
+  activate(): void;
   dispose(): void;
 };
 
@@ -45,7 +46,7 @@ const createRegistry = (
 ): OpenCodeControllerRegistry => {
   let eventSource: OpenCodeEventSource | null = null;
   const controllers = new Map<string, OpenCodeThreadController>();
-  let generation = 0;
+  let disposed = false;
 
   const getEventSource = () => {
     eventSource ??= new OpenCodeEventSource(client);
@@ -55,11 +56,14 @@ const createRegistry = (
   return {
     getEventSource,
     controllers,
-    get generation() {
-      return generation;
+    get disposed() {
+      return disposed;
+    },
+    activate() {
+      disposed = false;
     },
     dispose() {
-      generation += 1;
+      disposed = true;
       eventSource?.dispose();
       eventSource = null;
       for (const controller of controllers.values()) {
@@ -282,7 +286,6 @@ const useNewOpenCodeThreadStore = (
       extras,
       ...(options.adapters && { adapters: options.adapters }),
       onNew: async (message: AppendMessage) => {
-        const generation = registry.generation;
         const optimistic = toOptimisticThreadMessage(
           message,
           optimisticMessageIndexRef.current++,
@@ -295,7 +298,7 @@ const useNewOpenCodeThreadStore = (
               messages.filter((candidate) => candidate !== optimistic),
             );
           };
-          if (registry.generation !== generation) {
+          if (registry.disposed) {
             removeOptimisticMessage();
             return;
           }
@@ -310,7 +313,7 @@ const useNewOpenCodeThreadStore = (
               initializationRef.current ??
               (initializationRef.current = aui.threadListItem.initialize());
             const { remoteId, externalId } = await initialization;
-            if (registry.generation !== generation) {
+            if (registry.disposed) {
               removeOptimisticMessage();
               return;
             }
@@ -373,6 +376,7 @@ export const useOpenCodeRuntime = (
   const registry = useMemo(() => createRegistry(client), [client]);
 
   useEffect(() => {
+    registry.activate();
     return () => {
       registry.dispose();
     };

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -36,7 +36,7 @@ import { useOpenCodeStreamingTiming } from "./useOpenCodeStreamingTiming";
 type OpenCodeControllerRegistry = {
   getEventSource(): OpenCodeEventSource;
   controllers: Map<string, OpenCodeThreadController>;
-  generation: number;
+  readonly generation: number;
   dispose(): void;
 };
 
@@ -290,7 +290,15 @@ const useNewOpenCodeThreadStore = (
         setOptimisticMessages((messages) => [...messages, optimistic]);
 
         const task = sendQueueRef.current.then(async () => {
-          if (registry.generation !== generation) return;
+          const removeOptimisticMessage = () => {
+            setOptimisticMessages((messages) =>
+              messages.filter((candidate) => candidate !== optimistic),
+            );
+          };
+          if (registry.generation !== generation) {
+            removeOptimisticMessage();
+            return;
+          }
           let initialization:
             | Promise<{
                 remoteId: string;
@@ -302,18 +310,17 @@ const useNewOpenCodeThreadStore = (
               initializationRef.current ??
               (initializationRef.current = aui.threadListItem.initialize());
             const { remoteId, externalId } = await initialization;
-            if (registry.generation !== generation) return;
+            if (registry.generation !== generation) {
+              removeOptimisticMessage();
+              return;
+            }
             const sessionId = externalId ?? remoteId;
             const controller = getController(registry, client, sessionId);
             const dispatch = sendOpenCodeMessage(controller, message, options);
-            setOptimisticMessages((messages) =>
-              messages.filter((candidate) => candidate !== optimistic),
-            );
+            removeOptimisticMessage();
             await dispatch;
           } catch (error) {
-            setOptimisticMessages((messages) =>
-              messages.filter((candidate) => candidate !== optimistic),
-            );
+            removeOptimisticMessage();
             invokeErrorCallback(options.onError, error);
             throw error;
           } finally {

--- a/packages/react-opencode/src/useOpenCodeRuntimeApproval.test.tsx
+++ b/packages/react-opencode/src/useOpenCodeRuntimeApproval.test.tsx
@@ -95,6 +95,7 @@ type ApprovalAdapter = {
 
 type RuntimeAdapter = ApprovalAdapter & {
   onNew?: (message: { role: "user"; content: [] }) => Promise<void> | void;
+  messageRepository?: { messages: unknown[] };
 };
 
 const stubClient = {
@@ -246,6 +247,45 @@ describe("useOpenCodeRuntime", () => {
     sessionCreate.resolve({ data: { id: "session-1" } });
     await sendPromise;
 
+    expect(mocks.controller.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("clears pending optimistic messages after client replacement", async () => {
+    const sessionCreate = Promise.withResolvers<{ data: { id: string } }>();
+    mocks.sessionCreate.mockReturnValue(sessionCreate.promise);
+    mocks.threadListItem.externalId = undefined;
+    mocks.threadListItem.remoteId = undefined;
+    mocks.threadListItem.status = "new";
+    mocks.state = createOpenCodeThreadState("session-1");
+
+    const App = ({ client }: { client: typeof stubClient }) => {
+      useOpenCodeRuntime({ client });
+      return null;
+    };
+
+    root = createRoot(document.createElement("div"));
+    await act(async () =>
+      root!.render(createElement(App, { client: stubClient })),
+    );
+
+    const adapter = mocks.adapters.at(-1) as RuntimeAdapter;
+    const sendPromise = adapter.onNew!({ role: "user", content: [] });
+    await vi.waitFor(() => expect(mocks.sessionCreate).toHaveBeenCalledOnce());
+
+    const replacementClient = {
+      ...stubClient,
+    } as ReturnType<typeof createOpencodeClient>;
+    await act(async () =>
+      root!.render(createElement(App, { client: replacementClient })),
+    );
+
+    await act(async () => {
+      sessionCreate.resolve({ data: { id: "session-1" } });
+      await sendPromise;
+    });
+
+    const replacementAdapter = mocks.adapters.at(-1) as RuntimeAdapter;
+    expect(replacementAdapter.messageRepository?.messages).toEqual([]);
     expect(mocks.controller.sendMessage).not.toHaveBeenCalled();
   });
 

--- a/packages/react-opencode/src/useOpenCodeRuntimeApproval.test.tsx
+++ b/packages/react-opencode/src/useOpenCodeRuntimeApproval.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, createElement } from "react";
+import { act, createElement, StrictMode, useEffect, useRef } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RespondToToolApprovalOptions } from "@assistant-ui/react";
@@ -287,6 +287,41 @@ describe("useOpenCodeRuntime", () => {
     const replacementAdapter = mocks.adapters.at(-1) as RuntimeAdapter;
     expect(replacementAdapter.messageRepository?.messages).toEqual([]);
     expect(mocks.controller.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps a pending new-thread send across StrictMode effect replay", async () => {
+    const sessionCreate = Promise.withResolvers<{ data: { id: string } }>();
+    mocks.sessionCreate.mockReturnValue(sessionCreate.promise);
+    mocks.threadListItem.externalId = undefined;
+    mocks.threadListItem.remoteId = undefined;
+    mocks.threadListItem.status = "new";
+    mocks.state = createOpenCodeThreadState("session-1");
+    let sendPromise: Promise<void> | void;
+
+    const Harness = () => {
+      useOpenCodeRuntime({ client: stubClient });
+      const sentRef = useRef(false);
+      useEffect(() => {
+        if (sentRef.current) return;
+        sentRef.current = true;
+        const adapter = mocks.adapters.at(-1) as RuntimeAdapter;
+        sendPromise = adapter.onNew!({ role: "user", content: [] });
+      }, []);
+      return null;
+    };
+
+    root = createRoot(document.createElement("div"));
+    await act(async () => {
+      root!.render(createElement(StrictMode, null, createElement(Harness)));
+    });
+    await vi.waitFor(() => expect(mocks.sessionCreate).toHaveBeenCalledOnce());
+
+    await act(async () => {
+      sessionCreate.resolve({ data: { id: "session-1" } });
+      await sendPromise;
+    });
+
+    expect(mocks.controller.sendMessage).toHaveBeenCalledOnce();
   });
 
   it("replies to standard approvals through the OpenCode permission API", async () => {

--- a/packages/react-opencode/src/useOpenCodeRuntimeApproval.test.tsx
+++ b/packages/react-opencode/src/useOpenCodeRuntimeApproval.test.tsx
@@ -221,6 +221,34 @@ describe("useOpenCodeRuntime", () => {
     expect(onError).toHaveBeenCalledWith(initializationError);
   });
 
+  it("drops pending new-thread sends after runtime teardown", async () => {
+    const sessionCreate = Promise.withResolvers<{ data: { id: string } }>();
+    mocks.sessionCreate.mockReturnValue(sessionCreate.promise);
+    mocks.threadListItem.externalId = undefined;
+    mocks.threadListItem.remoteId = undefined;
+    mocks.threadListItem.status = "new";
+    mocks.state = createOpenCodeThreadState("session-1");
+
+    const App = () => {
+      useOpenCodeRuntime({ client: stubClient });
+      return null;
+    };
+
+    root = createRoot(document.createElement("div"));
+    await act(async () => root!.render(createElement(App)));
+
+    const adapter = mocks.adapters.at(-1) as RuntimeAdapter;
+    const sendPromise = adapter.onNew!({ role: "user", content: [] });
+    await vi.waitFor(() => expect(mocks.sessionCreate).toHaveBeenCalledOnce());
+
+    act(() => root!.unmount());
+    root = undefined;
+    sessionCreate.resolve({ data: { id: "session-1" } });
+    await sendPromise;
+
+    expect(mocks.controller.sendMessage).not.toHaveBeenCalled();
+  });
+
   it("replies to standard approvals through the OpenCode permission API", async () => {
     mocks.state = createOpenCodeThreadState("session-1");
 


### PR DESCRIPTION
## Problem

A new-thread send can still be waiting for session initialization when the OpenCode runtime unmounts or its client is replaced. When initialization later resolves, the stale continuation creates a controller and sends the message through the departed client.

On current main, a focused reproduction started a send, unmounted the runtime before session creation resolved, then completed creation. sendMessage was called once after teardown.

## Root cause

The new-thread store introduced by #6204 queues sends and awaits threadListItem.initialize(), but the controller registry had no lifecycle state. Registry cleanup disposed controllers that already existed, while the pending continuation could create a new controller afterward.

## Change

Track whether the private OpenCode controller registry is active. Effect setup reactivates the registry so React StrictMode effect replay preserves legitimate pending sends; cleanup marks it disposed so work owned by an unmounted or replaced registry exits before initialization or dispatch. Cancelled paths also remove their optimistic message.

## Verification

- Confirmed the teardown reproduction sends once without the lifecycle checks and zero times with the fix
- Added client-replacement coverage for optimistic-message cleanup
- Added StrictMode effect-replay coverage for a legitimate pending send
- pnpm --filter @assistant-ui/react-opencode... build
- pnpm --filter @assistant-ui/react-opencode test (12 files, 135 tests)
- pnpm exec oxlint packages/react-opencode/src/useOpenCodeRuntime.ts packages/react-opencode/src/useOpenCodeRuntimeApproval.test.tsx
- pnpm exec oxfmt --check packages/react-opencode/src/useOpenCodeRuntime.ts packages/react-opencode/src/useOpenCodeRuntimeApproval.test.tsx
- pnpm changesets:check
- git diff --check

## Public surface

@assistant-ui/react-opencode receives a patch changeset. No exports or public signatures change.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.FIeDgWFm8MAR9BXNCgys7DCHTdEp1EYefAVPaLnFyAABBIK8Jf7Akp6-xzk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->