### PR TITLE
fix(react-generative-ui): preserve prototype-named properties

### DIFF
--- a/.changeset/sharp-jobs-study.md
+++ b/.changeset/sharp-jobs-study.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: preserve prototype-named properties in generated component schemas

--- a/packages/react-generative-ui/src/buildPresentParameters.ts
+++ b/packages/react-generative-ui/src/buildPresentParameters.ts
@@ -41,6 +41,8 @@ export function buildPresentParameters(
     }
     for (const [key, schema] of Object.entries(propsSchema.properties ?? {})) {
       if (key.startsWith("$") || key === "children") continue;
+      // Tool arguments are decoded with secure-json-parse, which rejects this key.
+      if (key === "__proto__") continue;
       if (!props.has(key)) {
         props.set(key, schema);
       }

--- a/packages/react-generative-ui/src/buildPresentParameters.ts
+++ b/packages/react-generative-ui/src/buildPresentParameters.ts
@@ -29,7 +29,7 @@ export function buildPresentParameters(
   // `children` are framework-reserved (see ir.ts), so drop any author-declared
   // copies. On a name clash the first component's schema wins — props are an
   // advisory hint here, not a strict per-component contract.
-  const props: Record<string, JSONSchema7Definition> = {};
+  const props = new Map<string, JSONSchema7Definition>();
   const propOwners = new Map<string, string[]>();
   for (const name of names) {
     const propsSchema = toJSONSchema(library[name]!.properties);
@@ -41,8 +41,8 @@ export function buildPresentParameters(
     }
     for (const [key, schema] of Object.entries(propsSchema.properties ?? {})) {
       if (key.startsWith("$") || key === "children") continue;
-      if (!(key in props)) {
-        props[key] = schema;
+      if (!props.has(key)) {
+        props.set(key, schema);
       }
       propOwners.set(key, [...(propOwners.get(key) ?? []), name]);
     }
@@ -78,7 +78,7 @@ export function buildPresentParameters(
           "Stable identity for this UI node. Use it for list items that may reorder.",
         anyOf: [{ type: "string" }, { type: "number" }],
       },
-      ...props,
+      ...Object.fromEntries(props),
       children: { $ref: "#/$defs/children" },
     },
     required: [TYPE_KEY],

--- a/packages/react-generative-ui/src/buildPresentParameters.ts
+++ b/packages/react-generative-ui/src/buildPresentParameters.ts
@@ -41,7 +41,8 @@ export function buildPresentParameters(
     }
     for (const [key, schema] of Object.entries(propsSchema.properties ?? {})) {
       if (key.startsWith("$") || key === "children") continue;
-      // Tool arguments are decoded with secure-json-parse, which rejects this key.
+      // secure-json-parse rejects the whole tool-argument payload on this key,
+      // so advertising it would cost the model the node rather than one prop.
       if (key === "__proto__") continue;
       if (!props.has(key)) {
         props.set(key, schema);

--- a/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
+++ b/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
@@ -263,7 +263,7 @@ describe("buildPresentParameters", () => {
     expect(schema.required).toEqual(["$type"]);
   });
 
-  it("preserves prototype-named component properties", () => {
+  it("preserves safe prototype-named component properties", () => {
     const schema = buildPresentParameters({
       PrototypeProps: {
         description: "Uses valid property names shared with Object.prototype.",
@@ -273,12 +273,17 @@ describe("buildPresentParameters", () => {
         }),
         render: () => null,
       },
+      FollowingProps: {
+        description: "Uses a property that can match a polluted prototype.",
+        properties: z.object({ type: z.string() }),
+        render: () => null,
+      },
     }) as any;
 
     expect(Object.hasOwn(schema.properties, "toString")).toBe(true);
-    expect(Object.hasOwn(schema.properties, "__proto__")).toBe(true);
     expect(schema.properties.toString.type).toBe("string");
-    expect(schema.properties["__proto__"].type).toBe("number");
+    expect(Object.hasOwn(schema.properties, "__proto__")).toBe(false);
+    expect(schema.properties.type.type).toBe("string");
   });
 
   it("names every component that declares the same prop in the dev warning", () => {

--- a/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
+++ b/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
@@ -263,27 +263,35 @@ describe("buildPresentParameters", () => {
     expect(schema.required).toEqual(["$type"]);
   });
 
-  it("preserves safe prototype-named component properties", () => {
+  it("keeps props whose names are inherited from Object.prototype", () => {
     const schema = buildPresentParameters({
       PrototypeProps: {
-        description: "Uses valid property names shared with Object.prototype.",
+        description: "Declares props that shadow Object.prototype members.",
         properties: z.object({
-          ["toString"]: z.string(),
-          ["__proto__"]: z.number(),
+          toString: z.string(),
+          valueOf: z.number(),
+          constructor: z.boolean(),
         }),
-        render: () => null,
-      },
-      FollowingProps: {
-        description: "Uses a property that can match a polluted prototype.",
-        properties: z.object({ type: z.string() }),
         render: () => null,
       },
     }) as any;
 
-    expect(Object.hasOwn(schema.properties, "toString")).toBe(true);
     expect(schema.properties.toString.type).toBe("string");
+    expect(schema.properties.valueOf.type).toBe("number");
+    expect(schema.properties.constructor.type).toBe("boolean");
+  });
+
+  it("omits __proto__, which the tool-argument decoder rejects", () => {
+    const schema = buildPresentParameters({
+      PrototypeProps: {
+        description: "Declares an undeliverable prop name.",
+        properties: z.object({ ["__proto__"]: z.number(), label: z.string() }),
+        render: () => null,
+      },
+    }) as any;
+
     expect(Object.hasOwn(schema.properties, "__proto__")).toBe(false);
-    expect(schema.properties.type.type).toBe("string");
+    expect(schema.properties.label.type).toBe("string");
   });
 
   it("names every component that declares the same prop in the dev warning", () => {

--- a/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
+++ b/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
@@ -263,6 +263,24 @@ describe("buildPresentParameters", () => {
     expect(schema.required).toEqual(["$type"]);
   });
 
+  it("preserves prototype-named component properties", () => {
+    const schema = buildPresentParameters({
+      PrototypeProps: {
+        description: "Uses valid property names shared with Object.prototype.",
+        properties: z.object({
+          ["toString"]: z.string(),
+          ["__proto__"]: z.number(),
+        }),
+        render: () => null,
+      },
+    }) as any;
+
+    expect(Object.hasOwn(schema.properties, "toString")).toBe(true);
+    expect(Object.hasOwn(schema.properties, "__proto__")).toBe(true);
+    expect(schema.properties.toString.type).toBe("string");
+    expect(schema.properties["__proto__"].type).toBe("number");
+  });
+
   it("names every component that declares the same prop in the dev warning", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {


### PR DESCRIPTION
## Problem

A component property whose name is inherited from `Object.prototype` is dropped from the generated `present` tool schema. A component declaring `toString`, `valueOf`, or `constructor` produces no such property on the emitted schema, so the model receives an incomplete component contract.

Affected package: `@assistant-ui/react-generative-ui@0.0.17`.

## Root cause

`buildPresentParameters` merged every component's props into a plain object and used `key in props` to detect a prior declaration. `in` walks the prototype chain, so an inherited name reports as already declared and its real schema is never stored. The later spread then has nothing to copy.

## Change

Collect the merged schemas in a `Map` and materialize them with `Object.fromEntries`. `Map` membership preserves the existing first-declaration-wins behavior without consulting inherited keys.

`__proto__` is skipped explicitly. The plain object never emitted it either, because `"__proto__" in props` is already true and the assignment was unreachable, but a `Map` stores it happily and `Object.fromEntries` would promote it to a real own property. It must not reach the schema: tool arguments are decoded by `parsePartialJsonObject`, whose `secure-json-parse` call throws on `__proto__` and throws again on the fallback reparse, so the decoder returns `undefined` and the model loses the entire node rather than one prop. A scalar `constructor` survives that decoder, so it stays advertised.

## Verification

- `keeps props whose names are inherited from Object.prototype` fails against the plain-object accumulator on `main` (`expected undefined to be 'string'`) and passes with the `Map`
- `omits __proto__, which the tool-argument decoder rejects` fails when the `__proto__` guard is removed from the `Map` version (`expected true to be false`)
- `pnpm --filter @assistant-ui/react-generative-ui test` (29 files, 624 tests)
- `pnpm --filter @assistant-ui/react-generative-ui... build`
- `pnpm exec oxlint` and `pnpm exec oxfmt --check` on both touched files
- `pnpm changesets:check`

## Public surface

`@assistant-ui/react-generative-ui` receives a patch changeset. No exports or public signatures change.
