### PR TITLE
fix: cancel a thread's in-flight request when its runtime is torn down

### DIFF
--- a/.changeset/per-thread-destroy-signal.md
+++ b/.changeset/per-thread-destroy-signal.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/ai-sdk": patch
+"@assistant-ui/core": patch
+"@assistant-ui/store": patch
+---
+
+fix(core): cancel a thread's in-flight request when its runtime is torn down
+
+each thread the remote thread list hosts now owns a destroy signal that aborts when its runtime is stopped or restarted, and `useChatRuntime` stops the chat on it. deleting or detaching a thread, replacing the thread list with one that drops it, or restarting its runtime now cancels the request that thread had in flight instead of leaving it streaming into a runtime nothing reads. hiding a thread under `<Activity mode="hidden">` is a soft unmount and keeps streaming.

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -251,7 +251,7 @@ declare const auiConfigBrand: unique symbol;
 declare const clientIdBrand: unique symbol;
 
 declare namespace entry_client_exports {
-  export { AssistantClient, AssistantClientAccessor, AssistantClientHandle, AssistantClientSource, AssistantConfigSource, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventSelector, AssistantState, AuiConfig, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, DefaultAssistantClient, Derived, DerivedElement, InferClientState, ScopeRegistry, ScopesConfig, Unsubscribe, ViewportMetrics, attachTransformScopes, createAssistantClient, createClientFacade, createLastValidCache, createStaleReporter, getProxiedAssistantState, isUserScrollUp, isViewportAtBottom, normalizeEventSelector, observeContentResize, shallowEqual, useAssistantClientRef, useAssistantContextProvider, useAssistantContextValue, useAssistantEmit, useAssistantScopeEffect, useClientLookup, useClientResource, useConfiguredAui, viewportOverflows };
+  export { AssistantClient, AssistantClientAccessor, AssistantClientHandle, AssistantClientSource, AssistantConfigSource, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventSelector, AssistantState, AuiConfig, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, DefaultAssistantClient, Derived, DerivedElement, InferClientState, ScopeRegistry, ScopesConfig, Unsubscribe, ViewportMetrics, attachTransformScopes, createAssistantClient, createClientFacade, createLastValidCache, createStaleReporter, getProxiedAssistantState, isUserScrollUp, isViewportAtBottom, normalizeEventSelector, observeContentResize, shallowEqual, useAssistantClientRef, useAssistantContextProvider, useAssistantContextValue, useAssistantEmit, useAssistantScopeEffect, useClientLookup, useClientResource, useConfiguredAui, useDestroySignalProvider, viewportOverflows };
 }
 
 declare const createAssistantClient: (config: AuiConfig.Input | AssistantConfigSource, options?: {
@@ -375,6 +375,8 @@ declare const useClientResource: <TMethods extends ClientMethods>(element: Resou
 };
 
 declare const useConfiguredAui: (parent: AssistantClient, clients: AuiConfig.Input) => ScopedAuiClient;
+
+declare const useDestroySignalProvider: <TResult>(destroySignal: AbortSignal | undefined, fn: () => TResult) => TResult;
 
 declare const useShallowSelector: <TState, TResult extends object>(select: (state: TState) => TResult) => ((state: TState) => TResult);
 

--- a/packages/ai-sdk/src/runtime/__tests__/controlled-transport.ts
+++ b/packages/ai-sdk/src/runtime/__tests__/controlled-transport.ts
@@ -1,4 +1,6 @@
 import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
+import { useAui, type AssistantClient } from "@assistant-ui/store";
+import { flushTapSync } from "@assistant-ui/tap";
 
 export const createControlledTransport = () => {
   let controller!: ReadableStreamDefaultController<UIMessageChunk>;
@@ -39,5 +41,24 @@ export const createCancellableTransport = () => {
     transport,
     getCancelCount: () => cancelCount,
     close: () => controller.close(),
+  };
+};
+
+export const nextTask = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+export const createStreamHarness = () => {
+  let aui: AssistantClient | undefined;
+  const Probe = () => {
+    aui = useAui();
+    return null;
+  };
+  return {
+    Probe,
+    send: () => {
+      flushTapSync(() => aui!.composer.setText("keep streaming"));
+      flushTapSync(() => aui!.composer.send());
+    },
+    isRunning: () => aui?.thread.getState().isRunning === true,
+    client: () => aui!,
   };
 };

--- a/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
@@ -1,12 +1,17 @@
 // @vitest-environment jsdom
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
-import type { UIMessage } from "ai";
-import { StrictMode, useState } from "react";
+import type { ChatTransport, UIMessage } from "ai";
+import { Activity, StrictMode, useState, type ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import { AssistantChatTransport } from "../transport/AssistantChatTransport";
+import {
+  createCancellableTransport,
+  createStreamHarness,
+  nextTask,
+} from "./__tests__/controlled-transport";
 import { useChatRuntime } from "./useChatRuntime";
 import { useThreadTokenUsage } from "../usage";
 
@@ -65,7 +70,78 @@ describe("useChatRuntime integration", () => {
       );
     });
   });
+
+  it("aborts a deleted thread's stream while the host stays mounted", async () => {
+    const { transport, getCancelCount } = createCancellableTransport();
+    const { Probe, send, isRunning, client } = createStreamHarness();
+
+    const view = render(
+      <StrictMode>
+        <StreamingApp transport={transport} probe={<Probe />} />
+      </StrictMode>,
+    );
+
+    await act(async () => send());
+    await waitFor(() => expect(isRunning()).toBe(true));
+
+    await act(async () => client().threadListItem.delete());
+
+    await waitFor(() => expect(getCancelCount()).toBe(1));
+    view.unmount();
+  });
+
+  it("keeps a hidden thread streaming", async () => {
+    const { transport, getCancelCount } = createCancellableTransport();
+    const { Probe, send, isRunning } = createStreamHarness();
+
+    let setMode: ((mode: "visible" | "hidden") => void) | undefined;
+    const Shell = () => {
+      const [mode, set] = useState<"visible" | "hidden">("visible");
+      setMode = set;
+      return (
+        <Activity mode={mode}>
+          <StreamingApp transport={transport} probe={<Probe />} />
+        </Activity>
+      );
+    };
+
+    const view = render(
+      <StrictMode>
+        <Shell />
+      </StrictMode>,
+    );
+
+    await act(async () => send());
+    await waitFor(() => expect(isRunning()).toBe(true));
+
+    await act(async () => setMode?.("hidden"));
+    await act(nextTask);
+    expect(getCancelCount()).toBe(0);
+    expect(isRunning()).toBe(true);
+
+    await act(async () => setMode?.("visible"));
+    await act(nextTask);
+    expect(getCancelCount()).toBe(0);
+    expect(isRunning()).toBe(true);
+
+    view.unmount();
+  });
 });
+
+const StreamingApp = ({
+  transport,
+  probe,
+}: {
+  transport: ChatTransport<UIMessage>;
+  probe: ReactNode;
+}) => {
+  const runtime = useChatRuntime({ transport });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {probe}
+    </AssistantRuntimeProvider>
+  );
+};
 
 const UsageProbe = () => {
   const usage = useThreadTokenUsage();

--- a/packages/ai-sdk/src/runtime/useChatRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.ts
@@ -29,6 +29,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     isMainThread,
     getThreadListItem: () =>
       aui.threadListItem.source ? aui.threadListItem : undefined,
+    stopOnClientDestroy: true,
   });
 };
 

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.destroy.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.destroy.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadListRuntimeCore } from "../../runtime/interfaces/thread-list-runtime-core";
+import { RemoteThreadListHookInstanceManager } from "./RemoteThreadListHookInstanceManager";
+
+const makeManager = () =>
+  new RemoteThreadListHookInstanceManager(
+    () => ({}) as never,
+    {} as ThreadListRuntimeCore,
+  );
+
+// No AdapterSink attaches a runtime here, so the start and restart promises
+// stay pending or reject on stop; neither is what these tests are about.
+const start = (manager: RemoteThreadListHookInstanceManager, id: string) => {
+  manager.startThreadRuntime(id).catch(() => {});
+};
+const restart = (manager: RemoteThreadListHookInstanceManager, id: string) => {
+  manager.__internal_restartThreadRuntime(id).catch(() => {});
+};
+
+const publishedSignal = (
+  manager: RemoteThreadListHookInstanceManager,
+  id: string,
+) => {
+  const { hostStore } = manager as unknown as {
+    hostStore: {
+      getState: () => {
+        threads: readonly { id: string; destroySignal: AbortSignal }[];
+      };
+    };
+  };
+  return hostStore.getState().threads.find((thread) => thread.id === id)
+    ?.destroySignal;
+};
+
+describe("RemoteThreadListHookInstanceManager destroy signal", () => {
+  it("publishes a live signal for each started thread", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+
+    expect(publishedSignal(manager, "thread-1")?.aborted).toBe(false);
+  });
+
+  it("aborts the thread's signal when its runtime stops", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    const signal = publishedSignal(manager, "thread-1")!;
+
+    manager.stopThreadRuntime("thread-1");
+
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("leaves sibling threads untouched when one stops", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    start(manager, "thread-2");
+    const sibling = publishedSignal(manager, "thread-2")!;
+
+    manager.stopThreadRuntime("thread-1");
+
+    expect(sibling.aborted).toBe(false);
+  });
+
+  it("hands the next generation a fresh signal on restart", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    const first = publishedSignal(manager, "thread-1")!;
+
+    restart(manager, "thread-1");
+    const second = publishedSignal(manager, "thread-1")!;
+
+    expect(first.aborted).toBe(true);
+    expect(second).not.toBe(first);
+    expect(second.aborted).toBe(false);
+  });
+
+  it("aborts every thread when the manager is disposed", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    start(manager, "thread-2");
+    const signals = [
+      publishedSignal(manager, "thread-1")!,
+      publishedSignal(manager, "thread-2")!,
+    ];
+
+    manager.__internal_dispose();
+
+    expect(signals.map((signal) => signal.aborted)).toEqual([true, true]);
+  });
+});

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.destroy.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.destroy.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ThreadListRuntimeCore } from "../../runtime/interfaces/thread-list-runtime-core";
+import type { ThreadRuntimeCore } from "../../runtime/interfaces/thread-runtime-core";
 import { RemoteThreadListHookInstanceManager } from "./RemoteThreadListHookInstanceManager";
 
 const makeManager = () =>
@@ -86,5 +87,86 @@ describe("RemoteThreadListHookInstanceManager destroy signal", () => {
     manager.__internal_dispose();
 
     expect(signals.map((signal) => signal.aborted)).toEqual([true, true]);
+  });
+});
+
+const makeRunningRuntime = () => {
+  const subscribers = new Set<() => void>();
+  const eventListeners = new Map<string, Set<() => void>>();
+  const runtime = {
+    isRunning: true,
+    messages: [],
+    subscribe: (callback: () => void) => {
+      subscribers.add(callback);
+      return () => subscribers.delete(callback);
+    },
+    unstable_on: (event: string, callback: () => void) => {
+      let listeners = eventListeners.get(event);
+      if (!listeners) {
+        listeners = new Set();
+        eventListeners.set(event, listeners);
+      }
+      listeners.add(callback);
+      return () => listeners.delete(callback);
+    },
+  } as unknown as ThreadRuntimeCore & { isRunning: boolean };
+
+  return {
+    runtime,
+    // what a stopOnClientDestroy consumer does when the destroy signal fires
+    stop: () => {
+      runtime.isRunning = false;
+      for (const callback of eventListeners.get("runEnd") ?? []) callback();
+      for (const callback of subscribers) callback();
+    },
+  };
+};
+
+const publish = (
+  manager: RemoteThreadListHookInstanceManager,
+  threadId: string,
+  runtime: ThreadRuntimeCore,
+) => {
+  const internals = manager as unknown as {
+    instances: Map<string, { generation: number }>;
+    _publishThreadRuntime: (
+      threadId: string,
+      runtime: ThreadRuntimeCore,
+      generation: number,
+    ) => void;
+  };
+  internals._publishThreadRuntime(
+    threadId,
+    runtime,
+    internals.instances.get(threadId)!.generation,
+  );
+};
+
+describe("RemoteThreadListHookInstanceManager restart teardown", () => {
+  it("keeps the outgoing generation's terminal events off the thread's subscribers", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    const { runtime, stop } = makeRunningRuntime();
+    publish(manager, "thread-1", runtime);
+
+    const signal = publishedSignal(manager, "thread-1")!;
+    signal.addEventListener("abort", stop, { once: true });
+
+    const events: string[] = [];
+    manager.__internal_subscribeThreadEvents((event) =>
+      events.push(event.type),
+    );
+    const runningChanges: boolean[] = [];
+    manager.__internal_subscribeRunningChanged(() =>
+      runningChanges.push(manager.__internal_isThreadRunning("thread-1")),
+    );
+    expect(manager.__internal_isThreadRunning("thread-1")).toBe(true);
+
+    restart(manager, "thread-1");
+
+    expect(signal.aborted).toBe(true);
+    expect(events).toEqual([]);
+    expect(runningChanges).toEqual([]);
+    expect(manager.__internal_isThreadRunning("thread-1")).toBe(true);
   });
 });

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.test.tsx
@@ -37,13 +37,19 @@ describe("RemoteThreadListHookInstanceManager", () => {
     const internals = manager as unknown as {
       instances: Map<
         string,
-        { runtime: typeof runtime; generation: number; isRunning: boolean }
+        {
+          runtime: typeof runtime;
+          generation: number;
+          isRunning: boolean;
+          destroy: AbortController;
+        }
       >;
     };
     internals.instances.set("thread-1", {
       runtime,
       generation: 0,
       isRunning: false,
+      destroy: new AbortController(),
     });
 
     const appendPromise = runtime.append({

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -53,6 +53,9 @@ type RemoteThreadListHookInstance = {
   generation: number;
   isRunning: boolean;
   unsubscribeRunning?: Unsubscribe | undefined;
+  // Permanent teardown of the thread's runtime, aborted when the thread is
+  // stopped or its runtime restarted. A soft unmount leaves it armed.
+  destroy: AbortController;
 };
 
 type AdapterSnapshot = {
@@ -61,7 +64,11 @@ type AdapterSnapshot = {
 };
 
 type HostSnapshot = {
-  threads: readonly { id: string; generation: number }[];
+  threads: readonly {
+    id: string;
+    generation: number;
+    destroySignal: AbortSignal;
+  }[];
   hookEpoch: number;
 };
 
@@ -129,6 +136,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
       this.instances.set(threadId, {
         generation,
         isRunning: false,
+        destroy: new AbortController(),
       });
       this._syncHostThreads();
     }
@@ -141,6 +149,8 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     if (!instance) return this.startThreadRuntime(threadId);
 
     if (instance.runtime) invalidateThreadRuntime(instance.runtime);
+    instance.destroy.abort();
+    instance.destroy = new AbortController();
     instance.generation = this.nextGeneration++;
     this._syncHostThreads();
     this._notifySubscribers();
@@ -261,6 +271,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     const instance = this.instances.get(threadId);
     if (instance?.runtime) invalidateThreadRuntime(instance.runtime);
     instance?.unsubscribeRunning?.();
+    instance?.destroy.abort();
     this.instances.delete(threadId);
     this.pendingThreadAdapters.delete(threadId);
     this._syncHostThreads();
@@ -302,7 +313,11 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     this.hostStore.setState({
       ...host,
       threads: Array.from(this.instances.entries()).map(
-        ([id, { generation }]) => ({ id, generation }),
+        ([id, { generation, destroy }]) => ({
+          id,
+          generation,
+          destroySignal: destroy.signal,
+        }),
       ),
     });
   }
@@ -312,7 +327,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     const adapters = useSubscribable(this.adapterStore);
     const runtimeHook = this.runtimeHook;
     return useResources(
-      threads.map(({ id, generation }) => {
+      threads.map(({ id, generation, destroySignal }) => {
         const threadAdapters = this.pendingThreadAdapters.has(id)
           ? this.pendingThreadAdapters.get(id)!
           : (adapters.threadAdapters.get(id) ?? adapters.defaultAdapters);
@@ -326,6 +341,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
             parentClient,
             adapters: threadAdapters,
             publish: this._publish,
+            destroySignal,
           }),
         );
       }),

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -149,6 +149,12 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     if (!instance) return this.startThreadRuntime(threadId);
 
     if (instance.runtime) invalidateThreadRuntime(instance.runtime);
+    // Detach before aborting, as stopThreadRuntime does: the abort runs the
+    // destroy listeners synchronously, and a listener that stops the outgoing
+    // runtime would otherwise emit that generation's terminal events through
+    // the subscription the next generation is about to reuse.
+    instance.unsubscribeRunning?.();
+    instance.unsubscribeRunning = undefined;
     instance.destroy.abort();
     instance.destroy = new AbortController();
     instance.generation = this.nextGeneration++;

--- a/packages/core/src/react/runtimes/RemoteThreadResource.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadResource.ts
@@ -3,6 +3,7 @@ import { resource } from "@assistant-ui/tap";
 import {
   useAssistantContextProvider,
   useConfiguredAui,
+  useDestroySignalProvider,
 } from "@assistant-ui/store/client";
 import { ThreadListItemClient } from "../../store/internal";
 import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
@@ -38,6 +39,7 @@ export type RemoteThreadResourceProps = {
     runtime: ThreadRuntimeCore,
     generation: number,
   ) => void;
+  destroySignal: AbortSignal;
 };
 
 export const subscribeToTitleGeneration = (
@@ -180,6 +182,7 @@ const useRemoteThreadResource = ({
   parentClient,
   adapters,
   publish,
+  destroySignal,
 }: RemoteThreadResourceProps) => {
   const itemRuntime = useMemo(
     () =>
@@ -216,14 +219,16 @@ const useRemoteThreadResource = ({
     threadListItem: ThreadListItemClient({ runtime: itemRuntime }),
   });
 
-  return useAssistantContextProvider(client, function useThreadClient() {
-    return useRuntimeAdaptersProvider(adapters, function useBoundRuntime() {
-      return useRemoteThreadBinder({
-        threadId,
-        generation,
-        runtimeHook,
-        publish,
-        itemRuntime,
+  return useDestroySignalProvider(destroySignal, function useOwnedThread() {
+    return useAssistantContextProvider(client, function useThreadClient() {
+      return useRuntimeAdaptersProvider(adapters, function useBoundRuntime() {
+        return useRemoteThreadBinder({
+          threadId,
+          generation,
+          runtimeHook,
+          publish,
+          itemRuntime,
+        });
       });
     });
   });

--- a/packages/store/src/client.ts
+++ b/packages/store/src/client.ts
@@ -17,6 +17,7 @@ export {
   useAssistantContextValue,
 } from "./utils/react-assistant-context";
 export { useConfiguredAui } from "./useAui";
+export { useDestroySignalProvider } from "./utils/destroy-signal-context";
 export { getProxiedAssistantState } from "./utils/proxied-assistant-state";
 export {
   useAssistantClientRef,

--- a/packages/store/src/createAssistantClient.ts
+++ b/packages/store/src/createAssistantClient.ts
@@ -7,6 +7,7 @@ import type { AssistantClient, Unsubscribe } from "./types/client";
 import type { AuiConfig } from "./AuiConfig";
 import { DefaultAssistantClient } from "./utils/react-assistant-context";
 import { createNotificationManager } from "./utils/NotificationManager";
+import { useDestroySignalProvider } from "./utils/destroy-signal-context";
 import {
   applyTransformScopes,
   useAuiRoot,
@@ -159,13 +160,12 @@ export const createAssistantClient = (
       const entries = Object.entries(
         applyTransformScopes(currentConfig, parent),
       ) as ScopeEntry[];
-      const result = useAuiRoot({
-        parent,
-        entries,
-        clientRef,
-        notifications,
-        destroySignal: destroyController.signal,
-      });
+      const result = useDestroySignalProvider(
+        destroyController.signal,
+        function useRootClient() {
+          return useAuiRoot({ parent, entries, clientRef, notifications });
+        },
+      );
       // Seeded during render, before the commit runs mount effects that read it
       if (clientRef.current === null) {
         clientRef.current = result.client;

--- a/packages/store/src/internal.ts
+++ b/packages/store/src/internal.ts
@@ -1,4 +1,4 @@
-export { useAssistantClientDestroySignal } from "./utils/tap-assistant-context";
+export { useAssistantClientDestroySignal } from "./utils/destroy-signal-context";
 export {
   shallowEqual,
   useShallowSelector,

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -285,19 +285,17 @@ export const useAuiRoot = ({
   entries,
   clientRef,
   notifications,
-  destroySignal,
 }: {
   parent: AssistantClient;
   entries: ScopeEntry[];
   clientRef: ClientRef;
   notifications: NotificationManager;
-  destroySignal?: AbortSignal | undefined;
 }): { client: AssistantClient } => {
   const fields = useClientFields({ notifications, clientRef });
   const building = createClientObject(parent, fields);
 
   const accessors = useAssistantTapContextProvider(
-    { clientRef, emit: notifications.emit, destroySignal },
+    { clientRef, emit: notifications.emit },
     function WithTapContext() {
       return useAssistantContextProvider(
         building,

--- a/packages/store/src/utils/destroy-signal-context.ts
+++ b/packages/store/src/utils/destroy-signal-context.ts
@@ -1,0 +1,23 @@
+import { createContext, use } from "react";
+import { useContextProvider } from "@assistant-ui/tap";
+
+const DestroySignalContext = createContext<AbortSignal | undefined>(undefined);
+
+/**
+ * Scopes a subtree to the permanent teardown of whatever owns it. The signal
+ * aborts when the owner is destroyed for good, never when a resource soft
+ * unmounts and may come back, so a consumer may release work on it without
+ * losing state a later reveal still needs.
+ */
+export const useDestroySignalProvider = <TResult>(
+  destroySignal: AbortSignal | undefined,
+  fn: () => TResult,
+): TResult => useContextProvider(DestroySignalContext, destroySignal, fn);
+
+/**
+ * Returns the permanent teardown signal of the owner the caller runs under.
+ * A caller outside any owned subtree resolves none, which retains its
+ * resources rather than releasing them early.
+ */
+export const useAssistantClientDestroySignal = (): AbortSignal | undefined =>
+  use(DestroySignalContext);

--- a/packages/store/src/utils/tap-assistant-context.ts
+++ b/packages/store/src/utils/tap-assistant-context.ts
@@ -17,7 +17,6 @@ type EmitFn = <TEvent extends Exclude<AssistantEventName, "*">>(
 export type AssistantTapContextValue = {
   clientRef: { parent: AssistantClient; current: AssistantClient | null };
   emit: EmitFn;
-  destroySignal?: AbortSignal | undefined;
 };
 
 const AssistantTapContext = createContext<AssistantTapContextValue | null>(
@@ -42,15 +41,6 @@ const useAssistantTapContext = () => {
 
 export const useAssistantClientRef = () => {
   return useAssistantTapContext().clientRef;
-};
-
-/**
- * Returns the permanent teardown signal for a standalone assistant client.
- * React-hosted clients do not expose a distinct destroy lifecycle.
- */
-export const useAssistantClientDestroySignal = (): AbortSignal | undefined => {
-  const ctx = use(AssistantTapContext);
-  return ctx?.destroySignal;
 };
 
 /**


### PR DESCRIPTION
refs #7016
refs #6016

part 1 of the #7016 split. does not close #7016 or #6016.

## problem

a thread whose runtime is torn down leaves its request streaming. deleting a thread, detaching it, dropping it from a replaced thread list, or restarting its runtime all destroy that thread's runtime, but nothing cancels the request it had in flight, so the response keeps arriving into a runtime nothing reads.

## root cause

two layers, and the second is why the first was never enough.

`RemoteThreadListHookInstanceManager` tracks a generation per thread but holds no cancellation handle, so `stopThreadRuntime` and `__internal_restartThreadRuntime` tear a runtime down without telling that thread's own async work.

even given a signal, it could not reach the consumer. `useResourceCleanup` reads `useAssistantClientDestroySignal`, which read off `AssistantTapContext`. `useAuiRoot` provides that context around its scope mounts only, while `RemoteThreadResource` builds its client with `useConfiguredAui` and then renders the thread's runtime hook in a sibling provider outside it. the runtime hook therefore resolved whatever ambient context happened to enclose it, which under a React host is none. confirmed with a probe on the `useChatRuntime` path: every `useResourceCleanup` call saw `destroySignal: undefined`.

## change

**store.** the destroy signal moves onto its own context. `useDestroySignalProvider(signal, fn)` is provided by whatever owns a subtree, and `useAssistantClientDestroySignal()` resolves it by tree position. `createAssistantClient` now provides its controller's signal there, and `AssistantTapContextValue.destroySignal` plus the matching `useAuiRoot` parameter are removed, so one mechanism carries this fact instead of two. this also avoids the `bindClientDestroySignal` WeakMap and the prototype walk that #6395 needed to reach the same consumers.

**core.** the instance manager owns one `AbortController` per thread, aborted in `stopThreadRuntime` and in `__internal_restartThreadRuntime`, which then mints a fresh one for the next generation. the signal rides the host snapshot beside `id` and `generation`, and `RemoteThreadResource` provides it around the subtree that runs the runtime hook.

**ai-sdk.** `useChatRuntime` opts its thread hook into `stopOnClientDestroy`.

a soft unmount leaves the signal armed, so a thread hidden under `<Activity mode="hidden">` keeps streaming and only a real teardown aborts. a `hookEpoch` bump does not abort either: it swaps the runtime hook while the thread stays, and its chat entry is deliberately reused.

two consequences worth naming. a nested `allowNesting` chat under a hosted thread now resolves the owning thread's signal, since the provider sits above it; it previously resolved none. and this does not cancel on host unmount, because nothing mints a signal for a React host yet. that is #6016, and it lands with part 3.

## verification

- the new integration case is a real repro: swap the provider's signal for `undefined`, rebuild core, and `aborts a deleted thread's stream while the host stays mounted` fails with `cancelCount` 0; restore it and it passes at 1
- `RemoteThreadListHookInstanceManager.destroy.test.tsx` pins the manager contract: a live signal per started thread, abort on stop, siblings untouched, a fresh signal per restart, and every thread aborted on `__internal_dispose`
- `keeps a hidden thread streaming` pins the soft-unmount half: hide then reveal, no cancel, `isRunning` holds
- `pnpm exec turbo test --continue` -> 90/90 tasks, core 1774, store 204, ai-sdk 271, tap 581
- `pnpm lint` clean, `pnpm test:react-compiler` 11/11, `pnpm size:check` all ok (`@assistant-ui/store ./internal` moves 441 to 451 B, well inside the 256 B floor), `check-changesets` and `check-changeset-semver` pass

reviewer should verify: with a multi-thread `useChatRuntime` app, start a response and delete that thread mid-stream; the request aborts while the rest of the app keeps working. then repeat with the thread hidden under `<Activity mode="hidden">` and confirm it keeps streaming.

## public surface

- `@assistant-ui/store`: `useDestroySignalProvider` added to `./client`, additive. `useAssistantClientDestroySignal` keeps its name and `./internal` path, re-pointed to the new module.
- removed, and neither is published (api-surface carries neither): `AssistantTapContextValue.destroySignal` and the `destroySignal` parameter of `useAuiRoot`.
- `@assistant-ui/core`: `RemoteThreadResourceProps` gains a required `destroySignal`; the type is internal to the runtime plumbing.
- api-surface: one added line, regenerated.
- changeset: patch on `@assistant-ui/store`, `@assistant-ui/core`, `@assistant-ui/ai-sdk`.
- docs and api-reference: no change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.IVMG_hLaRUmkcZr7NfRwPMKykI290UIpwLhqDre-hK9jDVi-iDg88I0XPQs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->