### PR TITLE
test(react-native): stop the message content runtime tests from timing out on CI

### DIFF
--- a/packages/react-native/src/primitives/message/MessageContent.runtime.test.tsx
+++ b/packages/react-native/src/primitives/message/MessageContent.runtime.test.tsx
@@ -1,0 +1,81 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it } from "vitest";
+import type { MessagePartState, ThreadMessageLike } from "@assistant-ui/core";
+import {
+  AssistantRuntimeProvider,
+  MessageByIndexProvider,
+  useAssistantDataUI,
+  useAssistantToolUI,
+  useExternalStoreRuntime,
+} from "@assistant-ui/core/react";
+import { MessageContent } from "./MessageContent";
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("MessageContent with a runtime", () => {
+  it.each(["tool-call", "data"] as const)(
+    "renders derived status for registered %s UIs",
+    async (type) => {
+      const Status = ({ status }: Pick<MessagePartState, "status">) => (
+        <span>{status.type}</span>
+      );
+      const Registrations = () => {
+        useAssistantToolUI({ toolName: "search", render: Status });
+        useAssistantDataUI({ name: "chart", render: Status });
+        return <MessageContent />;
+      };
+      const App = ({ message }: { message: ThreadMessageLike }) => {
+        const runtime = useExternalStoreRuntime({
+          messages: [message],
+          convertMessage: (value) => value,
+          onNew: async () => {},
+        });
+        return (
+          <AssistantRuntimeProvider runtime={runtime}>
+            <MessageByIndexProvider index={0}>
+              <Registrations />
+            </MessageByIndexProvider>
+          </AssistantRuntimeProvider>
+        );
+      };
+      const container = document.createElement("div");
+      const root = createRoot(container);
+      try {
+        for (const status of [
+          "running",
+          "requires-action",
+          "complete",
+        ] as const) {
+          if (type === "data" && status === "requires-action") continue;
+          const message: ThreadMessageLike = {
+            id: "m1",
+            role: "assistant",
+            status:
+              status === "running"
+                ? { type: status }
+                : status === "complete"
+                  ? { type: status, reason: "stop" }
+                  : { type: status, reason: "tool-calls" },
+            content: [
+              type === "data"
+                ? { type, name: "chart", data: { value: 1 } }
+                : {
+                    type,
+                    toolName: "search",
+                    toolCallId: "c1",
+                    args: {},
+                    argsText: "{}",
+                    ...(status === "complete" ? { result: "done" } : {}),
+                  },
+            ],
+          };
+          await act(async () => root.render(<App message={message} />));
+          expect(container.textContent).toBe(status);
+        }
+      } finally {
+        await act(async () => root.unmount());
+      }
+    },
+  );
+});

--- a/packages/react-native/src/primitives/message/MessageContent.test.tsx
+++ b/packages/react-native/src/primitives/message/MessageContent.test.tsx
@@ -1,7 +1,6 @@
 import { act, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { MessagePartState, ThreadMessageLike } from "@assistant-ui/core";
 import { MessageContent } from "./MessageContent";
 
 type AnyPart = { type: string; [key: string]: unknown };
@@ -275,84 +274,4 @@ describe("MessageContent", () => {
 
     expect(container.textContent).toBe("A[tool][data]");
   });
-});
-
-describe("MessageContent with a runtime", () => {
-  it.each(["tool-call", "data"] as const)(
-    "renders derived status for registered %s UIs",
-    async (type) => {
-      vi.doUnmock("@assistant-ui/store");
-      vi.resetModules();
-      // Static imports retain the store mock used by the dispatch tests.
-      const { MessageContent: RuntimeContent } =
-        await import("./MessageContent");
-      const {
-        AssistantRuntimeProvider,
-        MessageByIndexProvider,
-        useExternalStoreRuntime,
-        useAssistantToolUI,
-        useAssistantDataUI,
-      } = await import("@assistant-ui/core/react");
-
-      const Status = ({ status }: Pick<MessagePartState, "status">) => (
-        <span>{status.type}</span>
-      );
-      const Registrations = () => {
-        useAssistantToolUI({ toolName: "search", render: Status });
-        useAssistantDataUI({ name: "chart", render: Status });
-        return <RuntimeContent />;
-      };
-      const App = ({ message }: { message: ThreadMessageLike }) => {
-        const runtime = useExternalStoreRuntime({
-          messages: [message],
-          convertMessage: (value) => value,
-          onNew: async () => {},
-        });
-        return (
-          <AssistantRuntimeProvider runtime={runtime}>
-            <MessageByIndexProvider index={0}>
-              <Registrations />
-            </MessageByIndexProvider>
-          </AssistantRuntimeProvider>
-        );
-      };
-      const container = document.createElement("div");
-      const root = createRoot(container);
-      try {
-        for (const status of [
-          "running",
-          "requires-action",
-          "complete",
-        ] as const) {
-          if (type === "data" && status === "requires-action") continue;
-          const message: ThreadMessageLike = {
-            id: "m1",
-            role: "assistant",
-            status:
-              status === "running"
-                ? { type: status }
-                : status === "complete"
-                  ? { type: status, reason: "stop" }
-                  : { type: status, reason: "tool-calls" },
-            content: [
-              type === "data"
-                ? { type, name: "chart", data: { value: 1 } }
-                : {
-                    type,
-                    toolName: "search",
-                    toolCallId: "c1",
-                    args: {},
-                    argsText: "{}",
-                    ...(status === "complete" ? { result: "done" } : {}),
-                  },
-            ],
-          };
-          await act(async () => root.render(<App message={message} />));
-          expect(container.textContent).toBe(status);
-        }
-      } finally {
-        await act(async () => root.unmount());
-      }
-    },
-  );
 });


### PR DESCRIPTION
## Problem

`MessageContent with a runtime > renders derived status for registered %s UIs` has failed on CI in every run since #6986 landed, on PRs that touch nothing near it: [#7002](https://github.com/assistant-ui/assistant-ui/actions/runs/34182762883/job/101926785037) and [#6980](https://github.com/assistant-ui/assistant-ui/actions/runs/34183051897/job/101925845516) hit the identical pair. the tool-call case dies with `Error: Test timed out in 5000ms.`, the data case with `AssertionError: expected 'running' to be 'complete'`. it passes locally, which is why it got through review.

## Root cause

both cases live in `MessageContent.test.tsx`, which mocks `@assistant-ui/store` for the dispatch tests. to reach a real runtime they undo that mock per test with `vi.doUnmock("@assistant-ui/store")` plus `vi.resetModules()`, then `await import("@assistant-ui/core/react")` inside the test body. that re-evaluates the whole core react module graph under the 5000ms test timeout: measured at 568ms on an idle mac and 719 to 725ms in a `node:24` container at `--cpus=2`. a GitHub runner executing turbo's package suites in parallel is slow enough to cross it.

the second failure follows from the first. when the tool-call case times out it never reaches its `finally` unmount, so the leaked act queue leaves the sibling data case reading the pre-update DOM.

## Change

the runtime cases never needed the store mock, so they move to `MessageContent.runtime.test.tsx` with plain static imports and no module-registry work. the assertions are unchanged. `MessageContent.test.tsx` keeps the mocked dispatch tests and drops the type import only the moved block used.

`packages/react/src/tests/` already splits variants of one module this way (`MessageParts.loading.test.tsx`, `MessageParts.rendererOptions.test.tsx`).

## Verification

| | tool-call case | data case |
|---|---|---|
| before, macOS | 568ms | fast |
| before, `node:24 --cpus=2` | 719 to 725ms, 3 runs | fast |
| before, GitHub runner | timeout at 5000ms | stale read |
| after, macOS | 18ms | 3ms |
| after, `node:24 --cpus=2` | 21 to 22ms, 2 runs | 4 to 5ms |

- `pnpm --filter @assistant-ui/react-native test`: 34 files, 258 tests passed.
- the same suite in the linux container: both cases pass, 2 runs.
- scoped oxlint and oxfmt pass.

## Public surface

none. test files only, so no changeset: nothing in the published package changes.

Fixes #7006
Fixes #7007

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.p64kP-N7tSSlLWsy5N8eCE9oK8xasVI-mGaFEKRninn3QQQnUNhzDx9hzTk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->