### PR TITLE
fix: cancel in-flight work when the React host that owns it unmounts

### DIFF
--- a/.changeset/react-host-destroy-signal.md
+++ b/.changeset/react-host-destroy-signal.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/ai-sdk": patch
+"@assistant-ui/core": patch
+"@assistant-ui/store": patch
+---
+
+fix(store): cancel in-flight work when the React host that owns it unmounts
+
+a React-hosted client now carries a permanent teardown signal, so unmounting an `AuiProvider`, a `useAui(config)` host, or a `useRemoteThreadListRuntime` host cancels the requests it owned instead of leaving them streaming into a deleted tree. a hidden `<Activity>`, a Strict Mode replay, and a re-suspended boundary are soft and keep streaming.

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -374,7 +374,7 @@ declare const useClientResource: <TMethods extends ClientMethods>(element: Resou
   key: string | number | undefined;
 };
 
-declare const useConfiguredAui: (parent: AssistantClient, clients: AuiConfig.Input) => ScopedAuiClient;
+declare const useConfiguredAui: (parent: AssistantClient, clients: AuiConfig.Input, destroySignal?: AbortSignal) => ScopedAuiClient;
 
 declare const useDestroySignalProvider: <TResult>(destroySignal: AbortSignal | undefined, fn: () => TResult) => TResult;
 

--- a/packages/ai-sdk/src/runtime/AISDKChat.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/AISDKChat.integration.test.tsx
@@ -1,47 +1,65 @@
 // @vitest-environment jsdom
 
-import { useEffect } from "react";
-import { render, waitFor } from "@testing-library/react";
-import { StrictMode } from "react";
+import { StrictMode, type ReactNode } from "react";
+import { act, render, waitFor } from "@testing-library/react";
 import { AuiConfig, AuiProvider, useAui } from "@assistant-ui/store";
-import { flushTapSync } from "@assistant-ui/tap";
+import type { ChatTransport, UIMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import { AISDKChat } from "./AISDKChat";
-import { createCancellableTransport } from "./__tests__/controlled-transport";
+import {
+  createCancellableTransport,
+  createStreamHarness,
+} from "./__tests__/controlled-transport";
 
 describe("AISDKChat React integration", () => {
-  it("does not treat React provider unmount as client destruction", async () => {
-    const { transport, getCancelCount, close } = createCancellableTransport();
-    let started = false;
-    let isRunning = () => false;
-
-    const SendOnMount = () => {
-      const aui = useAui();
-      isRunning = () => aui.thread.getState().isRunning;
-      useEffect(() => {
-        if (started) return;
-        started = true;
-        flushTapSync(() => aui.composer.setText("keep streaming"));
-        flushTapSync(() => aui.composer.send());
-      }, [aui]);
-      return null;
-    };
+  it("aborts the in-flight transport after a real unmount", async () => {
+    const { transport, getCancelCount } = createCancellableTransport();
+    const { Probe, send, isRunning } = createStreamHarness();
 
     const view = render(
       <StrictMode>
         <AuiProvider config={AuiConfig({ threads: AISDKChat({ transport }) })}>
-          <SendOnMount />
+          <Probe />
         </AuiProvider>
       </StrictMode>,
     );
 
-    await waitFor(() => {
-      expect(isRunning()).toBe(true);
-    });
+    await act(async () => send());
+    await waitFor(() => expect(isRunning()).toBe(true));
 
     view.unmount();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(getCancelCount()).toBe(0);
-    close();
+    await waitFor(() => expect(getCancelCount()).toBe(1));
+  });
+});
+
+describe("AISDKChat legacy useAui host integration", () => {
+  const LegacyProvider = ({
+    transport,
+    children,
+  }: {
+    transport: ChatTransport<UIMessage>;
+    children: ReactNode;
+  }) => {
+    const aui = useAui(AuiConfig({ threads: AISDKChat({ transport }) }));
+    return <AuiProvider value={aui}>{children}</AuiProvider>;
+  };
+
+  it("aborts the in-flight transport after a real unmount", async () => {
+    const { transport, getCancelCount } = createCancellableTransport();
+    const { Probe, send, isRunning } = createStreamHarness();
+
+    const view = render(
+      <StrictMode>
+        <LegacyProvider transport={transport}>
+          <Probe />
+        </LegacyProvider>
+      </StrictMode>,
+    );
+
+    await act(async () => send());
+    await waitFor(() => expect(isRunning()).toBe(true));
+
+    view.unmount();
+    await waitFor(() => expect(getCancelCount()).toBe(1));
   });
 });

--- a/packages/ai-sdk/src/runtime/AISDKChat.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/AISDKChat.integration.test.tsx
@@ -26,6 +26,8 @@ describe("AISDKChat React integration", () => {
 
     await act(async () => send());
     await waitFor(() => expect(isRunning()).toBe(true));
+    // the Strict Mode double mount already ran a host cleanup by now
+    expect(getCancelCount()).toBe(0);
 
     view.unmount();
     await waitFor(() => expect(getCancelCount()).toBe(1));
@@ -58,6 +60,7 @@ describe("AISDKChat legacy useAui host integration", () => {
 
     await act(async () => send());
     await waitFor(() => expect(isRunning()).toBe(true));
+    expect(getCancelCount()).toBe(0);
 
     view.unmount();
     await waitFor(() => expect(getCancelCount()).toBe(1));

--- a/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
@@ -104,6 +104,8 @@ describe("useChatRuntime integration", () => {
 
     await act(async () => send());
     await waitFor(() => expect(isRunning()).toBe(true));
+    // the Strict Mode double mount already ran a host cleanup by now
+    expect(getCancelCount()).toBe(0);
 
     view.unmount();
     await waitFor(() => expect(getCancelCount()).toBe(1));
@@ -148,7 +150,7 @@ describe("useChatRuntime integration", () => {
     await waitFor(() => expect(getCancelCount()).toBe(1));
   });
 
-  it("aborts a nested runtime's stream when the host it runs under unmounts", async () => {
+  it("aborts a nested runtime's stream when the provider above it unmounts", async () => {
     const outer = createCancellableTransport();
     const { transport, getCancelCount } = createCancellableTransport();
     let nested: AssistantRuntime | undefined;

--- a/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
@@ -2,7 +2,9 @@
 
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
-import { useAuiState } from "@assistant-ui/store";
+import { AuiConfig, AuiProvider, useAuiState } from "@assistant-ui/store";
+import type { AssistantRuntime } from "@assistant-ui/core";
+import { AISDKChat } from "./AISDKChat";
 import type { ChatTransport, UIMessage } from "ai";
 import { Activity, StrictMode, useState, type ReactNode } from "react";
 import { describe, expect, it } from "vitest";
@@ -90,7 +92,24 @@ describe("useChatRuntime integration", () => {
     view.unmount();
   });
 
-  it("keeps a hidden thread streaming", async () => {
+  it("aborts the in-flight transport after a real unmount", async () => {
+    const { transport, getCancelCount } = createCancellableTransport();
+    const { Probe, send, isRunning } = createStreamHarness();
+
+    const view = render(
+      <StrictMode>
+        <StreamingApp transport={transport} probe={<Probe />} />
+      </StrictMode>,
+    );
+
+    await act(async () => send());
+    await waitFor(() => expect(isRunning()).toBe(true));
+
+    view.unmount();
+    await waitFor(() => expect(getCancelCount()).toBe(1));
+  });
+
+  it("keeps streaming while hidden and aborts when the hidden host unmounts", async () => {
     const { transport, getCancelCount } = createCancellableTransport();
     const { Probe, send, isRunning } = createStreamHarness();
 
@@ -124,7 +143,43 @@ describe("useChatRuntime integration", () => {
     expect(getCancelCount()).toBe(0);
     expect(isRunning()).toBe(true);
 
+    await act(async () => setMode?.("hidden"));
     view.unmount();
+    await waitFor(() => expect(getCancelCount()).toBe(1));
+  });
+
+  it("aborts a nested runtime's stream when the host it runs under unmounts", async () => {
+    const outer = createCancellableTransport();
+    const { transport, getCancelCount } = createCancellableTransport();
+    let nested: AssistantRuntime | undefined;
+
+    // allowNesting: the inner useChatRuntime runs its thread hook directly, as
+    // a plain React hook under the provider rather than inside a tap resource.
+    const NestedChat = () => {
+      nested = useChatRuntime({ transport });
+      return null;
+    };
+
+    const view = render(
+      <StrictMode>
+        <AuiProvider
+          config={AuiConfig({
+            threads: AISDKChat({ transport: outer.transport }),
+          })}
+        >
+          <NestedChat />
+        </AuiProvider>
+      </StrictMode>,
+    );
+
+    await waitFor(() => expect(nested).toBeDefined());
+    await act(async () => {
+      await nested!.thread.append("keep streaming");
+    });
+    await waitFor(() => expect(nested!.thread.getState().isRunning).toBe(true));
+
+    view.unmount();
+    await waitFor(() => expect(getCancelCount()).toBe(1));
   });
 });
 

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
@@ -1,6 +1,7 @@
 import {
   useState,
   useEffect,
+  useInsertionEffect,
   useMemo,
   useRef,
   useCallback,
@@ -39,6 +40,16 @@ const useRemoteThreadListRuntimeImpl = (
   options: RemoteThreadListOptions,
 ): AssistantRuntime => {
   const [runtime] = useState(() => new RemoteThreadListRuntimeCore(options));
+
+  // Insertion-effect cleanup runs only when React deletes the fiber, so a
+  // hidden <Activity> or a re-suspended boundary keeps the threads alive; the
+  // disposal is deferred to a microtask because it notifies subscribers and
+  // React forbids scheduling updates from an insertion effect.
+  useInsertionEffect(
+    () => () => queueMicrotask(() => runtime.threads.__internal_dispose()),
+    [runtime],
+  );
+
   useEffect(() => {
     runtime.threads.__internal_setOptions(options);
     runtime.threads.__internal_load();

--- a/packages/store/src/AuiProvider.tsx
+++ b/packages/store/src/AuiProvider.tsx
@@ -11,6 +11,8 @@ import {
   useAssistantContextValue,
 } from "./utils/react-assistant-context";
 import { useConfiguredAui } from "./useAui";
+import { DestroySignalContext } from "./utils/destroy-signal-context";
+import { useHostDestroySignal } from "./utils/useHostDestroySignal";
 import { isDevelopment } from "./utils/env";
 
 const EMPTY_CONFIG = AuiConfig({});
@@ -169,13 +171,24 @@ export const AuiProvider: {
     : hasValue
       ? (props.value ?? DefaultAssistantClient)
       : contextParent;
-  const { client, effects } = useConfiguredAui(parent, config ?? EMPTY_CONFIG);
+  // Published twice because tap's context is a snapshot taken at tap-root
+  // creation and never reads React's: the tap side reaches the client's own
+  // scope mounts, the React side reaches consumers that run as plain hooks
+  // under this provider.
+  const destroySignal = useHostDestroySignal();
+  const { client, effects } = useConfiguredAui(
+    parent,
+    config ?? EMPTY_CONFIG,
+    destroySignal,
+  );
   useImperativeHandle(ref, () => client, [client]);
   return (
-    <AssistantContext.Provider value={client}>
-      <MountTapEffects effects={getTapEffects(parent)} />
-      {effects && <MountTapEffects effects={effects} />}
-      {children}
-    </AssistantContext.Provider>
+    <DestroySignalContext.Provider value={destroySignal}>
+      <AssistantContext.Provider value={client}>
+        <MountTapEffects effects={getTapEffects(parent)} />
+        {effects && <MountTapEffects effects={effects} />}
+        {children}
+      </AssistantContext.Provider>
+    </DestroySignalContext.Provider>
   );
 }) as never;

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -665,8 +665,8 @@ export function useAui(clients?: useAui.Props): AssistantClient {
   const parent = useAssistantContextValue();
   if (clients) {
     // oxlint-disable-next-line react-hooks/rules-of-hooks -- fixed per call site
-    // oxlint-disable-next-line react-hooks/rules-of-hooks -- fixed per call site
     const destroySignal = useHostDestroySignal();
+    // oxlint-disable-next-line react-hooks/rules-of-hooks -- fixed per call site
     const { client, effects } = useConfiguredAuiImpl(
       parent,
       clients,

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -46,6 +46,8 @@ import {
   type NotificationManager,
 } from "./utils/NotificationManager";
 import { useAssistantTapContextProvider } from "./utils/tap-assistant-context";
+import { useDestroySignalProvider } from "./utils/destroy-signal-context";
+import { useHostDestroySignal } from "./utils/useHostDestroySignal";
 import { ClientResource } from "./useClientResource";
 import { useShallowStable } from "./utils/useShallowStable";
 import {
@@ -316,20 +318,18 @@ export const useAuiRoot = ({
 const useHostedAssistantClient = ({
   parent,
   entries,
-}: {
-  parent: AssistantClient;
-  entries: ScopeEntry[];
-}): ScopedAuiClient => {
+  destroySignal,
+}: HostProps): ScopedAuiClient => {
   const clientRef = useRef<ClientRef>({ parent, current: null }).current;
   const { value: client, effects } = useTapHost(function AssistantClientHost() {
     const notifications = useNotificationManager();
 
-    const { client } = useAuiRoot({
-      parent,
-      entries,
-      clientRef,
-      notifications,
-    });
+    const { client } = useDestroySignalProvider(
+      destroySignal,
+      function useOwnedRoot() {
+        return useAuiRoot({ parent, entries, clientRef, notifications });
+      },
+    );
 
     useEffect(
       () => parent.subscribe(notifications.notifySubscribers),
@@ -360,17 +360,17 @@ const useHostedAssistantClient = ({
 const useTapRootAssistantClient = ({
   parent,
   entries,
-}: {
-  parent: AssistantClient;
-  entries: ScopeEntry[];
-}): ScopedAuiClient => {
+  destroySignal,
+}: HostProps): ScopedAuiClient => {
   const clientRef = useRef<ClientRef>({ parent, current: null }).current;
   const { value: client, effects } = useTapHost(
     function LegacyAssistantClientHost() {
       const notifications = useNotificationManager();
 
       const store = useTapRoot(function AuiRoot() {
-        return useAuiRoot({ parent, entries, clientRef, notifications });
+        return useDestroySignalProvider(destroySignal, function useOwnedRoot() {
+          return useAuiRoot({ parent, entries, clientRef, notifications });
+        });
       });
 
       const client = useSyncExternalStore(
@@ -525,6 +525,12 @@ const useDerivedOnlyClient = (
 
 type ScopedAuiClient = { client: AssistantClient; effects?: () => void };
 
+type HostProps = {
+  parent: AssistantClient;
+  entries: ScopeEntry[];
+  destroySignal: AbortSignal | undefined;
+};
+
 const useScopeEntries = (
   parent: AssistantClient,
   clients: AuiConfig.Input,
@@ -550,17 +556,21 @@ const useScopeEntries = (
 // React root) with the scopes in the config; context is never consulted.
 // `effects` (rooted mode only) commits the host — the provider mounts it
 // ahead of its children's effects; hosts also self-commit as a fallback.
-// `useHost` is fixed per call site.
+// `useHost` is fixed per call site. `destroySignal` is the permanent teardown
+// of whatever owns the client; a caller that owns no distinct lifetime passes
+// none and the enclosing owner keeps standing. A derived-only client resolves
+// its owner on read instead, so only a rooted config carries one.
 const useConfiguredAuiImpl = (
   parent: AssistantClient,
   clients: AuiConfig.Input,
   useHost: typeof useHostedAssistantClient,
+  destroySignal: AbortSignal | undefined,
 ): ScopedAuiClient => {
   const { entries, rooted } = useScopeEntries(parent, clients);
 
   if (rooted) {
     // oxlint-disable-next-line react-hooks/rules-of-hooks
-    return useHost({ parent, entries });
+    return useHost({ parent, entries, destroySignal });
   }
   // oxlint-disable-next-line react-hooks/rules-of-hooks
   return { client: useDerivedOnlyClient(parent, entries) };
@@ -569,8 +579,14 @@ const useConfiguredAuiImpl = (
 export const useConfiguredAui = (
   parent: AssistantClient,
   clients: AuiConfig.Input,
+  destroySignal?: AbortSignal,
 ): ScopedAuiClient =>
-  useConfiguredAuiImpl(parent, clients, useHostedAssistantClient);
+  useConfiguredAuiImpl(
+    parent,
+    clients,
+    useHostedAssistantClient,
+    destroySignal,
+  );
 
 export namespace useAui {
   export type Props = AuiConfig.Input;
@@ -649,10 +665,13 @@ export function useAui(clients?: useAui.Props): AssistantClient {
   const parent = useAssistantContextValue();
   if (clients) {
     // oxlint-disable-next-line react-hooks/rules-of-hooks -- fixed per call site
+    // oxlint-disable-next-line react-hooks/rules-of-hooks -- fixed per call site
+    const destroySignal = useHostDestroySignal();
     const { client, effects } = useConfiguredAuiImpl(
       parent,
       clients,
       useTapRootAssistantClient,
+      destroySignal,
     );
     if (effects) setTapEffects(client, effects);
     return client;

--- a/packages/store/src/utils/destroy-signal-context.ts
+++ b/packages/store/src/utils/destroy-signal-context.ts
@@ -1,18 +1,28 @@
 import { createContext, use } from "react";
 import { useContextProvider } from "@assistant-ui/tap";
 
-const DestroySignalContext = createContext<AbortSignal | undefined>(undefined);
+export const DestroySignalContext = createContext<AbortSignal | undefined>(
+  undefined,
+);
 
 /**
  * Scopes a subtree to the permanent teardown of whatever owns it. The signal
  * aborts when the owner is destroyed for good, never when a resource soft
  * unmounts and may come back, so a consumer may release work on it without
- * losing state a later reveal still needs.
+ * losing state a later reveal still needs. A caller with no owner of its own
+ * passes `undefined` and the enclosing owner keeps standing.
  */
 export const useDestroySignalProvider = <TResult>(
   destroySignal: AbortSignal | undefined,
   fn: () => TResult,
-): TResult => useContextProvider(DestroySignalContext, destroySignal, fn);
+): TResult => {
+  const inherited = use(DestroySignalContext);
+  return useContextProvider(
+    DestroySignalContext,
+    destroySignal ?? inherited,
+    fn,
+  );
+};
 
 /**
  * Returns the permanent teardown signal of the owner the caller runs under.

--- a/packages/store/src/utils/useHostDestroySignal.test.tsx
+++ b/packages/store/src/utils/useHostDestroySignal.test.tsx
@@ -5,7 +5,13 @@ import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useHostDestroySignal } from "./useHostDestroySignal";
 
-afterEach(cleanup);
+let consoleErrors: ReturnType<typeof vi.spyOn> | undefined;
+
+afterEach(() => {
+  cleanup();
+  consoleErrors?.mockRestore();
+  consoleErrors = undefined;
+});
 
 const nextTask = () => new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -59,6 +65,7 @@ describe("useHostDestroySignal", () => {
 
   it("lets an abort listener update a surviving component", async () => {
     const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleErrors = errors;
     let bump: (() => void) | undefined;
     const Sibling = () => {
       const [, set] = useState(0);
@@ -79,7 +86,6 @@ describe("useHostDestroySignal", () => {
     await act(async () => view.rerender(<Shell mounted={false} />));
     expect(captured.aborted).toBe(true);
     expect(errors).not.toHaveBeenCalled();
-    errors.mockRestore();
   });
 
   it("stays armed while a sibling keeps the boundary re-suspended", async () => {

--- a/packages/store/src/utils/useHostDestroySignal.test.tsx
+++ b/packages/store/src/utils/useHostDestroySignal.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { Activity, StrictMode, Suspense, useState } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useHostDestroySignal } from "./useHostDestroySignal";
+
+afterEach(cleanup);
+
+const nextTask = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("useHostDestroySignal", () => {
+  let signal: AbortSignal;
+  const Probe = () => {
+    signal = useHostDestroySignal();
+    return null;
+  };
+
+  it("does not abort across a Strict Mode double mount", async () => {
+    render(
+      <StrictMode>
+        <Probe />
+      </StrictMode>,
+    );
+    const captured = signal;
+
+    await nextTask();
+    expect(captured.aborted).toBe(false);
+  });
+
+  it("stays armed while an Activity is hidden and aborts when the hidden host unmounts", async () => {
+    const App = ({ mode }: { mode: "visible" | "hidden" }) => (
+      <Activity mode={mode}>
+        <Probe />
+      </Activity>
+    );
+    const view = render(<App mode="visible" />);
+    const captured = signal;
+
+    view.rerender(<App mode="hidden" />);
+    await act(nextTask);
+    expect(captured.aborted).toBe(false);
+
+    view.rerender(<App mode="visible" />);
+    expect(signal).toBe(captured);
+    expect(captured.aborted).toBe(false);
+
+    await act(async () => {
+      view.rerender(<App mode="hidden" />);
+    });
+    await act(nextTask);
+    expect(captured.aborted).toBe(false);
+
+    view.unmount();
+    expect(captured.aborted).toBe(false);
+    await act(async () => {});
+    expect(captured.aborted).toBe(true);
+  });
+
+  it("lets an abort listener update a surviving component", async () => {
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    let bump: (() => void) | undefined;
+    const Sibling = () => {
+      const [, set] = useState(0);
+      bump = () => set((n) => n + 1);
+      return null;
+    };
+    const Shell = ({ mounted }: { mounted: boolean }) => (
+      <>
+        <Sibling />
+        {mounted && <Probe />}
+      </>
+    );
+
+    const view = render(<Shell mounted={true} />);
+    const captured = signal;
+    captured.addEventListener("abort", () => bump?.());
+
+    await act(async () => view.rerender(<Shell mounted={false} />));
+    expect(captured.aborted).toBe(true);
+    expect(errors).not.toHaveBeenCalled();
+    errors.mockRestore();
+  });
+
+  it("stays armed while a sibling keeps the boundary re-suspended", async () => {
+    const never = new Promise<void>(() => {});
+    const Sibling = ({ suspended }: { suspended: boolean }) => {
+      if (suspended) throw never;
+      return null;
+    };
+    let setSuspended: ((suspended: boolean) => void) | undefined;
+    const Shell = () => {
+      const [suspended, set] = useState(false);
+      setSuspended = set;
+      return (
+        <Suspense fallback={null}>
+          <Probe />
+          <Sibling suspended={suspended} />
+        </Suspense>
+      );
+    };
+
+    const view = render(<Shell />);
+    const captured = signal;
+
+    act(() => setSuspended?.(true));
+    await act(nextTask);
+    expect(captured.aborted).toBe(false);
+
+    act(() => setSuspended?.(false));
+    expect(signal).toBe(captured);
+    expect(captured.aborted).toBe(false);
+
+    view.unmount();
+    await act(async () => {});
+    expect(captured.aborted).toBe(true);
+  });
+});

--- a/packages/store/src/utils/useHostDestroySignal.ts
+++ b/packages/store/src/utils/useHostDestroySignal.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useInsertionEffect, useState } from "react";
+
+/**
+ * Permanent teardown signal for a React-hosted assistant client. Insertion
+ * effects are cleaned up only when React deletes the fiber: a Strict Mode
+ * replay, a hidden `<Activity>`, or a re-suspended boundary disconnects
+ * layout and passive effects but leaves this one in place, so the signal
+ * aborts on a real unmount and nothing else. The abort runs in a microtask
+ * because React forbids scheduling updates from inside an insertion effect
+ * and abort listeners may update surviving components. React-land only:
+ * under tap's dispatcher this is a plain effect and would abort on every
+ * soft unmount.
+ */
+export const useHostDestroySignal = (): AbortSignal => {
+  const [controller] = useState(() => new AbortController());
+  useInsertionEffect(
+    () => () => queueMicrotask(() => controller.abort()),
+    [controller],
+  );
+  return controller.signal;
+};


### PR DESCRIPTION
closes #6016
refs #7016

part 3 of the #7016 split, on top of #7027. part 2 is not needed; the reasoning is in https://github.com/assistant-ui/assistant-ui/issues/7016#issuecomment-5581891219.

## problem

unmounting the React tree that owns an assistant client leaves its requests streaming. removing an `<AuiProvider>`, a `useAui(config)` host, or a `useChatRuntime` host tears down every consumer of that client, but nothing tells the runtime, so the response keeps arriving into a tree React has deleted. #6016 reports this against the AI SDK transport.

## root cause

two gaps, and they need different mechanisms because tap and React do not share a context stack.

no React host minted a permanent teardown signal. #7027 gave a hosted thread one and moved the signal onto its own context, but the only publisher was `createAssistantClient`, so every React-hosted client resolved nothing.

and a signal alone would not have reached the remote thread list. tap's context is a `Map` snapshotted at tap-root creation (`cloneCurrentTapContext`) and never reads React's fiber stack, while `RemoteThreadResource` is mounted from React land through `__internal_Host` rendering `useResources`. so a React-side provider is invisible to it, and its tap root inherits nothing from the host's.

## change

**`useHostDestroySignal`.** aborts from a `useInsertionEffect` cleanup, which React runs only when it deletes the fiber. a Strict Mode replay, a hidden `<Activity>` and a re-suspended boundary disconnect layout and passive effects but leave this one in place, so the signal fires on a real unmount and nothing else. the abort itself is deferred to a microtask because React forbids scheduling updates from an insertion effect and abort listeners may update surviving components. it is React-land only: under tap's dispatcher an insertion effect is a plain effect and would abort on every soft unmount.

**`AuiProvider` publishes it twice**, once per context stack. the tap side rides `useConfiguredAui`'s new optional third argument into the host's tap render and reaches the client's own scope mounts (`AISDKChat`, `AISDKThreads`, `RuntimeAdapter`). the React side is a plain `<DestroySignalContext.Provider>` around the children and reaches consumers that run as plain hooks underneath, which is the `allowNesting` case. `useAui(config)` mints one too; it has no children to wrap, so it publishes tap-side only.

**`useDestroySignalProvider` inherits on `undefined`.** a caller with no lifetime of its own no longer shadows the enclosing owner with nothing. that is what lets `RemoteThreadResource` keep passing its per-thread signal while every other host passes none.

**the remote thread list disposes on host unmount.** rather than threading a second signal through the manager into a tap root that cannot see React context, `useRemoteThreadListRuntime` wires its own insertion-effect cleanup to `RemoteThreadListThreadListRuntimeCore.__internal_dispose()`, which stops every thread runtime and therefore aborts each thread's own destroy signal from #7027. that seam existed unwired; this is the caller #7016 asked whether to write. the disposal is deferred to a microtask because it notifies subscribers.

no destroy chain, no `bindClientDestroySignal`, no `WeakMap`, and no prototype walk: each consumer resolves exactly one signal, from the nearest owner in whichever stack it lives in.

## verification

each mechanism was removed in turn against the rest of the change to confirm it is load-bearing:

- drop the tap-side signal from `AuiProvider` -> `AISDKChat React integration > aborts the in-flight transport after a real unmount` fails
- drop the React-side `<DestroySignalContext.Provider>` -> `aborts a nested runtime's stream when the host it runs under unmounts` fails
- drop the `__internal_dispose` wiring -> both `useChatRuntime` unmount cases fail

other checks:

- `useHostDestroySignal.test.tsx` pins the discriminator on react-dom 19.2.8: no abort across a Strict Mode double mount, armed through a hidden `<Activity>` and through a reveal, armed while a sibling keeps a `Suspense` boundary re-suspended, aborted on a real unmount including one that happens while hidden, and an abort listener may update a surviving component without a React warning. swapping `useInsertionEffect` for `useEffect` fails two of the four, which is the same result #6395 recorded on 19.2.3.
- `pnpm exec turbo test --continue` -> 90/90 tasks
- `pnpm lint` clean, `pnpm test:react-compiler` 11/11, `pnpm size:check` all ok and `pnpm size:update` re-recorded nothing, `check-changesets` passes

reviewer should verify: start a response in a `useChatRuntime` app and unmount the whole tree mid-stream; the request aborts. then put the same tree under `<Activity mode="hidden">`, hide it mid-stream and reveal it; it keeps streaming and the response completes.

## public surface

- `@assistant-ui/store`: `useConfiguredAui` gains an optional third `destroySignal` parameter, additive. `useHostDestroySignal` and `DestroySignalContext` stay internal to the package.
- behavior change, intended: a React host unmount is now a client destruction. the previous assertion in `AISDKChat.integration.test.tsx` protected Strict Mode and remounts, which the insertion effect handles directly. a subtree that should keep streaming while closed renders under `<Activity mode="hidden">`, which stays soft.
- `@assistant-ui/core`: no exported signature changed.
- api-surface: one changed line, regenerated. changeset: patch on the three packages. docs and api-reference: no claims to update.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.TGEKG9R6-RiMX0EDta_qDWpz-pDMh4_jLdAEOLEVNlN7v6T71u_pWoMVa2I?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->