### PR TITLE
fix(react-pi): cancel pending new-thread sends on teardown

### DIFF
--- a/.changeset/shy-spoons-float.md
+++ b/.changeset/shy-spoons-float.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: cancel pending new-thread sends when the runtime is torn down

--- a/packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
+++ b/packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, createElement } from "react";
+import { act, createElement, StrictMode, useEffect, useRef } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -11,8 +11,22 @@ import type { AssistantRuntime } from "@assistant-ui/react";
 import type { PiClient, PiThreadSnapshot } from "../types";
 
 const mocks = vi.hoisted(() => ({
+  adapters: [] as unknown[],
   sendMessage: vi.fn().mockResolvedValue(undefined),
 }));
+
+vi.mock("@assistant-ui/react", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@assistant-ui/react")>();
+  return {
+    ...original,
+    useExternalStoreRuntime: (
+      adapter: Parameters<typeof original.useExternalStoreRuntime>[0],
+    ) => {
+      mocks.adapters.push(adapter);
+      return original.useExternalStoreRuntime(adapter);
+    },
+  };
+});
 
 vi.mock("./ThreadController", async (importOriginal) => {
   const original = await importOriginal<typeof import("./ThreadController")>();
@@ -84,6 +98,7 @@ let root: Root | undefined;
 afterEach(() => {
   act(() => root?.unmount());
   root = undefined;
+  mocks.adapters.length = 0;
   vi.clearAllMocks();
 });
 
@@ -183,5 +198,45 @@ describe("usePiRuntime new-thread first message", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(mocks.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps a pending new-thread send across StrictMode effect replay", async () => {
+    const sessionCreate = Promise.withResolvers<PiThreadSnapshot>();
+    const { client, createThread } = createClient(() => sessionCreate.promise);
+    let sendPromise: Promise<void> | void;
+
+    const Harness = () => {
+      const runtime = usePiRuntime({ client });
+      const sentRef = useRef(false);
+      useEffect(() => {
+        if (sentRef.current) return;
+        sentRef.current = true;
+        const adapter = mocks.adapters.at(-1) as {
+          onNew: (message: {
+            role: "user";
+            content: [{ type: "text"; text: string }];
+          }) => Promise<void>;
+        };
+        sendPromise = adapter.onNew({
+          role: "user",
+          content: [{ type: "text", text: "strict mode message" }],
+        });
+      }, []);
+      return createElement(AssistantRuntimeProvider, { runtime }, null);
+    };
+
+    root = createRoot(document.createElement("div"));
+    await act(async () => {
+      root!.render(createElement(StrictMode, null, createElement(Harness)));
+    });
+    await vi.waitFor(() => expect(createThread).toHaveBeenCalledOnce());
+
+    await act(async () => {
+      sessionCreate.resolve(snapshot);
+      await sendPromise;
+    });
+
+    expect(mocks.sendMessage).toHaveBeenCalledOnce();
+    expect(sentTexts()).toEqual(["strict mode message"]);
   });
 });

--- a/packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
+++ b/packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
@@ -155,4 +155,33 @@ describe("usePiRuntime new-thread first message", () => {
     expect(createThread.mock.calls[0]?.[0]?.initialMessage).toBeUndefined();
     expect(sentTexts()).toEqual(["message A", "message B"]);
   });
+
+  it("drops a pending new-thread send after runtime teardown", async () => {
+    const sessionCreate = Promise.withResolvers<PiThreadSnapshot>();
+    const { client, createThread } = createClient(() => sessionCreate.promise);
+    let runtime!: AssistantRuntime;
+
+    const Harness = () => {
+      runtime = usePiRuntime({ client });
+      return createElement(AssistantRuntimeProvider, { runtime }, null);
+    };
+
+    root = createRoot(document.createElement("div"));
+    await act(async () => {
+      root!.render(createElement(Harness));
+    });
+    await act(async () => {});
+
+    await act(async () => {
+      runtime.thread.append("late message");
+    });
+    await vi.waitFor(() => expect(createThread).toHaveBeenCalledOnce());
+
+    act(() => root!.unmount());
+    root = undefined;
+    sessionCreate.resolve(snapshot);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+  });
 });

--- a/packages/react-pi/src/runtime/usePiRuntime.ts
+++ b/packages/react-pi/src/runtime/usePiRuntime.ts
@@ -48,15 +48,21 @@ type PiControllerRegistry = {
   /** The client these controllers are bound to (a new client ⇒ a new registry). */
   client: PiClient;
   controllers: Map<string, PiThreadController>;
+  generation: number;
   dispose(): void;
 };
 
 const createRegistry = (client: PiClient): PiControllerRegistry => {
   const controllers = new Map<string, PiThreadController>();
+  let generation = 0;
   return {
     client,
     controllers,
+    get generation() {
+      return generation;
+    },
     dispose() {
+      generation += 1;
       for (const controller of controllers.values()) controller.dispose();
       // Controllers stay cached so a StrictMode cleanup/remount reuses them;
       // a real unmount drops this whole registry.
@@ -405,6 +411,7 @@ const useNewPiThreadStore = (
       extras: EMPTY_RUNTIME_EXTRAS,
       ...(adapters ? { adapters } : {}),
       onNew: async (message) => {
+        const generation = registry.generation;
         const optimistic = toOptimisticThreadMessage(
           message,
           optimisticMessageIndexRef.current++,
@@ -416,6 +423,7 @@ const useNewPiThreadStore = (
           // deliver the message to the live thread.
           const { remoteId, externalId } =
             await aui.threadListItem.initialize();
+          if (registry.generation !== generation) return;
           await getController(registry, externalId ?? remoteId).sendMessage(
             message,
           );

--- a/packages/react-pi/src/runtime/usePiRuntime.ts
+++ b/packages/react-pi/src/runtime/usePiRuntime.ts
@@ -48,21 +48,25 @@ type PiControllerRegistry = {
   /** The client these controllers are bound to (a new client ⇒ a new registry). */
   client: PiClient;
   controllers: Map<string, PiThreadController>;
-  generation: number;
+  readonly disposed: boolean;
+  activate(): void;
   dispose(): void;
 };
 
 const createRegistry = (client: PiClient): PiControllerRegistry => {
   const controllers = new Map<string, PiThreadController>();
-  let generation = 0;
+  let disposed = false;
   return {
     client,
     controllers,
-    get generation() {
-      return generation;
+    get disposed() {
+      return disposed;
+    },
+    activate() {
+      disposed = false;
     },
     dispose() {
-      generation += 1;
+      disposed = true;
       for (const controller of controllers.values()) controller.dispose();
       // Controllers stay cached so a StrictMode cleanup/remount reuses them;
       // a real unmount drops this whole registry.
@@ -411,29 +415,32 @@ const useNewPiThreadStore = (
       extras: EMPTY_RUNTIME_EXTRAS,
       ...(adapters ? { adapters } : {}),
       onNew: async (message) => {
-        const generation = registry.generation;
         const optimistic = toOptimisticThreadMessage(
           message,
           optimisticMessageIndexRef.current++,
         );
         setOptimisticMessages((messages) => [...messages, optimistic]);
+        const removeOptimisticMessage = () => {
+          setOptimisticMessages((messages) =>
+            messages.filter((candidate) => candidate !== optimistic),
+          );
+        };
         try {
           // The core starts thread initialization before dispatching onNew,
           // so adapter.initialize has already created the thread empty;
           // deliver the message to the live thread.
           const { remoteId, externalId } =
             await aui.threadListItem.initialize();
-          if (registry.generation !== generation) return;
+          if (registry.disposed) {
+            removeOptimisticMessage();
+            return;
+          }
           await getController(registry, externalId ?? remoteId).sendMessage(
             message,
           );
-          setOptimisticMessages((messages) =>
-            messages.filter((candidate) => candidate !== optimistic),
-          );
+          removeOptimisticMessage();
         } catch (error) {
-          setOptimisticMessages((messages) =>
-            messages.filter((message) => message !== optimistic),
-          );
+          removeOptimisticMessage();
           invokePiErrorCallback(onError, error);
           throw error;
         }
@@ -517,7 +524,10 @@ export const usePiRuntime = (options: PiRuntimeOptions): AssistantRuntime => {
   const { client } = options;
   const registry = useMemo(() => createRegistry(client), [client]);
 
-  useEffect(() => () => registry.dispose(), [registry]);
+  useEffect(() => {
+    registry.activate();
+    return () => registry.dispose();
+  }, [registry]);
 
   const adapter = useMemo(
     () => ({


### PR DESCRIPTION
## Problem

A new-thread message can remain blocked on Pi thread initialization while the runtime unmounts or its client is replaced. When initialization later resolves, the stale continuation creates a controller from the departed registry and sends the message through the previous client.

On current main, a focused reproduction started a new-thread append, unmounted before createThread resolved, and then completed creation. The old controller received the message once after teardown.

## Root cause

The new-thread store awaits threadListItem.initialize() before looking up its controller. Registry cleanup disposes controllers that already exist, but initialization can finish afterward and create a fresh controller with no lifecycle check.

## Change

Track whether the private Pi controller registry is active. Effect setup reactivates the registry so React StrictMode effect replay preserves legitimate pending sends; cleanup marks it disposed so a continuation owned by an unmounted or replaced registry exits without creating a controller. The cancellation path also removes its optimistic message.

## Verification

- Confirmed the teardown reproduction sends once without the lifecycle check and zero times with the fix
- Added StrictMode effect-replay coverage for a legitimate pending send
- pnpm --filter @assistant-ui/react-pi... build
- pnpm --filter @assistant-ui/react-pi test (13 files, 255 tests)
- pnpm exec oxlint packages/react-pi/src/runtime/usePiRuntime.ts packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
- pnpm exec oxfmt --check packages/react-pi/src/runtime/usePiRuntime.ts packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
- pnpm changesets:check
- git diff --check

## Public surface

@assistant-ui/react-pi receives a patch changeset. No exports or public signatures change.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-5U_74DU-g1xDuK5CfxkNvhox89dxnq4NhAQxARRLv6z9nLQuvqt8VNskLs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->