### PR TITLE
fix(ai-sdk): preserve prototype-named MCP tools

### DIFF
--- a/.changeset/fresh-mcp-tool-names.md
+++ b/.changeset/fresh-mcp-tool-names.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+fix: preserve MCP tools whose names collide with object prototype properties

--- a/packages/ai-sdk/src/tools/generativeTools.test.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.test.ts
@@ -139,6 +139,30 @@ describe("AISDKToolkit", () => {
     mocks.createMCPClient.mockReset();
   });
 
+  it("preserves prototype-named MCP tools", async () => {
+    const prototypeTool = { inputSchema: {} };
+    mocks.tools.mockResolvedValue(
+      Object.fromEntries([["__proto__", prototypeTool]]),
+    );
+    mocks.createMCPClient.mockResolvedValue({
+      tools: mocks.tools,
+      close: mocks.close,
+    });
+
+    const toolkit = new AISDKToolkit({
+      toolkit: {
+        docs: {
+          type: "mcp",
+          server: { type: "http", url: "http://localhost:3001/mcp" },
+        },
+      },
+    });
+
+    const tools = await toolkit.tools();
+    expect(Object.hasOwn(tools, "__proto__")).toBe(true);
+    expect(tools["__proto__"]).toBe(prototypeTool);
+  });
+
   it("loads MCP tools through pooled clients", async () => {
     mocks.tools.mockResolvedValue({ echo: { inputSchema: {} } });
     mocks.createMCPClient.mockResolvedValue({

--- a/packages/ai-sdk/src/tools/generativeTools.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.ts
@@ -254,7 +254,7 @@ export class AISDKToolkit {
         }),
     );
 
-    const tools: ToolSet = {};
+    const tools = Object.create(null) as ToolSet;
     const toolSources = new Map<string, string>();
     for (const [serverName, mcpTool, toolSet] of toolSets) {
       for (const [toolName, tool] of Object.entries(toolSet)) {


### PR DESCRIPTION
## Problem

An MCP server can expose a tool named `__proto__`, but `AISDKToolkit.tools()` silently omits it from the returned tool set.

A focused reproduction returned `Object.hasOwn(tools, "__proto__") === false`, so the model cannot discover or call that server-provided tool.

Affected package: `@assistant-ui/ai-sdk@0.0.4`.

## Root cause

The MCP aggregator assigned server-provided names into a normal object. In JavaScript, assigning the `__proto__` key invokes the inherited prototype setter instead of creating an enumerable own property. The later object spread therefore had no tool entry to copy.

## Change

Accumulate MCP tools in a prototype-free record. The internal record is still spread into the final result, so the public `ToolSet` remains an ordinary object.

## Verification

- Confirmed the reproduction fails on current main.
- Added a regression test using an own `__proto__` MCP tool entry.
- `pnpm --filter @assistant-ui/ai-sdk test` (25 files, 269 tests)
- `pnpm --filter @assistant-ui/ai-sdk... build`
- `pnpm lint`
- `pnpm changesets:check`

## Public surface

- Package: `@assistant-ui/ai-sdk`
- API changes: None
- Documentation changes: None
- Includes a patch changeset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.QLUC3-Vcb9Frd2Fo4YGpYZJx8E5nrI3cxBVU3QpPNwD6NgxnXxu0MvItr4o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->