### PR TITLE
fix(metro): isolate transformer settings between configs

### DIFF
--- a/.changeset/fresh-metro-configs.md
+++ b/.changeset/fresh-metro-configs.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/metro": patch
+---
+
+fix: isolate transformer settings between independently loaded Metro configs

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -75,6 +75,7 @@ export function withAui<T extends MetroConfigLike>(config: T): T {
 
   // A double-wrap is a re-entry: the first call already captured the real
   // upstream, and replacing it with our transformer would cause recursion.
+  // An explicit `aui` on a rewrap still replaces the backendless setting.
   const isRewrap = upstream === self;
 
   if (aui !== undefined || !isRewrap) {

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -73,20 +73,18 @@ export function withAui<T extends MetroConfigLike>(config: T): T {
   const { aui, ...baseConfig } = config;
   const upstream = config.transformer?.babelTransformerPath;
 
-  if (aui?.backendless) {
-    process.env[BACKENDLESS_ENV] = "1";
-  } else if (aui !== undefined || upstream !== self) {
-    delete process.env[BACKENDLESS_ENV];
+  // A double-wrap is a re-entry: the first call already captured the real
+  // upstream, and replacing it with our transformer would cause recursion.
+  const isRewrap = upstream === self;
+
+  if (aui !== undefined || !isRewrap) {
+    if (aui?.backendless) process.env[BACKENDLESS_ENV] = "1";
+    else delete process.env[BACKENDLESS_ENV];
   }
 
-  // Guard against a double-wrap (`withAui(withAui(config))`, or a shared config
-  // already wrapped): if it already points at our transformer, keep the real
-  // upstream captured earlier rather than overwriting it with our own path,
-  // which would make `resolveUpstream()` return this transformer and recurse.
-  if (upstream && upstream !== self) {
-    process.env[UPSTREAM_TRANSFORMER_ENV] = upstream;
-  } else if (upstream !== self) {
-    delete process.env[UPSTREAM_TRANSFORMER_ENV];
+  if (!isRewrap) {
+    if (upstream) process.env[UPSTREAM_TRANSFORMER_ENV] = upstream;
+    else delete process.env[UPSTREAM_TRANSFORMER_ENV];
   }
 
   return {

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -73,7 +73,11 @@ export function withAui<T extends MetroConfigLike>(config: T): T {
   const { aui, ...baseConfig } = config;
   const upstream = config.transformer?.babelTransformerPath;
 
-  if (aui?.backendless) process.env[BACKENDLESS_ENV] = "1";
+  if (aui?.backendless) {
+    process.env[BACKENDLESS_ENV] = "1";
+  } else if (aui !== undefined || upstream !== self) {
+    delete process.env[BACKENDLESS_ENV];
+  }
 
   // Guard against a double-wrap (`withAui(withAui(config))`, or a shared config
   // already wrapped): if it already points at our transformer, keep the real
@@ -81,6 +85,8 @@ export function withAui<T extends MetroConfigLike>(config: T): T {
   // which would make `resolveUpstream()` return this transformer and recurse.
   if (upstream && upstream !== self) {
     process.env[UPSTREAM_TRANSFORMER_ENV] = upstream;
+  } else if (upstream !== self) {
+    delete process.env[UPSTREAM_TRANSFORMER_ENV];
   }
 
   return {

--- a/packages/metro/src/transformer.test.ts
+++ b/packages/metro/src/transformer.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { withAui, UPSTREAM_TRANSFORMER_ENV } from "./index";
+import { BACKENDLESS_ENV, withAui, UPSTREAM_TRANSFORMER_ENV } from "./index";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const mockUpstream = join(here, "__fixtures__/mock-upstream.cjs");
@@ -21,6 +21,16 @@ export default defineToolkit({
 `;
 
 describe("withAui", () => {
+  beforeEach(() => {
+    delete process.env[BACKENDLESS_ENV];
+    delete process.env[UPSTREAM_TRANSFORMER_ENV];
+  });
+
+  afterEach(() => {
+    delete process.env[BACKENDLESS_ENV];
+    delete process.env[UPSTREAM_TRANSFORMER_ENV];
+  });
+
   it("points babelTransformerPath at our transformer, preserving the rest", () => {
     const config = withAui({
       projectRoot: "/app",
@@ -42,6 +52,7 @@ describe("withAui", () => {
 
   it("is idempotent: a double-wrap keeps the real upstream, not the wrapper", () => {
     const once = withAui({
+      aui: { backendless: true },
       transformer: { babelTransformerPath: "/up/stream.js" },
     });
     const self = once.transformer?.babelTransformerPath;
@@ -50,6 +61,19 @@ describe("withAui", () => {
     // still points at our transformer, and the env still names the real upstream
     expect(twice.transformer?.babelTransformerPath).toBe(self);
     expect(process.env[UPSTREAM_TRANSFORMER_ENV]).toBe("/up/stream.js");
+    expect(process.env[BACKENDLESS_ENV]).toBe("1");
+  });
+
+  it("clears settings left by an independently loaded config", () => {
+    withAui({
+      aui: { backendless: true },
+      transformer: { babelTransformerPath: "/workspace-a/transformer.js" },
+    });
+
+    withAui({});
+
+    expect(process.env[BACKENDLESS_ENV]).toBeUndefined();
+    expect(process.env[UPSTREAM_TRANSFORMER_ENV]).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem

Calling `withAui()` for more than one independent Metro config in the same process can carry settings from the first config into the next one.

For example, after loading a config with `backendless: true` and a custom upstream transformer, a later config with neither option still inherits both process environment values. That later app can be compiled with the wrong generative-UI mode or transformer.

Affected package: `@assistant-ui/metro@0.0.12`.

## Root cause

`withAui()` writes its worker configuration through process environment variables, but previously only set those variables. It never cleared values when a subsequent independent config omitted or disabled the corresponding option.

## Change

Replace or clear the worker environment settings for each independent config. Preserve the existing double-wrap behavior so `withAui(withAui(config))` keeps the original upstream transformer and backendless setting.

## Verification

- Confirmed the reproduction leaves both stale values on current main.
- Added a regression test for resetting settings between independent configs.
- Extended the idempotency test to cover the backendless option.
- `pnpm --filter @assistant-ui/metro test`
- `pnpm --filter @assistant-ui/metro... build`
- `pnpm lint`
- `pnpm changesets:check`

## Public surface

- Package: `@assistant-ui/metro`
- API changes: None
- Documentation changes: None
- Includes a patch changeset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.xfcitiUz6e_9oOUbQ73tXaZ0Znp6Vr8h4avHqM47Y3P2bRZfQ60zZF4Sb_Q?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->