### PR TITLE
fix(react-opencode): preserve prototype-named message ids

### DIFF
--- a/.changeset/opencode-message-ids.md
+++ b/.changeset/opencode-message-ids.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: preserve OpenCode messages whose IDs match object prototype properties

--- a/packages/react-opencode/src/openCodeThreadState.test.ts
+++ b/packages/react-opencode/src/openCodeThreadState.test.ts
@@ -328,6 +328,60 @@ describe("reduceOpenCodeThreadState", () => {
     expect(history.messageOrder).toEqual(["msg_1"]);
   });
 
+  it("loads a history message whose ID is __proto__", () => {
+    const initial = createOpenCodeThreadState("ses_1");
+
+    const history = reduceOpenCodeThreadState(initial, {
+      type: "history.loaded",
+      session: null,
+      messages: [
+        {
+          info: {
+            id: "__proto__",
+            role: "assistant",
+            sessionID: "ses_1",
+            time: { created: 1000 },
+          },
+          parts: [],
+        } as unknown as MessageWithParts,
+      ],
+    });
+
+    expect(history.messageOrder).toEqual(["__proto__"]);
+    expect(Object.hasOwn(history.messagesById, "__proto__")).toBe(true);
+    expect(history.messagesById["__proto__"]?.id).toBe("__proto__");
+  });
+
+  it.each(["__proto__", "constructor", "toString"])(
+    "adds a streamed message whose ID is %s",
+    (messageId) => {
+      const initial = createOpenCodeThreadState("ses_1");
+      const withExisting = reduceOpenCodeThreadState(initial, {
+        type: "message.updated",
+        info: {
+          id: "msg_existing",
+          role: "assistant",
+          sessionID: "ses_1",
+          time: { created: 1000 },
+        } as never,
+      });
+
+      const updated = reduceOpenCodeThreadState(withExisting, {
+        type: "message.updated",
+        info: {
+          id: messageId,
+          role: "assistant",
+          sessionID: "ses_1",
+          time: { created: 1001 },
+        } as never,
+      });
+
+      expect(updated.messageOrder).toEqual(["msg_existing", messageId]);
+      expect(Object.hasOwn(updated.messagesById, messageId)).toBe(true);
+      expect(updated.messagesById[messageId]?.id).toBe(messageId);
+    },
+  );
+
   it("adds assistant parts without losing message order", () => {
     const initial = createOpenCodeThreadState("ses_1");
 

--- a/packages/react-opencode/src/openCodeThreadState.ts
+++ b/packages/react-opencode/src/openCodeThreadState.ts
@@ -83,11 +83,12 @@ const updateExistingMessage = (
   const current = state.messagesById[messageId];
   if (!current) return state;
 
+  const messagesById = copyMessagesById(state.messagesById);
+  messagesById[messageId] = updater(current);
+
   return {
     ...state,
-    messagesById: Object.assign(copyMessagesById(state.messagesById), {
-      [messageId]: updater(current),
-    }),
+    messagesById,
   };
 };
 

--- a/packages/react-opencode/src/openCodeThreadState.ts
+++ b/packages/react-opencode/src/openCodeThreadState.ts
@@ -13,6 +13,14 @@ import { serializeOpenCodeParts } from "./serializeUserParts";
 const PENDING_MATCH_WINDOW_MS = 2 * 60 * 1000;
 const MAX_UNHANDLED_EVENTS = 25;
 
+const copyMessagesById = (
+  messagesById?: Readonly<Record<string, OpenCodeServerMessage>>,
+): Record<string, OpenCodeServerMessage> =>
+  Object.assign(
+    Object.create(null) as Record<string, OpenCodeServerMessage>,
+    messagesById,
+  );
+
 const extractCreatedAt = (message: Message | undefined): number | undefined => {
   const created = message?.time?.created;
   return typeof created === "number" ? created : undefined;
@@ -54,10 +62,8 @@ const upsertMessage = (
 ): OpenCodeThreadState => {
   const current = state.messagesById[messageId];
   const nextMessage = updater(current);
-  const messagesById = {
-    ...state.messagesById,
-    [messageId]: nextMessage,
-  };
+  const messagesById = copyMessagesById(state.messagesById);
+  messagesById[messageId] = nextMessage;
   const messageOrder = current
     ? state.messageOrder
     : sortMessageIds(messagesById, [...state.messageOrder, messageId]);
@@ -79,10 +85,9 @@ const updateExistingMessage = (
 
   return {
     ...state,
-    messagesById: {
-      ...state.messagesById,
+    messagesById: Object.assign(copyMessagesById(state.messagesById), {
       [messageId]: updater(current),
-    },
+    }),
   };
 };
 
@@ -153,7 +158,7 @@ const historyLoaded = (
     ...state,
     session,
     loadState: { type: "ready" },
-    messagesById: {} as Readonly<Record<string, OpenCodeServerMessage>>,
+    messagesById: copyMessagesById(),
     messageOrder: [],
     sync: {
       ...state.sync,
@@ -161,7 +166,7 @@ const historyLoaded = (
     },
   };
 
-  const nextMessagesById: Record<string, OpenCodeServerMessage> = {};
+  const nextMessagesById = copyMessagesById();
   for (const message of messages) {
     const pendingMatch =
       message.info.role === "user"
@@ -242,7 +247,7 @@ export const createOpenCodeThreadState = (
   loadState: { type: "idle" },
   runState: { type: "idle" },
   messageOrder: [],
-  messagesById: {} as Readonly<Record<string, OpenCodeServerMessage>>,
+  messagesById: copyMessagesById(),
   childSessionsById: {} as Readonly<Record<string, OpenCodeThreadState>>,
   pendingUserMessages: {} as Readonly<Record<string, PendingUserMessage>>,
   interactions: {
@@ -417,7 +422,7 @@ export const reduceOpenCodeThreadState = (
 
     case "message.removed": {
       if (!(event.messageId in state.messagesById)) return state;
-      const messagesById = { ...state.messagesById };
+      const messagesById = copyMessagesById(state.messagesById);
       delete messagesById[event.messageId];
       return {
         ...state,


### PR DESCRIPTION
## Problem

`@assistant-ui/react-opencode@0.2.22` can lose messages whose provider-issued IDs match properties on `Object.prototype`. Loading a history message with ID `__proto__` produces an empty message order, while streamed IDs such as `constructor` and `toString` can be mistaken for existing inherited entries.

## Root cause

The thread reducer stored messages in ordinary objects and recreated those objects with spread syntax. Bracket assignment of `__proto__` changes an ordinary object's prototype, and missing prototype-named IDs resolve to inherited values instead of `undefined`.

## Change

Keep the OpenCode message dictionary prototype-free through initialization, history loading, updates, and removals. Add reducer coverage for history-loaded and streamed prototype-named IDs.

## Verification

- Confirmed the history reproduction fails on current `main` with `messageOrder: []`
- `pnpm --filter @assistant-ui/react-opencode test`
- `pnpm --filter @assistant-ui/react-opencode... build`
- `pnpm lint`
- `pnpm changesets:check`

## Public surface

`@assistant-ui/react-opencode` behavior changes with a patch changeset. No exports or API signatures change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.przAs3j4WRX6X6qZU5PFAcimbFFbwo-7OQ6m7SPohV5dxIYXl6Afy6ZVS8o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->