### PR TITLE
fix(react-google-adk): preserve prototype-named state keys

### DIFF
--- a/.changeset/google-adk-state-keys.md
+++ b/.changeset/google-adk-state-keys.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-google-adk": patch
 ---
 
-fix: preserve namespaced ADK state keys that match object prototype properties
+fix: preserve prototype-named ADK state keys and stabilize namespaced state hooks

--- a/.changeset/google-adk-state-keys.md
+++ b/.changeset/google-adk-state-keys.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: preserve namespaced ADK state keys that match object prototype properties

--- a/packages/react-google-adk/src/hooks.render.test.tsx
+++ b/packages/react-google-adk/src/hooks.render.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { useAdkAppState } from "./hooks";
+import { useAdkRuntime } from "./useAdkRuntime";
+
+describe("ADK state hook rendering", () => {
+  it("keeps the selected app state stable between store reads", () => {
+    const { result: runtimeResult } = renderHook(() =>
+      useAdkRuntime({
+        stream: async function* () {},
+      }),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AssistantRuntimeProvider runtime={runtimeResult.current}>
+        {children}
+      </AssistantRuntimeProvider>
+    );
+
+    const { result, rerender } = renderHook(() => useAdkAppState(), {
+      wrapper,
+    });
+    const initial = result.current;
+    rerender();
+
+    expect(result.current).toBe(initial);
+    expect(result.current).toEqual({});
+  });
+});

--- a/packages/react-google-adk/src/hooks.render.test.tsx
+++ b/packages/react-google-adk/src/hooks.render.test.tsx
@@ -1,32 +1,74 @@
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
+import type { AssistantRuntime } from "@assistant-ui/core";
 import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
-import type { ReactNode } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { useAdkAppState } from "./hooks";
+import type { AdkEvent } from "./types";
 import { useAdkRuntime } from "./useAdkRuntime";
 
 describe("ADK state hook rendering", () => {
-  it("keeps the selected app state stable between store reads", () => {
-    const { result: runtimeResult } = renderHook(() =>
-      useAdkRuntime({
-        stream: async function* () {},
-      }),
-    );
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <AssistantRuntimeProvider runtime={runtimeResult.current}>
-        {children}
-      </AssistantRuntimeProvider>
-    );
-
-    const { result, rerender } = renderHook(() => useAdkAppState(), {
-      wrapper,
+  it("keeps app state stable across unrelated store updates", async () => {
+    const deltas = [
+      {
+        "app:visible": 1,
+        "app:__proto__": { source: "provider" },
+      },
+      { unrelated: true },
+      { "app:visible": 2 },
+    ];
+    const stream = vi.fn(async function* () {
+      const call = stream.mock.calls.length - 1;
+      yield {
+        id: `event-${call}`,
+        author: "agent",
+        actions: { stateDelta: deltas[call] },
+        turnComplete: true,
+      } satisfies AdkEvent;
     });
-    const initial = result.current;
-    rerender();
 
-    expect(result.current).toBe(initial);
-    expect(result.current).toEqual({});
+    let runtime: AssistantRuntime | undefined;
+    let appState: Record<string, unknown> | undefined;
+
+    const Probe = () => {
+      appState = useAdkAppState();
+      return null;
+    };
+
+    const App = () => {
+      runtime = useAdkRuntime({
+        stream,
+        create: async () => ({ externalId: "thread-1" }),
+      });
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <Probe />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    render(<App />);
+    const send = (text: string) =>
+      act(async () => {
+        await runtime!.thread.append({
+          role: "user",
+          content: [{ type: "text", text }],
+        });
+      });
+
+    await send("first");
+    await waitFor(() => expect(appState?.visible).toBe(1));
+
+    const initial = appState;
+    expect(Object.hasOwn(initial!, "__proto__")).toBe(true);
+    expect(initial?.["__proto__"]).toEqual({ source: "provider" });
+
+    await send("second");
+    expect(appState).toBe(initial);
+
+    await send("third");
+    await waitFor(() => expect(appState?.visible).toBe(2));
+    expect(appState).not.toBe(initial);
   });
 });

--- a/packages/react-google-adk/src/hooks.test.tsx
+++ b/packages/react-google-adk/src/hooks.test.tsx
@@ -1,0 +1,32 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  stateDelta: {} as Record<string, unknown>,
+}));
+
+vi.mock("./adkExtras", () => ({
+  adkExtras: {
+    use: (
+      selector: (extras: { stateDelta: Record<string, unknown> }) => unknown,
+    ) => selector({ stateDelta: mocks.stateDelta }),
+  },
+}));
+
+import { useAdkAppState } from "./hooks";
+
+describe("ADK state hooks", () => {
+  it("preserves a prototype-named state key", () => {
+    mocks.stateDelta = Object.fromEntries([
+      ["app:__proto__", { source: "provider" }],
+      ["app:visible", true],
+    ]);
+
+    const { result } = renderHook(() => useAdkAppState());
+
+    expect(Object.getPrototypeOf(result.current)).toBe(Object.prototype);
+    expect(Object.hasOwn(result.current, "__proto__")).toBe(true);
+    expect(result.current["__proto__"]).toEqual({ source: "provider" });
+    expect(result.current.visible).toBe(true);
+  });
+});

--- a/packages/react-google-adk/src/hooks.test.tsx
+++ b/packages/react-google-adk/src/hooks.test.tsx
@@ -5,7 +5,8 @@ const mocks = vi.hoisted(() => ({
   stateDelta: {} as Record<string, unknown>,
 }));
 
-vi.mock("./adkExtras", () => ({
+vi.mock("./adkExtras", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./adkExtras")>()),
   adkExtras: {
     use: (
       selector: (extras: { stateDelta: Record<string, unknown> }) => unknown,

--- a/packages/react-google-adk/src/hooks.ts
+++ b/packages/react-google-adk/src/hooks.ts
@@ -119,15 +119,12 @@ const TEMP_PREFIX = "temp:";
 const filterByPrefix = (
   state: Record<string, unknown>,
   prefix: string,
-): Record<string, unknown> => {
-  const result: Record<string, unknown> = {};
-  for (const key of Object.keys(state)) {
-    if (key.startsWith(prefix)) {
-      result[key.slice(prefix.length)] = state[key];
-    }
-  }
-  return result;
-};
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(state)
+      .filter(([key]) => key.startsWith(prefix))
+      .map(([key, value]) => [key.slice(prefix.length), value]),
+  );
 
 /** Returns app-level state (keys prefixed with `app:`, prefix stripped). */
 export const useAdkAppState = () =>

--- a/packages/react-google-adk/src/hooks.ts
+++ b/packages/react-google-adk/src/hooks.ts
@@ -1,5 +1,6 @@
 import { generateId } from "@assistant-ui/core";
 import { useAui } from "@assistant-ui/store";
+import { useShallowSelector } from "@assistant-ui/store/internal";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import { adkExtras } from "./adkExtras";
 import { toAdkConfirmationReply } from "./adkToolApproval";
@@ -10,6 +11,7 @@ import type {
   AdkAuthCredential,
   AdkAuthRequest,
   AdkMessageMetadata,
+  AdkRuntimeExtras,
 } from "./types";
 
 const EMPTY_STATE_DELTA: Record<string, unknown> = {};
@@ -126,23 +128,19 @@ const filterByPrefix = (
       .map(([key, value]) => [key.slice(prefix.length), value]),
   );
 
-/** Returns app-level state (keys prefixed with `app:`, prefix stripped). */
-export const useAdkAppState = () =>
+const useAdkStateByPrefix = (prefix: string) =>
   adkExtras.use(
-    (e) => filterByPrefix(e.stateDelta, APP_PREFIX),
+    useShallowSelector((e: AdkRuntimeExtras) =>
+      filterByPrefix(e.stateDelta, prefix),
+    ),
     EMPTY_STATE_DELTA,
   );
+
+/** Returns app-level state (keys prefixed with `app:`, prefix stripped). */
+export const useAdkAppState = () => useAdkStateByPrefix(APP_PREFIX);
 
 /** Returns user-level state (keys prefixed with `user:`, prefix stripped). */
-export const useAdkUserState = () =>
-  adkExtras.use(
-    (e) => filterByPrefix(e.stateDelta, USER_PREFIX),
-    EMPTY_STATE_DELTA,
-  );
+export const useAdkUserState = () => useAdkStateByPrefix(USER_PREFIX);
 
 /** Returns temp state (keys prefixed with `temp:`, prefix stripped). Not persisted. */
-export const useAdkTempState = () =>
-  adkExtras.use(
-    (e) => filterByPrefix(e.stateDelta, TEMP_PREFIX),
-    EMPTY_STATE_DELTA,
-  );
+export const useAdkTempState = () => useAdkStateByPrefix(TEMP_PREFIX);


### PR DESCRIPTION
## Problem

`@assistant-ui/react-google-adk@0.0.28` drops namespaced state entries whose stripped key is `__proto__`. For example, `app:__proto__` is not returned as an own property by `useAdkAppState()` and its value instead changes the result object's prototype.

The same app/user/temp selectors also return a fresh object for every store snapshot read. Through a real `AssistantRuntimeProvider`, React warns that `getSnapshot` is uncached and reaches `Maximum update depth exceeded`.

## Root cause

The prefix helper assigned provider-controlled keys into an ordinary object. Assignment to the legacy `__proto__` accessor mutates that object's prototype rather than creating an own data property. The derived selector also lacked the shallow stabilization required by `useAuiState`.

## Change

Construct filtered state with `Object.fromEntries()`, which safely defines every stripped key as an own property while preserving the existing plain-object return shape. Route all three namespaced state hooks through one `useShallowSelector`-backed helper so unchanged snapshots retain their identity.

Add focused public-hook coverage for the prototype-named key and a real-provider regression test for snapshot stability.

## Verification

- Confirmed the prototype-key reproduction fails on current `main`: `Object.hasOwn(result, "__proto__")` is false
- Confirmed the real-provider reproduction fails before stabilization with `Maximum update depth exceeded`
- `pnpm --filter @assistant-ui/react-google-adk test` (333 tests)
- `pnpm --filter @assistant-ui/react-google-adk... build`
- `pnpm lint`
- `pnpm changesets:check`

## Public surface

`@assistant-ui/react-google-adk` behavior changes with a patch changeset. No exports or API signatures change.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.mHFUGlHWkIBzdpdn9JmqpcakAYg1oFfevyqfAxvWIIo1FjbvCdPOgJFRixY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->