### PR TITLE
refactor(react): compose render elements through one shared helper

### DIFF
--- a/.changeset/hip-donkeys-smash.md
+++ b/.changeset/hip-donkeys-smash.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+refactor: extract the render-element Slot composition into one helper

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -1,6 +1,6 @@
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-import { DropdownMenu, Popover } from "radix-ui";
+import { DropdownMenu, Popover, Slot } from "radix-ui";
 
 import { Primitive } from "radix-ui/internal";
 

--- a/packages/react/src/primitives/composer/ComposerAttachmentDropzone.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerAttachmentDropzone.test.tsx
@@ -74,6 +74,49 @@ describe("ComposerPrimitiveAttachmentDropzone", () => {
     vi.restoreAllMocks();
   });
 
+  it("composes a render element and keeps the drag props attached", async () => {
+    await act(async () => {
+      root.render(
+        <ComposerPrimitiveAttachmentDropzone
+          data-testid="dropzone"
+          render={<section className="child" />}
+          className="parent"
+        >
+          <div>outer</div>
+        </ComposerPrimitiveAttachmentDropzone>,
+      );
+    });
+
+    const dropzone = container.querySelector(
+      "section[data-testid='dropzone']",
+    ) as HTMLElement;
+    expect(dropzone).not.toBeNull();
+    expect(dropzone.textContent).toBe("outer");
+    expect(dropzone.className).toContain("parent");
+    expect(dropzone.className).toContain("child");
+
+    await act(async () => {
+      dropzone.dispatchEvent(createDragEvent("dragenter", ["Files"]));
+    });
+
+    expect(dropzone.getAttribute("data-dragging")).toBe("true");
+  });
+
+  it("falls back to the render element's own children", async () => {
+    await act(async () => {
+      root.render(
+        <ComposerPrimitiveAttachmentDropzone
+          data-testid="dropzone"
+          render={<section>fallback</section>}
+        />,
+      );
+    });
+
+    expect(
+      container.querySelector("section[data-testid='dropzone']")?.textContent,
+    ).toBe("fallback");
+  });
+
   it("starts all dropped attachments before awaiting completion", async () => {
     const resolvers: Array<() => void> = [];
     addAttachment.mockImplementation(

--- a/packages/react/src/primitives/composer/ComposerAttachmentDropzone.tsx
+++ b/packages/react/src/primitives/composer/ComposerAttachmentDropzone.tsx
@@ -5,7 +5,6 @@ import {
   useCallback,
   useState,
   type ReactElement,
-  cloneElement,
   isValidElement,
 } from "react";
 
@@ -13,6 +12,7 @@ import { composeEventHandlers } from "radix-ui/internal";
 import { Slot } from "radix-ui";
 import type React from "react";
 import { useAui } from "@assistant-ui/store";
+import { renderSlot } from "../../utils/Primitive";
 
 export namespace ComposerPrimitiveAttachmentDropzone {
   export type Element = HTMLDivElement;
@@ -116,15 +116,7 @@ export const ComposerPrimitiveAttachmentDropzone = forwardRef<
   };
 
   if (render && isValidElement(render)) {
-    const renderChildren =
-      children !== undefined
-        ? children
-        : (render.props as Record<string, unknown>).children;
-    return (
-      <Slot.Root {...mergedProps}>
-        {cloneElement(render, undefined, renderChildren as React.ReactNode)}
-      </Slot.Root>
-    );
+    return renderSlot(render, children, mergedProps);
   }
 
   const Comp = asChild ? Slot.Root : "div";

--- a/packages/react/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.test.tsx
@@ -240,6 +240,28 @@ describe("ComposerPrimitiveInput", () => {
     return textarea;
   };
 
+  it("composes a render element with the computed input props", async () => {
+    await act(async () => {
+      root.render(
+        <form>
+          <ComposerPrimitiveInput
+            render={<textarea data-testid="custom" className="child" />}
+            className="parent"
+          />
+        </form>,
+      );
+    });
+
+    const textarea = container.querySelector(
+      "textarea[data-testid='custom']",
+    ) as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+    expect(textarea.className).toContain("parent");
+    expect(textarea.className).toContain("child");
+    expect(textarea.name).toBe("input");
+    expect(textarea.hasAttribute("render")).toBe(false);
+  });
+
   it("syncs setText during active composition so React 19 cannot reset the textarea", async () => {
     const textarea = await mount();
 

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -12,7 +12,6 @@ import {
   useCallback,
   useEffect,
   useRef,
-  cloneElement,
   isValidElement,
 } from "react";
 import TextareaAutosize, {
@@ -22,6 +21,7 @@ import TextareaAutosize, {
 import { useEscapeKeydown } from "radix-ui/internal";
 import { useOnScrollToBottom } from "../../utils/hooks/useOnScrollToBottom";
 import { useMediaQuery } from "../../utils/hooks/useMediaQuery";
+import { renderSlot } from "../../utils/Primitive";
 import { useAui } from "@assistant-ui/store";
 import { flushTapSync } from "@assistant-ui/tap";
 import { useComposerInputPluginRegistryOptional } from "./ComposerInputPluginContext";
@@ -434,14 +434,10 @@ export const ComposerPrimitiveInput = forwardRef<
     };
 
     if (render && isValidElement(render)) {
-      const renderChildren =
-        (rest as any).children !== undefined
-          ? ((rest as any).children as ReactNode)
-          : ((render.props as Record<string, unknown>).children as ReactNode);
-      return (
-        <Slot.Root {...inputProps}>
-          {cloneElement(render, undefined, renderChildren)}
-        </Slot.Root>
+      return renderSlot(
+        render,
+        (rest as { children?: ReactNode }).children,
+        inputProps,
       );
     }
 

--- a/packages/react/src/primitives/messagePart/MessagePartText.test.tsx
+++ b/packages/react/src/primitives/messagePart/MessagePartText.test.tsx
@@ -42,15 +42,20 @@ describe("MessagePartPrimitive.Text", () => {
   });
 
   it("keeps the default span and explicit component behavior", () => {
+    const spanRef = createRef<HTMLSpanElement>();
+    const componentRef = createRef<HTMLElement>();
     render(
       <TextMessagePartProvider text="Hello">
-        <MessagePartPrimitiveText />
-        <MessagePartPrimitiveText component="p" />
+        <MessagePartPrimitiveText ref={spanRef} />
+        <MessagePartPrimitiveText component="p" ref={componentRef} />
         <MessagePartPrimitiveText component="p" render={<mark />} />
         <MessagePartPrimitiveText component="p" render={undefined} />
       </TextMessagePartProvider>,
     );
 
+    expect(spanRef.current?.tagName).toBe("SPAN");
+    expect(spanRef.current?.getAttribute("data-status")).toBe("complete");
+    expect(componentRef.current?.tagName).toBe("P");
     expect(screen.getAllByText("Hello").map((text) => text.tagName)).toEqual([
       "SPAN",
       "P",

--- a/packages/react/src/primitives/messagePart/MessagePartText.tsx
+++ b/packages/react/src/primitives/messagePart/MessagePartText.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { Primitive } from "../../utils/Primitive";
-import { Slot } from "radix-ui";
+import { Primitive, renderSlot } from "../../utils/Primitive";
 import {
-  cloneElement,
   type ComponentRef,
   forwardRef,
   type ComponentPropsWithoutRef,
@@ -62,19 +60,17 @@ export const MessagePartPrimitiveText = forwardRef<
   ) => {
     const { text, status } = useSmooth(useMessagePartText(), smooth);
 
+    const mergedProps = {
+      "data-status": status.type,
+      ...rest,
+      ref: forwardedRef,
+    };
+
     if (render && isValidElement(render)) {
-      return (
-        <Slot.Root data-status={status.type} {...rest} ref={forwardedRef}>
-          {cloneElement(render, undefined, text)}
-        </Slot.Root>
-      );
+      return renderSlot(render, text, mergedProps);
     }
 
-    return (
-      <Component data-status={status.type} {...rest} ref={forwardedRef}>
-        {text}
-      </Component>
-    );
+    return <Component {...mergedProps}>{text}</Component>;
   },
 );
 

--- a/packages/react/src/utils/Primitive.test.tsx
+++ b/packages/react/src/utils/Primitive.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import { Primitive, withRenderProp } from "./Primitive";
+import { Primitive, renderSlot, withRenderProp } from "./Primitive";
 
 const ALL_NODES = [
   "a",
@@ -101,5 +101,50 @@ describe("Primitive", () => {
       expect(html).toContain("<p>A</p>");
       expect(html).toContain("<p>B</p>");
     });
+  });
+});
+
+describe("renderSlot", () => {
+  it("lets supplied children replace the render element's own", () => {
+    expect(
+      renderToStaticMarkup(renderSlot(<em>Original</em>, "Override", {})),
+    ).toBe("<em>Override</em>");
+  });
+
+  it("falls back to the render element's own children", () => {
+    expect(
+      renderToStaticMarkup(renderSlot(<em>Fallback</em>, undefined, {})),
+    ).toBe("<em>Fallback</em>");
+  });
+
+  it("treats null children as supplied rather than absent", () => {
+    expect(renderToStaticMarkup(renderSlot(<em>Fallback</em>, null, {}))).toBe(
+      "<em></em>",
+    );
+  });
+
+  it("merges call-site props into the render element", () => {
+    const html = renderToStaticMarkup(
+      renderSlot(<em className="child" id="kept" />, "text", {
+        className: "parent",
+        id: "dropped",
+      }),
+    );
+
+    expect(html).toContain('id="kept"');
+    expect(html).toContain("parent");
+    expect(html).toContain("child");
+  });
+
+  it("applies the same precedence as withRenderProp", () => {
+    expect(
+      renderToStaticMarkup(
+        renderSlot(<em>Fallback</em>, undefined, { className: "parent" }),
+      ),
+    ).toBe(
+      renderToStaticMarkup(
+        <Primitive.span className="parent" render={<em>Fallback</em>} />,
+      ),
+    );
   });
 });

--- a/packages/react/src/utils/Primitive.tsx
+++ b/packages/react/src/utils/Primitive.tsx
@@ -1,4 +1,5 @@
 import {
+  type ComponentProps,
   type ComponentPropsWithoutRef,
   type ComponentRef,
   type ElementType,
@@ -12,6 +13,7 @@ import {
   isValidElement,
 } from "react";
 import { Primitive as RadixPrimitive } from "radix-ui/internal";
+import { Slot } from "radix-ui";
 
 /**
  * Thin wrapper around Radix `Primitive` that adds `render` prop support.
@@ -64,6 +66,39 @@ type PrimitiveRef<E extends PrimitiveNode> = ComponentRef<
   (typeof RadixPrimitive)[E]
 >;
 
+/**
+ * Composes the children of a `render` element. Outer children win when supplied;
+ * the render element's own children are the fallback.
+ */
+function composeRenderElement(
+  render: ReactElement,
+  children: ReactNode,
+): ReactElement {
+  return cloneElement(
+    render,
+    undefined,
+    children !== undefined
+      ? children
+      : (render.props as { children?: ReactNode }).children,
+  );
+}
+
+/**
+ * Composes a `render` element at a call site that has already computed its props.
+ *
+ * `withRenderProp` wraps a component; this covers the case where the props are
+ * already in hand and the composition happens inline.
+ */
+function renderSlot(
+  render: ReactElement,
+  children: ReactNode,
+  props: ComponentProps<typeof Slot.Root>,
+): ReactElement {
+  return (
+    <Slot.Root {...props}>{composeRenderElement(render, children)}</Slot.Root>
+  );
+}
+
 function withRenderProp<T extends ElementType>(Component: T) {
   const Wrapped = forwardRef<ComponentRef<T>, WithRenderPropRuntimeProps<T>>(
     (
@@ -78,14 +113,9 @@ function withRenderProp<T extends ElementType>(Component: T) {
       const Comp = Component as any;
 
       if (render && isValidElement(render)) {
-        const renderChildren =
-          children !== undefined
-            ? children
-            : ((render.props as Record<string, unknown>).children as ReactNode);
-
         return (
           <Comp {...(rest as any)} asChild ref={ref}>
-            {cloneElement(render, undefined, renderChildren)}
+            {composeRenderElement(render, children)}
           </Comp>
         );
       }
@@ -129,5 +159,5 @@ const Primitive = NODES.reduce(
   },
 );
 
-export { Primitive, withRenderProp };
+export { Primitive, renderSlot, withRenderProp };
 export type { PrimitiveProps, WithRenderPropProps };


### PR DESCRIPTION
closes #7015

## problem

the "honor a `render` element by composing it through a slot and `cloneElement`" shape had four independent copies: `withRenderProp` in `packages/react/src/utils/Primitive.tsx`, plus hand-rolled branches in `ComposerInput`, `ComposerAttachmentDropzone` and `MessagePartText`. three of them repeated the same children fallback, so each one was its own chance to drift on which children win. #6969 was that class of bug.

one correction to how #7015 frames it: `MessagePartText` never carried the fallback. its props `Omit` both `children` and `asChild`, so it always passes the resolved `text`. it shared only the `Slot.Root` plus `cloneElement` skeleton, which is why routing it through the helper is behavior-identical rather than a merge.

## root cause

`withRenderProp` is the existing generic, but it composes through the wrapped component's own `asChild`, and it wraps more than the Radix `Primitive` nodes: `popoverRenderPrimitives.ts` and `dropdownMenuRenderPrimitives.ts` pass it `PopoverPrimitive.Trigger`, `DropdownMenuPrimitive.Item` and friends, whose `asChild` carries their own `aria-expanded`, `data-state` and handlers. swapping that for a bare `Slot.Root` would drop all of it, so the wrapper is a legitimate divergence. only the children fallback is genuinely shared, and it was copied four times.

## change

`composeRenderElement` owns the fallback (supplied children win, the render element's own children are the fallback) and does the `cloneElement`. all four sites go through it, `withRenderProp` included, so the precedence rule now has exactly one definition.

`renderSlot` wraps it in `Slot.Root` for the three call sites that already computed their props. that is the case `withRenderProp` cannot serve, and it is the only new export; it stays inside `utils/Primitive`, out of the package barrel.

doing only the call-site helper that #7015 suggests would have left `withRenderProp` holding a fourth copy of the fallback, which is the thing the issue set out to remove.

`MessagePartText` hoists its props into a `mergedProps` const, matching the shape `ComposerAttachmentDropzone` already uses. this is required rather than cosmetic: passing `{ "data-status": …, ...rest, ref }` as a fresh object literal trips excess property checking against `ComponentProps<typeof Slot.Root>`, since `data-*` keys are legal in JSX but not in a typed object literal. a named const goes through ordinary assignability instead.

## verification

from `packages/react`, on `c917f5087`:

- `vitest run` over the whole package: 65 files, 581 tests passed, no type errors.
- `tsc --noEmit -p tsconfig.json`: no errors in any touched file. three pre-existing errors remain in `ComposerAddAttachment.test.tsx` and `ComposerRoot.test.tsx`, unchanged by this branch.
- `oxlint` exit 0 and `oxfmt --check` exit 0 repo-wide.
- `node packages/x-performance/bin/aui-perf.mjs size` after building the package: `@assistant-ui/react .` moves 42329 to 42295 gzip bytes (34 bytes smaller, 0.1%), inside the tolerance, so `size-budgets.json` is untouched.

new tests pin the precedence once instead of three times: supplied children replace the render element's own, `undefined` falls back to them, `null` counts as supplied (the check is `!== undefined`, not `??`), call-site props merge in, and `renderSlot` produces markup identical to `withRenderProp` for the same input.

`ComposerInput` and `ComposerAttachmentDropzone` had no test touching their `render` branch at all, so the rewrite there would have been unverified. the second commit backfills that: prop merging, children override and fallback, and the drag handlers still firing on the composed element.

the third commit covers the other branch the props hoist touched. `MessagePartText`'s existing test asserted refs only through `render`; the `component` path had none, so moving its ref from a JSX attribute into a spread had nothing checking that it still lands. it now asserts the ref, the tag and `data-status` for both the default span and an explicit `component`.

## public surface

no exported type or value changes. `renderSlot` and `composeRenderElement` live in `packages/react/src/utils/Primitive.tsx`, which the package barrel does not re-export, so there is no api-reference output to regenerate. autofix regenerated `api-surface/assistant-ui__react.ts`, and the entire diff there is one added name on an import line (`Slot` from `radix-ui`), unreferenced by any declaration in the snapshot; the generator hoists imports from the module graph rather than from the exported types.

changeset: `@assistant-ui/react` patch.
