### PR TITLE
fix(docs): tell MCP clients search_docs reads page content

### DIFF
--- a/apps/docs/app/api/mcp/route.test.ts
+++ b/apps/docs/app/api/mcp/route.test.ts
@@ -32,6 +32,7 @@ vi.mock("@/lib/source", () => {
     url: string,
     title: string,
     description: string,
+    headings: string[],
     contents: string[],
   ) => ({
     url,
@@ -39,7 +40,10 @@ vi.mock("@/lib/source", () => {
       title,
       description,
       structuredData: () => ({
-        headings: [],
+        headings: headings.map((content) => ({
+          id: content.toLowerCase(),
+          content,
+        })),
         contents: contents.map((content) => ({ content })),
       }),
     },
@@ -49,12 +53,22 @@ vi.mock("@/lib/source", () => {
     source: {
       ...makeSource(),
       getPages: vi.fn(() => [
-        docsPage("/docs/ui/thread", "Thread", "Render a conversation.", [
-          "An unrelated opening paragraph.",
-        ]),
-        docsPage("/docs/guides/keyboard", "Keyboard", "Shortcuts.", [
-          "Press the escape key to dismiss the composer autocomplete popover.",
-        ]),
+        docsPage(
+          "/docs/ui/thread",
+          "Thread",
+          "Render a conversation.",
+          [],
+          ["An unrelated opening paragraph."],
+        ),
+        docsPage(
+          "/docs/guides/keyboard",
+          "Keyboard",
+          "Shortcuts.",
+          ["Bindings"],
+          [
+            "Press the escape key to dismiss the composer autocomplete popover.",
+          ],
+        ),
       ]),
     },
     examples: makeSource(),
@@ -320,6 +334,17 @@ describe("POST /api/mcp", () => {
 
     expect(pages.map((page) => page.url)).toEqual(["/docs/guides/keyboard"]);
     expect(pages[0]?.excerpt).toContain("autocomplete popover");
+  });
+
+  it("ranks a heading-only match and returns the headings with it", async () => {
+    const response = await requestMcp("tools/call", {
+      name: "search_docs",
+      arguments: { query: "bindings" },
+    });
+    const pages = searchedPages(getToolCallResult(response));
+
+    expect(pages.map((page) => page.url)).toEqual(["/docs/guides/keyboard"]);
+    expect(pages[0]?.headings).toEqual(["Bindings"]);
   });
 
   it("still matches search_docs on page metadata", async () => {

--- a/apps/docs/app/api/mcp/route.test.ts
+++ b/apps/docs/app/api/mcp/route.test.ts
@@ -28,8 +28,35 @@ vi.mock("@/lib/source", () => {
     getPages: vi.fn(() => []),
   });
 
+  const docsPage = (
+    url: string,
+    title: string,
+    description: string,
+    contents: string[],
+  ) => ({
+    url,
+    data: {
+      title,
+      description,
+      structuredData: () => ({
+        headings: [],
+        contents: contents.map((content) => ({ content })),
+      }),
+    },
+  });
+
   return {
-    source: makeSource(),
+    source: {
+      ...makeSource(),
+      getPages: vi.fn(() => [
+        docsPage("/docs/ui/thread", "Thread", "Render a conversation.", [
+          "An unrelated opening paragraph.",
+        ]),
+        docsPage("/docs/guides/keyboard", "Keyboard", "Shortcuts.", [
+          "Press the escape key to dismiss the composer autocomplete popover.",
+        ]),
+      ]),
+    },
     examples: makeSource(),
     design: makeSource(),
     elementsDocs: makeSource(),
@@ -89,6 +116,20 @@ async function requestMcp(
 function getToolCallResult(response: JsonRpcResponse): ToolCallResult {
   expect(response.error).toBeUndefined();
   return response.result as ToolCallResult;
+}
+
+type SearchedPage = {
+  title: string;
+  url: string;
+  description?: string;
+  headings?: string[];
+  excerpt?: string;
+};
+
+function searchedPages(result: ToolCallResult): SearchedPage[] {
+  return JSON.parse(
+    result.content.find((block) => block.type === "text")?.text ?? "[]",
+  ) as SearchedPage[];
 }
 
 function registerBrowserTools(fetchImpl: FetchLike) {
@@ -231,9 +272,13 @@ describe("POST /api/mcp", () => {
     const searchTool = tools.find((tool) => tool.name === "searchDocs");
     if (!searchTool) throw new Error("missing searchDocs tool");
 
-    await expect(searchTool.execute({ query: "tools" })).resolves.toEqual({
-      content: [{ type: "text", text: "[]" }],
-    });
+    const searched = (await searchTool.execute({
+      query: "dismiss the popover",
+    })) as ToolCallResult;
+
+    const pages = searchedPages(searched);
+    expect(pages.map((page) => page.url)).toEqual(["/docs/guides/keyboard"]);
+    expect(pages[0]?.excerpt).toContain("autocomplete popover");
     expect(responseContentType).toContain("application/json");
   });
 
@@ -264,6 +309,28 @@ describe("POST /api/mcp", () => {
         inputSchemaShape(routeTool!.inputSchema),
       );
     }
+  });
+
+  it("ranks search_docs over page content, not metadata alone", async () => {
+    const response = await requestMcp("tools/call", {
+      name: "search_docs",
+      arguments: { query: "dismiss the popover" },
+    });
+    const pages = searchedPages(getToolCallResult(response));
+
+    expect(pages.map((page) => page.url)).toEqual(["/docs/guides/keyboard"]);
+    expect(pages[0]?.excerpt).toContain("autocomplete popover");
+  });
+
+  it("still matches search_docs on page metadata", async () => {
+    const response = await requestMcp("tools/call", {
+      name: "search_docs",
+      arguments: { query: "thread" },
+    });
+
+    expect(
+      searchedPages(getToolCallResult(response)).map((page) => page.url),
+    ).toEqual(["/docs/ui/thread"]);
   });
 
   it("returns the catalog-backed template list", async () => {
@@ -451,14 +518,14 @@ describe("POST /api/mcp", () => {
 
     const response = await requestMcp("tools/call", {
       name: "search_docs",
-      arguments: { query: "runtime" },
+      arguments: { query: "keyboard" },
     });
     const result = getToolCallResult(response);
 
     expect(result.isError).toBeFalsy();
-    expect(result.content.find((block) => block.type === "text")?.text).toBe(
-      "[]",
-    );
+    expect(searchedPages(result).map((page) => page.url)).toEqual([
+      "/docs/guides/keyboard",
+    ]);
   });
 
   it("surfaces a throttled template tool without reaching the sandbox", async () => {

--- a/apps/docs/app/api/mcp/route.test.ts
+++ b/apps/docs/app/api/mcp/route.test.ts
@@ -347,15 +347,15 @@ describe("POST /api/mcp", () => {
     expect(pages[0]?.headings).toEqual(["Bindings"]);
   });
 
-  it("still matches search_docs on page metadata", async () => {
+  it("falls back to the opening paragraph when only metadata matched", async () => {
     const response = await requestMcp("tools/call", {
       name: "search_docs",
       arguments: { query: "thread" },
     });
+    const pages = searchedPages(getToolCallResult(response));
 
-    expect(
-      searchedPages(getToolCallResult(response)).map((page) => page.url),
-    ).toEqual(["/docs/ui/thread"]);
+    expect(pages.map((page) => page.url)).toEqual(["/docs/ui/thread"]);
+    expect(pages[0]?.excerpt).toBe("An unrelated opening paragraph.");
   });
 
   it("returns the catalog-backed template list", async () => {

--- a/apps/docs/content/docs/(getting-started)/llm.mdx
+++ b/apps/docs/content/docs/(getting-started)/llm.mdx
@@ -194,7 +194,7 @@ Restart Claude Desktop after updating the configuration.
 |------|-------------|
 | `list_pages` | List documentation pages, optionally filtered by a path prefix such as `/docs/tools` or `/examples` |
 | `get_navigation` | Return the docs navigation tree |
-| `search_docs` | Search docs, examples, design components, elements, and Tap docs over page content as well as metadata, with a matching excerpt per result |
+| `search_docs` | Search docs, examples, design components, elements, and Tap docs over page content as well as metadata, with an excerpt per result that has body prose |
 | `read_page` | Read one page as markdown by slug, path, or URL |
 | `list_templates` | List the hosted app templates and fixed demos |
 | `read_template` | Get a template's full authoring surface: config schemas, rules, and an example config |

--- a/apps/docs/content/docs/(getting-started)/llm.mdx
+++ b/apps/docs/content/docs/(getting-started)/llm.mdx
@@ -194,7 +194,7 @@ Restart Claude Desktop after updating the configuration.
 |------|-------------|
 | `list_pages` | List documentation pages, optionally filtered by a path prefix such as `/docs/tools` or `/examples` |
 | `get_navigation` | Return the docs navigation tree |
-| `search_docs` | Search docs, examples, design components, and Tap docs |
+| `search_docs` | Search docs, examples, design components, elements, and Tap docs over page content as well as metadata, with a matching excerpt per result |
 | `read_page` | Read one page as markdown by slug, path, or URL |
 | `list_templates` | List the hosted app templates and fixed demos |
 | `read_template` | Get a template's full authoring surface: config schemas, rules, and an example config |

--- a/apps/docs/lib/ai/search-docs.test.ts
+++ b/apps/docs/lib/ai/search-docs.test.ts
@@ -20,15 +20,6 @@ const mocks = vi.hoisted(() => ({
       headings: [{ id: "thread-list", content: "Thread List" }],
       contents: ["Wire an external store into the runtime."],
     },
-    {
-      url: "/docs/guides/keyboard",
-      title: "Keyboard",
-      description: "Shortcuts.",
-      headings: [],
-      contents: [
-        "Press the escape key to dismiss the composer autocomplete popover.",
-      ],
-    },
   ] satisfies ContentRecord[],
 }));
 
@@ -36,72 +27,7 @@ vi.mock("@/lib/search/content-index", () => ({
   buildContentIndex: () => Promise.resolve(mocks.records),
 }));
 
-import { searchContent } from "@/lib/search/content-search";
 import { createSearchDocsTool } from "./search-docs";
-
-describe("searchContent", () => {
-  it("ranks a title match above a heading-only match", () => {
-    expect(
-      searchContent(mocks.records, "thread list", 5).map((page) => page.url),
-    ).toEqual(["/docs/ui/thread-list", "/docs/runtimes/custom"]);
-  });
-
-  it("finds a page whose terms appear only in its body", () => {
-    expect(
-      searchContent(mocks.records, "dismiss the popover", 5).map(
-        (page) => page.url,
-      ),
-    ).toEqual(["/docs/guides/keyboard"]);
-  });
-
-  it("excerpts the paragraphs that matched", () => {
-    expect(searchContent(mocks.records, "thread list", 1)[0]?.excerpt).toBe(
-      "Render the thread list beside your thread.",
-    );
-  });
-
-  it("ignores filler words in a natural-language question", () => {
-    expect(
-      searchContent(mocks.records, "how do I render a thread list", 5).map(
-        (page) => page.url,
-      ),
-    ).toEqual(["/docs/ui/thread-list"]);
-  });
-
-  it("falls back to the pages each term finds when no page has them all", () => {
-    expect(
-      searchContent(mocks.records, "thread list keyboard escape", 5).map(
-        (page) => page.url,
-      ),
-    ).toEqual([
-      "/docs/ui/thread-list",
-      "/docs/runtimes/custom",
-      "/docs/guides/keyboard",
-    ]);
-  });
-
-  it("matches a term that appears only in the url", () => {
-    expect(
-      searchContent(mocks.records, "runtimes custom", 5).map(
-        (page) => page.url,
-      ),
-    ).toEqual(["/docs/runtimes/custom"]);
-  });
-
-  it("still returns an excerpt for a page matched on metadata alone", () => {
-    expect(searchContent(mocks.records, "keyboard", 1)[0]?.excerpt).toBe(
-      "Press the escape key to dismiss the composer autocomplete popover.",
-    );
-  });
-
-  it("caps results at the limit", () => {
-    expect(searchContent(mocks.records, "thread", 1)).toHaveLength(1);
-  });
-
-  it("returns nothing for a query of only filler", () => {
-    expect(searchContent(mocks.records, "   ", 5)).toEqual([]);
-  });
-});
 
 describe("createSearchDocsTool", () => {
   it("writes one absolute source part per returned page", async () => {

--- a/apps/docs/lib/mcp-tool-definitions.ts
+++ b/apps/docs/lib/mcp-tool-definitions.ts
@@ -39,7 +39,7 @@ export const docsToolDefinitions = [
   {
     name: "search_docs",
     description:
-      "Search assistant-ui docs, examples, design components, elements, and Tap docs. Ranks each page over its title, headings, URL, description, and body text, and returns the paragraphs that matched as an excerpt.",
+      "Search assistant-ui docs, examples, design components, elements, and Tap docs. Ranks each page over its title, headings, URL, description, and body text, and excerpts the paragraphs that matched, falling back to the page's opening paragraph when only its metadata matched.",
     inputSchema: searchDocsInputSchema,
   },
   {

--- a/apps/docs/lib/mcp-tool-definitions.ts
+++ b/apps/docs/lib/mcp-tool-definitions.ts
@@ -3,7 +3,11 @@ export const SEARCH_DOCS_RESULT_LIMIT = 20;
 export const searchDocsInputSchema = {
   type: "object",
   properties: {
-    query: { type: "string", description: "Search query." },
+    query: {
+      type: "string",
+      description:
+        "A short phrase of distinctive documentation terms, with filler words omitted.",
+    },
   },
   required: ["query"],
   additionalProperties: false,
@@ -35,7 +39,7 @@ export const docsToolDefinitions = [
   {
     name: "search_docs",
     description:
-      "Search assistant-ui docs, examples, design components, elements, and Tap docs by title, description, or URL.",
+      "Search assistant-ui docs, examples, design components, elements, and Tap docs. Ranks each page over its title, headings, URL, description, and body text, and returns the paragraphs that matched as an excerpt.",
     inputSchema: searchDocsInputSchema,
   },
   {

--- a/apps/docs/lib/search/content-search.test.ts
+++ b/apps/docs/lib/search/content-search.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { searchContent, type ContentRecord } from "./content-search";
+
+const records: ContentRecord[] = [
+  {
+    url: "/docs/ui/thread-list",
+    title: "Thread List",
+    description: "Render and manage conversation history.",
+    headings: [{ id: "usage", content: "Usage" }],
+    contents: [
+      "An unrelated opening paragraph.",
+      "Render the thread list beside your thread.",
+    ],
+  },
+  {
+    url: "/docs/runtimes/custom",
+    title: "Custom Runtime",
+    description: "Connect an external store.",
+    headings: [{ id: "thread-list", content: "Thread List" }],
+    contents: ["Wire an external store into the runtime."],
+  },
+  {
+    url: "/docs/guides/keyboard",
+    title: "Keyboard",
+    description: "Shortcuts.",
+    headings: [],
+    contents: [
+      "Press the escape key to dismiss the composer autocomplete popover.",
+    ],
+  },
+];
+
+describe("searchContent", () => {
+  it("ranks a title match above a heading-only match", () => {
+    expect(
+      searchContent(records, "thread list", 5).map((page) => page.url),
+    ).toEqual(["/docs/ui/thread-list", "/docs/runtimes/custom"]);
+  });
+
+  it("finds a page whose terms appear only in its body", () => {
+    expect(
+      searchContent(records, "dismiss the popover", 5).map((page) => page.url),
+    ).toEqual(["/docs/guides/keyboard"]);
+  });
+
+  it("excerpts the paragraphs that matched", () => {
+    expect(searchContent(records, "thread list", 1)[0]?.excerpt).toBe(
+      "Render the thread list beside your thread.",
+    );
+  });
+
+  it("ignores filler words in a natural-language question", () => {
+    expect(
+      searchContent(records, "how do I render a thread list", 5).map(
+        (page) => page.url,
+      ),
+    ).toEqual(["/docs/ui/thread-list"]);
+  });
+
+  it("falls back to the pages each term finds when no page has them all", () => {
+    expect(
+      searchContent(records, "thread list keyboard escape", 5).map(
+        (page) => page.url,
+      ),
+    ).toEqual([
+      "/docs/ui/thread-list",
+      "/docs/runtimes/custom",
+      "/docs/guides/keyboard",
+    ]);
+  });
+
+  it("matches a term that appears only in the url", () => {
+    expect(
+      searchContent(records, "runtimes custom", 5).map((page) => page.url),
+    ).toEqual(["/docs/runtimes/custom"]);
+  });
+
+  it("still returns an excerpt for a page matched on metadata alone", () => {
+    expect(searchContent(records, "keyboard", 1)[0]?.excerpt).toBe(
+      "Press the escape key to dismiss the composer autocomplete popover.",
+    );
+  });
+
+  it("caps results at the limit", () => {
+    expect(searchContent(records, "thread", 1)).toHaveLength(1);
+  });
+
+  it("returns nothing for a query of only filler", () => {
+    expect(searchContent(records, "   ", 5)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

`search_docs` tells every MCP client it matches "by title, description, or URL". That was true when #6721 was filed, but #6807 replaced the substring filter with `searchContent` over `buildContentIndex()`, so the tool now ranks title, headings, URL, description and body text and returns the matching paragraphs as an excerpt. The description was never swept, and the browser-facing `searchDocs` (WebMCP, #6467) interpolates the same string, so both surfaces still advertise a metadata-only search and never mention the `headings` and `excerpt` they return.

The recall itself was also only covered at the unit level. `route.test.ts` mocks `@/lib/source` with an empty `getPages()`, so every `search_docs` assertion in it was `[]`; pointing `searchDocs()` back at the old `pageSummary` filter kept the whole suite green.

## Root cause

#6807 changed the implementation and the demo tool. `apps/docs/lib/mcp-tool-definitions.ts` was outside its diff, and it is the file that carries the model-facing contract for the route and the browser tool alike.

## Change

- `search_docs` now describes what it does: ranks each page over title, headings, URL, description and body text, and returns the paragraphs that matched as an excerpt.
- the `query` hint matches the one the landing-page demo already uses ("a short phrase of distinctive documentation terms, with filler words omitted"). that guidance is load-bearing here: `rank()` requires every non-stop-word token on one page before the per-token fallback applies.
- `route.test.ts` gets a real two-page corpus with `structuredData()`, plus a body-only query case at the route and at the WebMCP adapter. the metering tests keep their concern and now assert against that corpus instead of `[]`.
- the `searchContent` tests move from `lib/ai/search-docs.test.ts` to `lib/search/content-search.test.ts`, beside the module they exercise. `search-docs.test.ts` keeps the `createSearchDocsTool` case.
- the tool table in `llm.mdx` picks up `elements` and the content search.

No behavior change: `route.ts` is untouched.

## Verification

- `vitest run app/api/mcp/route.test.ts lib/search lib/ai` in `apps/docs`: 68 passed.
- reproduction: swapping `searchDocs()` in `route.ts` back to the pre-#6807 metadata filter fails exactly the two new cases ("ranks search_docs over page content, not metadata alone" and "executes the WebMCP adapter through the route transport", both `expected [] to deeply equal [ '/docs/guides/keyboard' ]`). restoring the current implementation passes them.
- `oxlint` and `oxfmt --check` clean at the repo root.
- `tsc --noEmit` for `apps/docs` reports nothing in the touched files (a worktree without built package dists reports the usual `TS2307` cascade for every workspace import).

Closes #6721.

## Public surface

None. `@assistant-ui/docs` is private, so no changeset. The `search_docs` tool description and query hint change is what MCP clients and the WebMCP `searchDocs` tool see.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.kizjwgMWpmeyUaBbUIWdL-pHe-9KXgD7Jf7hXfCyEsE6WN87qIW_hhqoIL4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->