### PR TITLE
test(docs): stop charging provider module loading to the test timeout

### DIFF
--- a/apps/docs/runtimes/claim-reload.test.tsx
+++ b/apps/docs/runtimes/claim-reload.test.tsx
@@ -2,6 +2,9 @@
 
 import { afterEach, expect, it, vi } from "vitest";
 import { render } from "@testing-library/react";
+import { DocsRuntimeProvider } from "./docs";
+import { ArtifactsRuntimeProvider } from "./artifacts";
+import { InteractableRuntimeProvider } from "./interactable";
 
 const reload = vi.hoisted(() => vi.fn(() => Promise.resolve()));
 const useDocsChatRuntime = vi.hoisted(() =>
@@ -44,19 +47,12 @@ afterEach(() => {
 });
 
 it.each([
-  ["docs", () => import("./docs").then((m) => m.DocsRuntimeProvider)],
-  [
-    "artifacts",
-    () => import("./artifacts").then((m) => m.ArtifactsRuntimeProvider),
-  ],
-  [
-    "interactable sample",
-    () => import("./interactable").then((m) => m.InteractableRuntimeProvider),
-  ],
+  ["docs", DocsRuntimeProvider],
+  ["artifacts", ArtifactsRuntimeProvider],
+  ["interactable sample", InteractableRuntimeProvider],
 ])(
   "reloads the %s runtime's thread list only after a claim moved threads",
-  async (_name, load) => {
-    const Provider = await load();
+  (_name, Provider) => {
     const { rerender } = render(<Provider>{null}</Provider>);
 
     expect(reload).not.toHaveBeenCalled();

--- a/apps/docs/runtimes/providers.test.tsx
+++ b/apps/docs/runtimes/providers.test.tsx
@@ -4,6 +4,11 @@ import {
   CloudFileAttachmentAdapter,
   SimpleImageAttachmentAdapter,
 } from "@assistant-ui/react";
+import { DocsRuntimeProvider } from "./docs";
+import { ArtifactsRuntimeProvider } from "./artifacts";
+import { InteractableRuntimeProvider } from "./interactable";
+import { DocsAssistantRuntimeProvider } from "./docs-assistant";
+import { PlaygroundRuntimeProvider } from "./playground";
 
 const useDocsChatRuntime = vi.hoisted(() => vi.fn(() => ({}) as never));
 const useSpeechAdapters = vi.hoisted(() => vi.fn(() => ({ speech: "speech" })));
@@ -48,9 +53,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-it("wires the docs surface with a cloud, dictation and cloud attachments", async () => {
-  const { DocsRuntimeProvider } = await import("./docs");
-
+it("wires the docs surface with a cloud, dictation and cloud attachments", () => {
   renderToString(<DocsRuntimeProvider>{null}</DocsRuntimeProvider>);
 
   expect(useSpeechAdapters).toHaveBeenCalledWith({ dictation: true });
@@ -63,9 +66,7 @@ it("wires the docs surface with a cloud, dictation and cloud attachments", async
   expect(runtimeOptions().adapters?.feedback).toBeDefined();
 });
 
-it("wires the artifacts surface with a cloud and dictation but no feedback", async () => {
-  const { ArtifactsRuntimeProvider } = await import("./artifacts");
-
+it("wires the artifacts surface with a cloud and dictation but no feedback", () => {
   renderToString(<ArtifactsRuntimeProvider>{null}</ArtifactsRuntimeProvider>);
 
   expect(useSpeechAdapters).toHaveBeenCalledWith({ dictation: true });
@@ -74,9 +75,7 @@ it("wires the artifacts surface with a cloud and dictation but no feedback", asy
   expect(runtimeOptions().adapters?.feedback).toBeUndefined();
 });
 
-it("wires the interactable sample with a cloud and image attachments", async () => {
-  const { InteractableRuntimeProvider } = await import("./interactable");
-
+it("wires the interactable sample with a cloud and image attachments", () => {
   renderToString(
     <InteractableRuntimeProvider>{null}</InteractableRuntimeProvider>,
   );
@@ -91,9 +90,7 @@ it("wires the interactable sample with a cloud and image attachments", async () 
   expect(useSpeechAdapters).not.toHaveBeenCalled();
 });
 
-it("wires the docs assistant onto its own endpoint with no cloud", async () => {
-  const { DocsAssistantRuntimeProvider } = await import("./docs-assistant");
-
+it("wires the docs assistant onto its own endpoint with no cloud", () => {
   renderToString(
     <DocsAssistantRuntimeProvider>{null}</DocsAssistantRuntimeProvider>,
   );
@@ -107,9 +104,7 @@ it("wires the docs assistant onto its own endpoint with no cloud", async () => {
   expect(useSpeechAdapters).not.toHaveBeenCalled();
 });
 
-it("leaves the playground without a cloud or automatic sending", async () => {
-  const { PlaygroundRuntimeProvider } = await import("./playground");
-
+it("leaves the playground without a cloud or automatic sending", () => {
   renderToString(<PlaygroundRuntimeProvider>{null}</PlaygroundRuntimeProvider>);
 
   expect(useSpeechAdapters).toHaveBeenCalledWith();


### PR DESCRIPTION
closes #6754

## Problem

`apps/docs` tests intermittently fail the full `pnpm -C apps/docs vitest run` with `Test timed out in 5000ms`, and pass when the file is run alone. the failing file moves between runs depending on scheduling, which is the signature of a margin rather than a defect.

reproduced on `main` at bb099f622: `runtimes/claim-reload.test.tsx` spends **4109ms** on its first test against vitest's 5000ms per-test default, an 18% margin that any parallel load closes.

## Root cause

both `runtimes/claim-reload.test.tsx` and `runtimes/providers.test.tsx` loaded the runtime providers with `await import()` from inside a test body. that pulls the whole provider module graph (the `@assistant-ui/react` barrel, `@assistant-ui/ai-sdk`, the provider tree) through vite's transform while the per-test timer is already running, so the cold load is charged to the timeout budget. collection-phase imports are not bounded by `testTimeout`; test-body imports are.

vitest's transform cache is shared across workers, so only the file that gets there first pays. the two files load the same five modules, and whichever loses the race takes the 4s. that is why #6754 saw the failure hop between files.

it is not config assembly, which is what the issue guessed. the same pattern lived in `runtimes/chat-runtime.test.ts` when the issue was filed; #6843 rewrote that file to static imports and incidentally fixed it (its slowest test is now 107ms).

## Change

hoist the dynamic imports to static top-level imports in both files. `vi.mock` is hoisted above imports, so the mocks still apply, and neither file calls `vi.resetModules()`, so nothing depended on a fresh module. `providers.test.tsx` loses the now-pointless `async` on its five `it` callbacks, and `claim-reload.test.tsx` passes components through `it.each` instead of loader functions.

## Verification

isolated A/B on `claim-reload.test.tsx`, same warm cache:

| | first test | vitest breakdown |
|---|---|---|
| before | 1045ms | `tests 1.09s / import 54ms` |
| after | 6ms | `tests 8ms / import 944ms` |

the cost does not vanish, it moves out of the timeout budget and into collection.

full `apps/docs` suite, three consecutive runs: 766 tests, 0 failed. slowest single test **4109ms -> 1021ms / 1878ms / 2010ms**, now `scripts/generated-docs/workspace-resolution.test.ts`; `claim-reload` and `providers` drop off the list entirely.

also `tsc --noEmit -p apps/docs/tsconfig.json` clean on both files, `oxlint apps/docs/runtimes/` exit 0, `oxfmt --check` clean.

## Public surface

none. `@assistant-ui/docs` is private, so no changeset.

## Notes

`workspace-resolution.test.ts` is now the slowest test in the suite at 1 to 2s, and #6754 names it too. its cost is the ts-morph pass over every workspace import, which is the assertion itself rather than cold loading, so the mechanism this PR fixes does not apply to it. i tried hoisting its `getProject()` into a `beforeAll` and dropped it: measured over two runs each, that moves ~500ms off the smaller of the two tests and nothing off the binding one, so it does not earn a place in the diff. tracking stays on #6754.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.eUd3kAbvxDypBdNJ3C_DKTmklNKxmjUGm1bzzYnDM7vzmxfmwhgLf68mKcI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->