### PR TITLE
fix(core): keep the server on the title that wins the ordering race

### DIFF
--- a/.changeset/title-generation-server-ordering.md
+++ b/.changeset/title-generation-server-ordering.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep the server on the title that wins the ordering race
+
+an automatic title generation persists its title server-side through its own run, so an explicit generation that superseded it locally could still be overwritten once the older run finished. the losing run now waits for the winner to persist its title and writes that title back, and a rename that outranks the winning generation is reasserted the same way.

--- a/packages/core/src/runtimes/remote-thread-list/title-generation.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/title-generation.test.ts
@@ -378,6 +378,58 @@ describe("runThreadTitleGeneration", () => {
     expect(server).toBe("Manual");
   });
 
+  it("keeps a rename that lands while the superseded run reasserts", async () => {
+    const states = new Map<string, ThreadTitleState>();
+    const streamOpen = deferred<void>();
+    const renameOpen = deferred<void>();
+    let server: string | undefined;
+    let blocked = false;
+    const rename = async (next: string) => {
+      if (!blocked) {
+        blocked = true;
+        await renameOpen.promise;
+      }
+      server = next;
+    };
+
+    const automatic = runThreadTitleGeneration({
+      states,
+      threadId: "t1",
+      automatic: true,
+      generate: async (onTitle) => {
+        await streamOpen.promise;
+        await onTitle("Automatic");
+        server = "Automatic";
+      },
+      rename,
+      applyTitle: noop,
+    });
+
+    await runThreadTitleGeneration({
+      states,
+      threadId: "t1",
+      automatic: false,
+      generate: async (onTitle) => {
+        await onTitle("Explicit");
+        server = "Explicit";
+      },
+      rename,
+      applyTitle: noop,
+    });
+
+    streamOpen.resolve();
+    await flushMicrotasks();
+
+    const claim = startThreadTitleRename(states, "t1", "Manual");
+    server = "Manual";
+    finishThreadTitleRename(states, "t1", claim, true);
+
+    renameOpen.resolve();
+    await automatic;
+
+    expect(server).toBe("Manual");
+  });
+
   it("does not reassert when the superseded run persisted nothing", async () => {
     const states = new Map<string, ThreadTitleState>();
     const streamOpen = deferred<void>();

--- a/packages/core/src/runtimes/remote-thread-list/title-generation.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/title-generation.test.ts
@@ -277,7 +277,7 @@ describe("runThreadTitleGeneration", () => {
     expect(server).toBe("Explicit");
   });
 
-  it("reasserts the explicit title when the superseded run persists first", async () => {
+  it("leaves the explicit title alone when the superseded run persists first", async () => {
     const states = new Map<string, ThreadTitleState>();
     const automaticStream = deferred<void>();
     const explicitStream = deferred<void>();
@@ -428,6 +428,39 @@ describe("runThreadTitleGeneration", () => {
     await automatic;
 
     expect(server).toBe("Manual");
+  });
+
+  it("skips a claim a newer explicit generation has outranked", async () => {
+    const states = new Map<string, ThreadTitleState>();
+    const streamOpen = deferred<void>();
+    const renamed: string[] = [];
+    const runOf = (automatic: boolean, title: string, open?: Promise<void>) =>
+      runThreadTitleGeneration({
+        states,
+        threadId: "t1",
+        automatic,
+        generate: async (onTitle) => {
+          if (open) await open;
+          await onTitle(title);
+        },
+        rename: async (next) => {
+          renamed.push(next);
+        },
+        applyTitle: noop,
+      });
+
+    const automatic = runOf(true, "Automatic", streamOpen.promise);
+    await runOf(false, "Explicit");
+
+    const claim = startThreadTitleRename(states, "t1", "Manual");
+    finishThreadTitleRename(states, "t1", claim, true);
+
+    await runOf(false, "Newer");
+
+    streamOpen.resolve();
+    await automatic;
+
+    expect(renamed).toEqual(["Newer"]);
   });
 
   it("does not reassert when the superseded run persisted nothing", async () => {

--- a/packages/core/src/runtimes/remote-thread-list/title-generation.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/title-generation.test.ts
@@ -17,6 +17,10 @@ const deferred = <T>() => {
 
 const noop = async () => {};
 
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 10; i += 1) await Promise.resolve();
+};
+
 describe("runThreadTitleGeneration", () => {
   it("reasserts a rename that lands while the generated stream is open", async () => {
     const states = new Map<string, ThreadTitleState>();
@@ -241,6 +245,171 @@ describe("runThreadTitleGeneration", () => {
     await automatic;
 
     expect(applied).toEqual(["Explicit"]);
+  });
+
+  it("reasserts the explicit title when the superseded run persists last", async () => {
+    const states = new Map<string, ThreadTitleState>();
+    const streamOpen = deferred<void>();
+    let server: string | undefined;
+    const runOf = (automatic: boolean, title: string, open?: Promise<void>) =>
+      runThreadTitleGeneration({
+        states,
+        threadId: "t1",
+        automatic,
+        generate: async (onTitle) => {
+          if (open) await open;
+          await onTitle(title);
+          server = title;
+        },
+        rename: async (next) => {
+          server = next;
+        },
+        applyTitle: noop,
+      });
+
+    const automatic = runOf(true, "Automatic", streamOpen.promise);
+    await runOf(false, "Explicit");
+    expect(server).toBe("Explicit");
+
+    streamOpen.resolve();
+    await automatic;
+
+    expect(server).toBe("Explicit");
+  });
+
+  it("reasserts the explicit title when the superseded run persists first", async () => {
+    const states = new Map<string, ThreadTitleState>();
+    const automaticStream = deferred<void>();
+    const explicitStream = deferred<void>();
+    let server: string | undefined;
+    const runOf = (automatic: boolean, title: string, open: Promise<void>) =>
+      runThreadTitleGeneration({
+        states,
+        threadId: "t1",
+        automatic,
+        generate: async (onTitle) => {
+          await open;
+          await onTitle(title);
+          server = title;
+        },
+        rename: async (next) => {
+          server = next;
+        },
+        applyTitle: noop,
+      });
+
+    const automatic = runOf(true, "Automatic", automaticStream.promise);
+    const explicit = runOf(false, "Explicit", explicitStream.promise);
+
+    automaticStream.resolve();
+    explicitStream.resolve();
+    await Promise.all([automatic, explicit]);
+
+    expect(server).toBe("Explicit");
+  });
+
+  it("keeps a rename that lands after the superseding explicit generation", async () => {
+    const states = new Map<string, ThreadTitleState>();
+    const streamOpen = deferred<void>();
+    let server: string | undefined;
+    const runOf = (automatic: boolean, title: string, open?: Promise<void>) =>
+      runThreadTitleGeneration({
+        states,
+        threadId: "t1",
+        automatic,
+        generate: async (onTitle) => {
+          if (open) await open;
+          await onTitle(title);
+          server = title;
+        },
+        rename: async (next) => {
+          server = next;
+        },
+        applyTitle: noop,
+      });
+
+    const automatic = runOf(true, "Automatic", streamOpen.promise);
+    await runOf(false, "Explicit");
+
+    const claim = startThreadTitleRename(states, "t1", "Manual");
+    server = "Manual";
+    finishThreadTitleRename(states, "t1", claim, true);
+
+    streamOpen.resolve();
+    await automatic;
+
+    expect(server).toBe("Manual");
+  });
+
+  it("keeps a rename that lands while the superseded run waits to reassert", async () => {
+    const states = new Map<string, ThreadTitleState>();
+    const automaticStream = deferred<void>();
+    const explicitStream = deferred<void>();
+    let server: string | undefined;
+    const runOf = (automatic: boolean, title: string, open: Promise<void>) =>
+      runThreadTitleGeneration({
+        states,
+        threadId: "t1",
+        automatic,
+        generate: async (onTitle) => {
+          await open;
+          await onTitle(title);
+          server = title;
+        },
+        rename: async (next) => {
+          server = next;
+        },
+        applyTitle: noop,
+      });
+
+    const automatic = runOf(true, "Automatic", automaticStream.promise);
+    const explicit = runOf(false, "Explicit", explicitStream.promise);
+
+    automaticStream.resolve();
+    await flushMicrotasks();
+
+    const claim = startThreadTitleRename(states, "t1", "Manual");
+    server = "Manual";
+    finishThreadTitleRename(states, "t1", claim, true);
+
+    explicitStream.resolve();
+    await Promise.all([automatic, explicit]);
+
+    expect(server).toBe("Manual");
+  });
+
+  it("does not reassert when the superseded run persisted nothing", async () => {
+    const states = new Map<string, ThreadTitleState>();
+    const streamOpen = deferred<void>();
+    const rename = vi.fn(noop);
+
+    const automatic = runThreadTitleGeneration({
+      states,
+      threadId: "t1",
+      automatic: true,
+      generate: async (onTitle) => {
+        await streamOpen.promise;
+        await onTitle(undefined);
+      },
+      rename,
+      applyTitle: noop,
+    });
+
+    await runThreadTitleGeneration({
+      states,
+      threadId: "t1",
+      automatic: false,
+      generate: async (onTitle) => {
+        await onTitle("Explicit");
+      },
+      rename,
+      applyTitle: noop,
+    });
+
+    streamOpen.resolve();
+    await automatic;
+
+    expect(rename).not.toHaveBeenCalled();
   });
 
   it("drops per-thread state once nothing is in flight", async () => {

--- a/packages/core/src/runtimes/remote-thread-list/title-generation.ts
+++ b/packages/core/src/runtimes/remote-thread-list/title-generation.ts
@@ -11,13 +11,15 @@ type ThreadTitleGeneration = {
   claim: ThreadTitleClaim | null;
   beforeGenerationClaim: ThreadTitleClaim | null;
   superseded: boolean;
+  readonly persisted: Promise<string | undefined>;
+  readonly settlePersisted: (title: string | undefined) => void;
 };
 
 export type ThreadTitleState = {
   generations: Set<ThreadTitleGeneration>;
   pendingClaim: ThreadTitleClaim | null;
   manualTitle: string | undefined;
-  latestExplicitOrder: number;
+  latestExplicit: ThreadTitleGeneration | null;
   nextOrder: number;
 };
 
@@ -42,7 +44,7 @@ function getThreadTitleState(
       generations: new Set(),
       pendingClaim: null,
       manualTitle: undefined,
-      latestExplicitOrder: 0,
+      latestExplicit: null,
       nextOrder: 0,
     };
     states.set(threadId, state);
@@ -70,8 +72,16 @@ function isCurrentGeneration(
   generation: ThreadTitleGeneration,
 ): boolean {
   return (
-    !generation.superseded && state.latestExplicitOrder <= generation.order
+    !generation.superseded &&
+    (state.latestExplicit?.order ?? 0) <= generation.order
   );
+}
+
+function isCurrentClaim(
+  state: ThreadTitleState,
+  claim: ThreadTitleClaim,
+): boolean {
+  return (state.latestExplicit?.order ?? 0) < claim.order;
 }
 
 export function startThreadTitleRename(
@@ -148,17 +158,23 @@ function startThreadTitleGeneration(
     return null;
   }
 
+  let settlePersisted!: (title: string | undefined) => void;
+  const persisted = new Promise<string | undefined>((resolve) => {
+    settlePersisted = resolve;
+  });
   const generation: ThreadTitleGeneration = {
     automatic,
     order: ++state.nextOrder,
     claim: automatic ? state.pendingClaim : null,
     beforeGenerationClaim: automatic ? null : state.pendingClaim,
     superseded: false,
+    persisted,
+    settlePersisted,
   };
   if (!automatic) {
     state.pendingClaim = null;
     state.manualTitle = undefined;
-    state.latestExplicitOrder = generation.order;
+    state.latestExplicit = generation;
     for (const active of state.generations) {
       if (active.automatic) active.superseded = true;
     }
@@ -168,13 +184,14 @@ function startThreadTitleGeneration(
 }
 
 /**
- * Runs one title generation under the per-thread rename claims, so a rename
- * that lands while the generation is in flight stays the persisted title.
+ * Runs one title generation under the per-thread rename claims and generation
+ * ordering, so the title that wins locally is also the title left on the
+ * server.
  *
  * A generated run persists the title itself, and the adapter exposes no
- * compare-and-set, so a winning claim is reasserted through `rename` only after
- * `generate` has resolved. Reasserting mid-stream would race the run's own
- * write and lose the manual title on the server.
+ * compare-and-set, so the run that loses reasserts the winner through `rename`
+ * only after `generate` has resolved. Reasserting mid-stream would race the
+ * run's own write and lose the winning title on the server.
  */
 export async function runThreadTitleGeneration({
   states,
@@ -187,6 +204,9 @@ export async function runThreadTitleGeneration({
   const state = getThreadTitleState(states, threadId);
   const generation = startThreadTitleGeneration(states, threadId, automatic);
   if (generation === null) return;
+
+  let persistedTitle: string | undefined;
+  let persistedOrder = generation.order;
 
   const settleClaim = async (claim: ThreadTitleClaim) => {
     const renamed = await claim.settled;
@@ -201,7 +221,25 @@ export async function runThreadTitleGeneration({
   const retainManualTitle = () =>
     automatic && takeManualTitle(states, threadId, state) !== undefined;
 
-  try {
+  // `generate` resolves only once the run has persisted its title, so a run
+  // that lost the ordering race while it streamed has already overwritten the
+  // winner. It waits for the winning generation to persist its own title and
+  // writes that title back.
+  const repairLostRace = async () => {
+    if (persistedTitle === undefined) return;
+    while (true) {
+      const winner = state.latestExplicit;
+      if (winner === null || winner.order <= persistedOrder) return;
+      const title = await winner.persisted;
+      if (state.latestExplicit !== winner) continue;
+      persistedOrder = winner.order;
+      if (title === undefined || title === persistedTitle) return;
+      persistedTitle = title;
+      await rename(title);
+    }
+  };
+
+  const runGeneration = async () => {
     if (generation.beforeGenerationClaim !== null) {
       await generation.beforeGenerationClaim.settled;
     }
@@ -220,6 +258,7 @@ export async function runThreadTitleGeneration({
     await generate(async (title) => {
       sawTitle = true;
       lastTitle = title;
+      if (title !== undefined) persistedTitle = title;
       const claim = generation.claim;
       if (claim !== null) {
         const renamed = await settleClaim(claim);
@@ -244,15 +283,23 @@ export async function runThreadTitleGeneration({
         }
         return;
       }
-      if (!isCurrentGeneration(state, generation)) return;
+      if (!isCurrentClaim(state, claim)) return;
       await rename(claim.title);
+      persistedTitle = claim.title;
+      persistedOrder = claim.order;
       if (generation.claim !== claim) continue;
       if (!isCurrentGeneration(state, generation)) return;
       await applyTitle(claim.title);
       generation.superseded = true;
       return;
     }
+  };
+
+  try {
+    await runGeneration();
+    await repairLostRace();
   } finally {
+    generation.settlePersisted(persistedTitle);
     state.generations.delete(generation);
     pruneThreadTitleState(states, threadId, state);
   }

--- a/packages/core/src/runtimes/remote-thread-list/title-generation.ts
+++ b/packages/core/src/runtimes/remote-thread-list/title-generation.ts
@@ -228,6 +228,16 @@ export async function runThreadTitleGeneration({
   const repairLostRace = async () => {
     if (persistedTitle === undefined) return;
     while (true) {
+      const claim = generation.claim;
+      if (claim !== null && claim.order > persistedOrder) {
+        const renamed = await settleClaim(claim);
+        if (renamed === true) {
+          persistedTitle = claim.title;
+          persistedOrder = claim.order;
+          await rename(claim.title);
+        }
+        continue;
+      }
       const winner = state.latestExplicit;
       if (winner === null || winner.order <= persistedOrder) return;
       const title = await winner.persisted;

--- a/packages/core/src/runtimes/remote-thread-list/title-generation.ts
+++ b/packages/core/src/runtimes/remote-thread-list/title-generation.ts
@@ -229,7 +229,11 @@ export async function runThreadTitleGeneration({
     if (persistedTitle === undefined) return;
     while (true) {
       const claim = generation.claim;
-      if (claim !== null && claim.order > persistedOrder) {
+      if (
+        claim !== null &&
+        claim.order > persistedOrder &&
+        isCurrentClaim(state, claim)
+      ) {
         const renamed = await settleClaim(claim);
         if (renamed === true) {
           persistedTitle = claim.title;

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -56,6 +56,14 @@ export type RemoteThreadListAdapter = {
   unarchive(remoteId: string): Promise<void>;
   delete(remoteId: string): Promise<void>;
   initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
+  /**
+   * Generates a title for the thread and streams it back.
+   *
+   * When the generation persists the title itself, the returned stream must
+   * not complete before that write has landed. Concurrent generations are
+   * ordered by stream completion, and a run whose write outlives its stream
+   * can overwrite a newer title.
+   */
   generateTitle(
     remoteId: string,
     unstable_messages: readonly ThreadMessage[],


### PR DESCRIPTION
closes #6831

## Problem

superseding an automatic title generation only gated the local write. an explicit `generateTitle()` marks an in-flight automatic generation superseded, and `isCurrentGeneration` suppresses that run's `applyTitle`, but the run itself keeps going and its server side persists the title on its own. an automatic run that completes after an explicit generation left the server on the automatic title while the list showed the explicit one, and the divergence surfaced on the next reload.

minimal reproduction, modeling the server as a write that lands when the run stream closes:

```ts
const automatic = run({ automatic: true, title: "Automatic", open: deferred });
await run({ automatic: false, title: "Explicit" }); // server = "Explicit"
deferred.resolve();
await automatic;                                    // server = "Automatic"
```

affects `@assistant-ui/core` on the current release, and through it `@assistant-ui/react` and `@assistant-ui/react-native`.

## Root cause

two writers race on one field with no fence. `createCloudThreadListAdapter.generateTitle` starts a `cloud.runs.stream({ assistant_id: "system/thread_title" })` whose server side persists the title unconditionally, and `RemoteThreadListAdapter` exposes neither a cancel nor a compare-and-set, so whichever run finishes last owns the server value. `title-generation.ts` tracked ordering only as `latestExplicitOrder`, a number, which is enough to decide who may write locally but leaves the loser no handle on the winner to repair with.

the ordering signal needed for a repair already exists. `createAssistantStream` closes its stream only after the callback promise resolves (`packages/assistant-stream/src/core/modules/assistant-stream.ts`, `runTask` closes the controller in its `finally` after awaiting the callback), and the cloud title run awaits its own title write inside that callback, so `generate` resolving means that run's server write has landed. `RemoteThreadListAdapter.generateTitle` now states that requirement.

the cloud side of that claim lives in assistant-cloud (private), `apps/api/src/endpoints/runs/thread-title.ts`: `createThreadTitleRun` returns `createAssistantStream((controller) => { const run = runThreadTitle(...); waitUntil(c, run); return run; })`, and `runThreadTitle` does `controller.appendText(title)` and then `await updateThreadDb(c.var, thread_id, { title })` before returning, so the row is committed before the stream closes. `waitUntil` there keeps the worker alive past the response and does not detach the write from the stream's lifetime. `apps/api/src/endpoints/runs/stream.ts` routes `assistant_id: "system/thread_title"` to that function.

## Change

the run that loses the ordering race repairs the server, which is the reassert this file already performs for a winning rename claim (`await rename(claim.title)` only after `generate` resolves, never mid-stream).

`ThreadTitleState.latestExplicitOrder` becomes `latestExplicit`, holding the generation itself, and every generation carries a `persisted` promise settled in `finally` with the title it left on the server. after `runGeneration` returns, a generation that wrote a title and is outranked by a newer explicit generation waits for that winner to persist, then writes the winner's title back through `rename`. the wait terminates because a generation only ever awaits a strictly higher order.

the rename reassert switches its gate from `isCurrentGeneration(generation)` to `isCurrentClaim(claim)`. the server write asks whether the claim is still the newest authority, not whether this generation is current; without the switch a rename that outranks the winning generation is skipped and then overwritten by the repair.

the repair is a no-op unless a newer explicit generation exists, so a generation that wins takes the same path it did before. when the loser persisted first the repair reasserts a title the winner had already written; the extra write is idempotent and keeping it removes the need to track per-write completion order.

not addressed here: fencing the write server-side in assistant-cloud is defense in depth for the same race and belongs in that repo, and `@assistant-ui/cloud-ai-sdk` has no automatic-versus-explicit ordering at all, tracked as #7026. the issue lists cloud-ai-sdk under affected, so `closes #6831` covers the core half that this diff ships and #7026 carries the rest.

## Verification

from `packages/core`, `vitest run src/runtimes/remote-thread-list/title-generation.test.ts`: 16 passed, 7 of them new.

against the pre-fix `title-generation.ts` with the new tests in place, the three that demonstrate the bug fail and the rest pass:

```
× reasserts the explicit title when the superseded run persists last
× keeps a rename that lands after the superseding explicit generation
× skips a claim a newer explicit generation has outranked
Tests  3 failed | 13 passed (16)
```

each of the two review fixes is isolated the same way. removing only the repair loop's claim branch fails `keeps a rename that lands while the superseded run reasserts` (1 failed | 15 passed), and removing only its `isCurrentClaim` gate fails `skips a claim a newer explicit generation has outranked` (1 failed | 15 passed).

the remaining new tests (`leaves the explicit title alone when the superseded run persists first`, a rename landing during the repair wait, and a superseded run that persisted nothing) pass before and after; they guard adjacent interactions rather than demonstrate the bug.

`oxlint` over `src/runtimes/remote-thread-list/` and `oxfmt` over the changed files: clean. `tsc --strict --exactOptionalPropertyTypes --noUncheckedIndexedAccess` over `title-generation.ts`: clean.

not run: the full `packages/core` suite and `test:types`, which need a built workspace this branch did not install. the changed module imports nothing and no exported signature moved; `ThreadTitleState` is internal and both hosts use it only as an opaque map value.

## Public surface

`@assistant-ui/core`, patch. no export added, removed, or re-typed. `RemoteThreadListAdapter.generateTitle` gains JSDoc stating that a generation which persists its own title must not complete its stream before that write lands. no api-reference, docs, or template changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.WSBH0UwqcjY264D49z9Aor-unTyUdAp1X5w7-Ol1Dvgwu_60y6tofnq7bjw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->


