### PR TITLE
fix(docs): keep the anatomy chip clear of the scroll to bottom glyph

### DIFF
--- a/apps/docs/components/pages/home/primitives-anatomy.tsx
+++ b/apps/docs/components/pages/home/primitives-anatomy.tsx
@@ -56,9 +56,20 @@ const LINES: { text: string; part: PartId; indent: number }[] = [
   { text: "</ThreadPrimitive.Root>", part: "root", indent: 0 },
 ];
 
-function PartChip({ label }: { label: string }) {
+function PartChip({
+  label,
+  className,
+}: {
+  label: string;
+  className?: string | undefined;
+}) {
   return (
-    <span className="absolute -top-2.5 right-2 z-10 bg-blue-500 px-1.5 py-px font-mono text-[10px] font-medium tracking-wide text-white uppercase">
+    <span
+      className={cn(
+        "absolute -top-2.5 right-2 z-10 bg-blue-500 px-1.5 py-px font-mono text-[10px] font-medium tracking-wide text-white uppercase",
+        className,
+      )}
+    >
       {label}
     </span>
   );
@@ -68,11 +79,13 @@ function Region({
   part,
   active,
   className,
+  chipClassName,
   children,
 }: {
   part: PartId;
   active: PartId;
   className?: string;
+  chipClassName?: string | undefined;
   children?: React.ReactNode;
 }) {
   const current = active === part;
@@ -85,7 +98,7 @@ function Region({
         className,
       )}
     >
-      {current ? <PartChip label={label} /> : null}
+      {current ? <PartChip label={label} className={chipClassName} /> : null}
       {children}
     </div>
   );
@@ -189,6 +202,7 @@ export function PrimitivesAnatomy() {
               part="scroll"
               active={active}
               className="border-foreground/20 bg-background rounded-capsule mt-auto ml-auto grid size-6 place-items-center border"
+              chipClassName="top-1/2 right-full mr-1.5 -translate-y-1/2 whitespace-nowrap"
             >
               <ArrowDownIcon className="text-foreground/60 size-3" />
             </Region>


### PR DESCRIPTION
## problem

on the homepage "the primitives" section, when the anatomy diagram highlights `<ThreadPrimitive.ScrollToBottom />`, the blue `SCROLL TO BOTTOM` chip lands on top of the 24px glyph it is labeling. reported in #6934 with a screenshot: the chip wraps to three lines and covers the arrow, leaving only a sliver of the ring visible, so the part being pointed at is unreadable.

## root cause

`PartChip` anchors at `absolute -top-2.5 right-2`, which assumes the region is wider than the label. that holds for root, viewport, messages and composer, but the scroll region is `size-6`. an absolutely positioned box with only `right` set resolves `width: auto` by shrink-to-fit: available is 22 - 8 = 14px and min-content is the longest word (`BOTTOM`), so the chip settles at 49.5px and wraps to three lines.

measured at 1400px before the fix: chip 49.5x47 at x 1208 to 1258, region 24x24 at x 1243 to 1267, arrow 12x12 at x 1249 to 1261. the chip covers 9 of the arrow's 12px and the region's full height, and overhangs onto the composer border below.

## change

`PartChip` takes a `className` merged through `cn`, `Region` forwards it as `chipClassName`, and the scroll region overrides the anchor to `top-1/2 right-full mr-1.5 -translate-y-1/2 whitespace-nowrap`, moving the label outside the glyph and centering it on the same axis. `cn`'s last-wins resolution drops the base `-top-2.5` and `right-2`, so the other four chips keep the corner anchor unchanged.

`whitespace-nowrap` on its own is not enough: a single-line 112px chip still lands on the upper half of the circle at `right-2 -top-2.5`. the anchor has to move.

## verification

docs dev server, real code after reload, chip and glyph rects read from the DOM:

- 1400px light: chip 112x17 at x 1126 to 1238, region at 1243 to 1267. rect intersection against both the region and the arrow is false.
- 1400px dark: same geometry, matching the state in the issue screenshot.
- 375px mobile viewport: chip at x 177 to 289, root region starts at x 40, so 137px of slack. no clipping.
- root, viewport, messages and composer states screenshotted at 1400px: chips unchanged at their top-right corners.
- `oxfmt` and `oxlint` on the changed file: clean. `tsc --noEmit -p apps/docs/tsconfig.json`: 0 errors.

## public surface

none. `apps/docs` is private, so no changeset. `PartChip` and `Region` are module-local to `primitives-anatomy.tsx`.

fixes #6934

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.SWhk0TqxjIGLeazhH5OkaNGKOIKi8iANepzWQ31xDctJItuyKm0asr3D19M?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->