### PR TITLE
test(react-native): give the derived-status cases a real timeout

### DIFF
--- a/packages/react-native/src/primitives/message/MessageContent.test.tsx
+++ b/packages/react-native/src/primitives/message/MessageContent.test.tsx
@@ -354,5 +354,6 @@ describe("MessageContent with a runtime", () => {
         await act(async () => root.unmount());
       }
     },
+    30_000,
   );
 });


### PR DESCRIPTION
## Problem

`packages/react-native/src/primitives/message/MessageContent.test.tsx:281` ("renders derived status for registered %s UIs") fails non-deterministically on CI. Four consecutive runs across two heads produced four different outcomes: two assertion failures, then one, then a `Test timed out in 5000ms` plus one assertion failure.

It does not reproduce locally. On this machine the file takes 929ms; on the CI runner it takes 5826ms.

Closes #7007.

## Root cause

The case has no headroom against vitest's default 5000ms per-test budget. Each of the two `it.each` cases calls `vi.resetModules()` and then dynamically re-imports `@assistant-ui/core/react`, re-evaluating the full module graph, before rendering three sequential states through a live `useExternalStoreRuntime`. At 5826ms on a loaded runner it crosses the budget, and the pending React update has not flushed when the assertion runs, so it surfaces either as a timeout or as the last state still reading `running` instead of `complete`.

The work the case does is legitimate, so the budget is what is wrong, not the test.

## Change

Pass an explicit 30s timeout to the `it.each` case. Restructuring the case to re-evaluate the module graph once instead of once per case would also help, but it would trade away the per-case module isolation the current shape deliberately buys, so it is left alone.

## Verification

`pnpm --filter @assistant-ui/react-native test src/primitives/message/MessageContent.test.tsx`: 16 passed, and 10/10 green on repeat runs both before and after, since the failure only reproduces under CI load.

## Public surface

None. Test-only, so no changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.K9Za-dY6JWQ8oEJTZKcUPy7l_9xm9qMyKZm8vVObzXODkKq4Su-0E5gjfmc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->