### PR TITLE
fix(react-ink): preserve prototype-named tools

### DIFF
--- a/.changeset/sour-fans-remember.md
+++ b/.changeset/sour-fans-remember.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix: preserve prototype-named tools in runtime toolkits

--- a/packages/react-ink/src/toolkit.test.ts
+++ b/packages/react-ink/src/toolkit.test.ts
@@ -77,6 +77,16 @@ describe("defineToolkit (runtime)", () => {
     expect(tool["render"]).toBe(render);
   });
 
+  it("preserves a tool named __proto__ as an own property", () => {
+    const toolkit = defineToolkit({
+      ["__proto__"]: { type: "backend", render } as never,
+    });
+
+    expect(Object.hasOwn(toolkit, "__proto__")).toBe(true);
+    expect(toolkit["__proto__"]).toEqual({ type: "backend", render });
+    expect(Object.getPrototypeOf(toolkit)).toBe(Object.prototype);
+  });
+
   it("throws when a frontend tool has no render or renderText", () => {
     expect(() =>
       defineToolkit({

--- a/packages/react-ink/src/toolkit.ts
+++ b/packages/react-ink/src/toolkit.ts
@@ -98,14 +98,14 @@ function assertValid(name: string, tool: Record<string, unknown>): void {
  * unchanged.
  */
 function defineToolkitRuntime(definition: ToolkitDefinition): Toolkit {
-  const toolkit: Record<string, unknown> = {};
+  const toolkit = new Map<string, unknown>();
 
   for (const [name, entry] of Object.entries(definition)) {
     const tool = entry as Record<string, unknown>;
 
     // Already-typed entry (render-only `{ type, render }`, factory output, ...).
     if (typeof tool["type"] === "string") {
-      toolkit[name] = tool;
+      toolkit.set(name, tool);
       continue;
     }
 
@@ -130,10 +130,10 @@ function defineToolkitRuntime(definition: ToolkitDefinition): Toolkit {
     }
 
     assertValid(name, resolved);
-    toolkit[name] = resolved;
+    toolkit.set(name, resolved);
   }
 
-  return toolkit as Toolkit;
+  return Object.fromEntries(toolkit) as Toolkit;
 }
 
 /**


### PR DESCRIPTION
## Problem

A React Ink runtime toolkit cannot retain a valid tool named __proto__. Assigning that key to the plain object accumulator invokes its inherited prototype setter instead of creating an own property, so the tool silently disappears from the returned toolkit.

A focused reproduction on current main defined an explicitly typed __proto__ tool and observed Object.hasOwn returning false.

## Root cause

defineToolkitRuntime assembled resolved tools with bracket assignment into a normal object. The __proto__ key has legacy setter behavior on Object.prototype.

## Change

Collect resolved tools in a Map and return Object.fromEntries(toolkit). This treats every tool name as data while preserving the normal Object.prototype of the returned toolkit and the existing insertion order and resolution behavior.

## Verification

- Confirmed the retained regression fails with the original object accumulator and passes with the Map accumulator
- pnpm --filter @assistant-ui/react-ink... build
- pnpm --filter @assistant-ui/react-ink test (26 files, 282 tests)
- pnpm exec oxlint packages/react-ink/src/toolkit.ts packages/react-ink/src/toolkit.test.ts
- pnpm exec oxfmt --check packages/react-ink/src/toolkit.ts packages/react-ink/src/toolkit.test.ts
- pnpm changesets:check
- git diff --check

## Public surface

@assistant-ui/react-ink receives a patch changeset. No exports or public signatures change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.VuEeAS5WE7t3QTDMHAubujvyfCGNMXBGWPui5cNm3W33gPjec2JFJRrQZuQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->