### PR TITLE
perf(docs): read only the referenced files from the repo source tree

### DIFF
--- a/apps/docs/lib/repo-source.test.ts
+++ b/apps/docs/lib/repo-source.test.ts
@@ -124,6 +124,23 @@ describe("createRepoSourceReader", () => {
     ).resolves.toEqual({});
   });
 
+  it("bounds a named batch the same way a subtree read is bounded", async () => {
+    const files = Object.fromEntries(
+      Array.from({ length: 200 }, (_, index) => [
+        `packages/p${index % 20}/file-${index}.ts`,
+        `export const n = ${index};\n`,
+      ]),
+    );
+    const root = await createSourceTree(files);
+
+    const contents = await createRepoSourceReader(root).readFiles(
+      Object.keys(files),
+    );
+
+    expect(contents).toEqual(Object.keys(files).map((key) => files[key]));
+    expect(reads.peak).toBeLessThanOrEqual(32);
+  });
+
   it("bounds concurrent reads so a large subtree cannot exhaust file descriptors", async () => {
     const files = Object.fromEntries(
       Array.from({ length: 400 }, (_, index) => [
@@ -141,12 +158,14 @@ describe("createRepoSourceReader", () => {
 });
 
 describe("snapshotSourceReader", () => {
+  const snapshot = {
+    "AGENTS.md": "# assistant-ui\n",
+    "packages/core/src/index.ts": "export const a = 1;\n",
+    "packages/core-other/secret.ts": "not part of the package\n",
+  };
+
   it("serves named entries and prefix reads from a literal map", async () => {
-    const reader = snapshotSourceReader({
-      "AGENTS.md": "# assistant-ui\n",
-      "packages/core/src/index.ts": "export const a = 1;\n",
-      "packages/core-other/secret.ts": "not part of the package\n",
-    });
+    const reader = snapshotSourceReader(snapshot);
 
     await expect(reader.readFile("AGENTS.md")).resolves.toBe(
       "# assistant-ui\n",
@@ -154,8 +173,39 @@ describe("snapshotSourceReader", () => {
     await expect(
       reader.readFile("packages/absent.ts"),
     ).resolves.toBeUndefined();
+    await expect(
+      reader.readFiles(["AGENTS.md", "packages/absent.ts"]),
+    ).resolves.toEqual(["# assistant-ui\n", undefined]);
     await expect(reader.readUnder("packages/core")).resolves.toEqual({
       "src/index.ts": "export const a = 1;\n",
     });
+  });
+
+  it("resolves an equivalent prefix to the same subtree as the disk reader", async () => {
+    const root = await createSourceTree(snapshot);
+
+    for (const prefix of [
+      "packages/core",
+      "packages/core/",
+      "./packages/core",
+    ]) {
+      await expect(
+        snapshotSourceReader(snapshot).readUnder(prefix),
+      ).resolves.toEqual(await createRepoSourceReader(root).readUnder(prefix));
+    }
+  });
+
+  it("keeps a snapshot key that climbs out of the prefix out of the result", async () => {
+    const reader = snapshotSourceReader({
+      ...snapshot,
+      "packages/core/../escaped.ts": "outside the package\n",
+    });
+
+    await expect(reader.readUnder("packages/core")).resolves.toEqual({
+      "src/index.ts": "export const a = 1;\n",
+    });
+    await expect(reader.readFile("../../etc/passwd")).rejects.toThrow(
+      /Unsafe repo source path/,
+    );
   });
 });

--- a/apps/docs/lib/repo-source.test.ts
+++ b/apps/docs/lib/repo-source.test.ts
@@ -2,9 +2,17 @@ import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadRepoSourceSnapshot, repoSourceRoot } from "./repo-source";
+import {
+  createRepoSourceReader,
+  repoSourceRoot,
+  snapshotSourceReader,
+} from "./repo-source";
 
-const reads = vi.hoisted(() => ({ inFlight: 0, peak: 0 }));
+const reads = vi.hoisted(() => ({
+  inFlight: 0,
+  peak: 0,
+  paths: [] as string[],
+}));
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
@@ -13,6 +21,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     readFile: async (...args: Parameters<typeof actual.readFile>) => {
       reads.inFlight += 1;
       reads.peak = Math.max(reads.peak, reads.inFlight);
+      reads.paths.push(String(args[0]));
       try {
         return await actual.readFile(...args);
       } finally {
@@ -40,6 +49,7 @@ async function createSourceTree(files: Record<string, string>) {
 beforeEach(() => {
   reads.inFlight = 0;
   reads.peak = 0;
+  reads.paths = [];
 });
 
 afterEach(async () => {
@@ -56,28 +66,65 @@ describe("repoSourceRoot", () => {
   });
 });
 
-describe("loadRepoSourceSnapshot", () => {
-  it("keys nested files by their posix path relative to the root", async () => {
+describe("createRepoSourceReader", () => {
+  it("reads one named file as utf-8 without touching the rest of the tree", async () => {
+    const root = await createSourceTree({
+      "AGENTS.md": "🙂 assistant-ui\n",
+      "packages/core/src/index.ts": "export const a = 1;\n",
+    });
+
+    await expect(
+      createRepoSourceReader(root).readFile("AGENTS.md"),
+    ).resolves.toBe("🙂 assistant-ui\n");
+    expect(reads.paths).toEqual([path.join(root, "AGENTS.md")]);
+  });
+
+  it("resolves a missing file to undefined so callers keep their own error", async () => {
+    const root = await createSourceTree({ "AGENTS.md": "# assistant-ui\n" });
+
+    await expect(
+      createRepoSourceReader(root).readFile("packages/core/package.json"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a path that climbs out of the tree", async () => {
+    const root = await createSourceTree({ "AGENTS.md": "# assistant-ui\n" });
+
+    await expect(
+      createRepoSourceReader(root).readFile("../../etc/passwd"),
+    ).rejects.toThrow(/Unsafe repo source path/);
+  });
+
+  it("keys a prefix read by its path relative to that prefix", async () => {
     const root = await createSourceTree({
       "AGENTS.md": "# assistant-ui\n",
       "packages/core/src/index.ts": "export const a = 1;\n",
+      "packages/core/package.json": "{}\n",
+      "packages/core-other/secret.ts": "not part of the package\n",
     });
 
-    await expect(loadRepoSourceSnapshot(root)).resolves.toEqual({
-      "AGENTS.md": "# assistant-ui\n",
-      "packages/core/src/index.ts": "export const a = 1;\n",
-    });
-  });
-
-  it("reads contents as utf-8", async () => {
-    const root = await createSourceTree({ "emoji.md": "🙂 ok\n" });
-
-    await expect(loadRepoSourceSnapshot(root)).resolves.toEqual({
-      "emoji.md": "🙂 ok\n",
+    await expect(
+      createRepoSourceReader(root).readUnder("packages/core"),
+    ).resolves.toEqual({
+      "package.json": "{}\n",
+      "src/index.ts": "export const a = 1;\n",
     });
   });
 
-  it("bounds concurrent reads so a large tree cannot exhaust file descriptors", async () => {
+  it("resolves a missing prefix to an empty map", async () => {
+    const root = await createSourceTree({ "AGENTS.md": "# assistant-ui\n" });
+
+    await expect(
+      createRepoSourceReader(root).readUnder("packages/absent"),
+    ).resolves.toEqual({});
+    await expect(
+      createRepoSourceReader(
+        path.join(tmpdir(), "repo-source-absent"),
+      ).readUnder("packages"),
+    ).resolves.toEqual({});
+  });
+
+  it("bounds concurrent reads so a large subtree cannot exhaust file descriptors", async () => {
     const files = Object.fromEntries(
       Array.from({ length: 400 }, (_, index) => [
         `packages/p${index % 20}/file-${index}.ts`,
@@ -86,15 +133,29 @@ describe("loadRepoSourceSnapshot", () => {
     );
     const root = await createSourceTree(files);
 
-    const snapshot = await loadRepoSourceSnapshot(root);
+    const read = await createRepoSourceReader(root).readUnder("packages");
 
-    expect(Object.keys(snapshot)).toHaveLength(400);
+    expect(Object.keys(read)).toHaveLength(400);
     expect(reads.peak).toBeLessThanOrEqual(32);
   });
+});
 
-  it("rejects when the tree is missing", async () => {
+describe("snapshotSourceReader", () => {
+  it("serves named entries and prefix reads from a literal map", async () => {
+    const reader = snapshotSourceReader({
+      "AGENTS.md": "# assistant-ui\n",
+      "packages/core/src/index.ts": "export const a = 1;\n",
+      "packages/core-other/secret.ts": "not part of the package\n",
+    });
+
+    await expect(reader.readFile("AGENTS.md")).resolves.toBe(
+      "# assistant-ui\n",
+    );
     await expect(
-      loadRepoSourceSnapshot(path.join(tmpdir(), "repo-source-absent")),
-    ).rejects.toThrow(/ENOENT/);
+      reader.readFile("packages/absent.ts"),
+    ).resolves.toBeUndefined();
+    await expect(reader.readUnder("packages/core")).resolves.toEqual({
+      "src/index.ts": "export const a = 1;\n",
+    });
   });
 });

--- a/apps/docs/lib/repo-source.ts
+++ b/apps/docs/lib/repo-source.ts
@@ -3,6 +3,15 @@ import path from "node:path";
 
 export type RepoSourceSnapshot = Record<string, string>;
 
+/**
+ * Callers name the files they want rather than materializing the tree, so a
+ * request costs the entries it references instead of every tracked file.
+ */
+export type RepoSourceReader = {
+  readFile(filePath: string): Promise<string | undefined>;
+  readUnder(prefix: string): Promise<Record<string, string>>;
+};
+
 // Matches the generator's bound. Reading the tree unbounded keeps a descriptor
 // open per file and exhausts a 1024 descriptor limit well before the tree ends.
 const READ_CONCURRENCY = 32;
@@ -14,30 +23,103 @@ export function repoSourceRoot() {
   return path.join(process.cwd(), "generated", ".repo-source");
 }
 
-export async function loadRepoSourceSnapshot(
+export function createRepoSourceReader(
   sourceRoot = repoSourceRoot(),
-): Promise<RepoSourceSnapshot> {
-  const filePaths = await listFiles(sourceRoot);
-  const snapshot: RepoSourceSnapshot = {};
-  let index = 0;
+): RepoSourceReader {
+  return {
+    async readFile(filePath) {
+      try {
+        return await readFile(resolveWithin(sourceRoot, filePath), "utf-8");
+      } catch (error) {
+        if (isMissing(error)) return undefined;
+        throw error;
+      }
+    },
 
-  async function worker() {
-    while (index < filePaths.length) {
-      const relativePath = filePaths[index++]!;
-      snapshot[relativePath] = await readFile(
-        path.join(sourceRoot, relativePath),
-        "utf-8",
+    async readUnder(prefix) {
+      const directory = resolveWithin(sourceRoot, prefix);
+      let relativePaths: string[];
+
+      try {
+        relativePaths = await listFiles(directory);
+      } catch (error) {
+        if (isMissing(error)) return {};
+        throw error;
+      }
+
+      const files: Record<string, string> = {};
+      let index = 0;
+
+      async function worker() {
+        while (index < relativePaths.length) {
+          const relativePath = relativePaths[index++]!;
+          files[relativePath] = await readFile(
+            path.join(directory, relativePath),
+            "utf-8",
+          );
+        }
+      }
+
+      await Promise.all(
+        Array.from(
+          { length: Math.min(READ_CONCURRENCY, relativePaths.length) },
+          () => worker(),
+        ),
       );
-    }
+
+      return files;
+    },
+  };
+}
+
+export function snapshotSourceReader(
+  snapshot: RepoSourceSnapshot,
+): RepoSourceReader {
+  return {
+    async readFile(filePath) {
+      return snapshot[filePath];
+    },
+
+    async readUnder(prefix) {
+      const sourcePrefix = `${prefix}/`;
+      const files: Record<string, string> = {};
+
+      for (const snapshotPath of Object.keys(snapshot)) {
+        if (!snapshotPath.startsWith(sourcePrefix)) continue;
+        const relativePath = snapshotPath.slice(sourcePrefix.length);
+        if (!relativePath) continue;
+        files[relativePath] = snapshot[snapshotPath]!;
+      }
+
+      return files;
+    },
+  };
+}
+
+// The tree mirrors the monorepo on disk, so a path that climbs out of it would
+// read the deployment rather than the snapshot.
+function resolveWithin(sourceRoot: string, relativePath: string) {
+  const normalized = path.posix.normalize(relativePath.replaceAll("\\", "/"));
+
+  if (
+    !relativePath ||
+    normalized.startsWith("/") ||
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../")
+  ) {
+    throw new Error(`Unsafe repo source path: ${relativePath}`);
   }
 
-  await Promise.all(
-    Array.from({ length: Math.min(READ_CONCURRENCY, filePaths.length) }, () =>
-      worker(),
-    ),
-  );
+  return path.join(sourceRoot, normalized);
+}
 
-  return snapshot;
+function isMissing(error: unknown) {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
 }
 
 // Level by level rather than depth first: a recursive walk serializes every

--- a/apps/docs/lib/repo-source.ts
+++ b/apps/docs/lib/repo-source.ts
@@ -9,6 +9,7 @@ export type RepoSourceSnapshot = Record<string, string>;
  */
 export type RepoSourceReader = {
   readFile(filePath: string): Promise<string | undefined>;
+  readFiles(filePaths: readonly string[]): Promise<(string | undefined)[]>;
   readUnder(prefix: string): Promise<Record<string, string>>;
 };
 
@@ -26,7 +27,7 @@ export function repoSourceRoot() {
 export function createRepoSourceReader(
   sourceRoot = repoSourceRoot(),
 ): RepoSourceReader {
-  return {
+  const reader: RepoSourceReader = {
     async readFile(filePath) {
       try {
         return await readFile(resolveWithin(sourceRoot, filePath), "utf-8");
@@ -34,6 +35,10 @@ export function createRepoSourceReader(
         if (isMissing(error)) return undefined;
         throw error;
       }
+    },
+
+    async readFiles(filePaths) {
+      return mapBounded(filePaths, (filePath) => reader.readFile(filePath));
     },
 
     async readUnder(prefix) {
@@ -47,62 +52,86 @@ export function createRepoSourceReader(
         throw error;
       }
 
-      const files: Record<string, string> = {};
-      let index = 0;
-
-      async function worker() {
-        while (index < relativePaths.length) {
-          const relativePath = relativePaths[index++]!;
-          files[relativePath] = await readFile(
-            path.join(directory, relativePath),
-            "utf-8",
-          );
-        }
-      }
-
-      await Promise.all(
-        Array.from(
-          { length: Math.min(READ_CONCURRENCY, relativePaths.length) },
-          () => worker(),
-        ),
+      const contents = await mapBounded(relativePaths, (relativePath) =>
+        readFile(path.join(directory, relativePath), "utf-8"),
       );
+      const files: Record<string, string> = {};
+
+      relativePaths.forEach((relativePath, index) => {
+        files[relativePath] = contents[index]!;
+      });
 
       return files;
     },
   };
+
+  return reader;
 }
 
 export function snapshotSourceReader(
   snapshot: RepoSourceSnapshot,
 ): RepoSourceReader {
-  return {
+  const reader: RepoSourceReader = {
     async readFile(filePath) {
-      return snapshot[filePath];
+      return snapshot[normalizeSourcePath(filePath)];
+    },
+
+    async readFiles(filePaths) {
+      return Promise.all(
+        filePaths.map((filePath) => reader.readFile(filePath)),
+      );
     },
 
     async readUnder(prefix) {
-      const sourcePrefix = `${prefix}/`;
+      const sourcePrefix = `${normalizeSourcePath(prefix)}/`;
       const files: Record<string, string> = {};
 
       for (const snapshotPath of Object.keys(snapshot)) {
         if (!snapshotPath.startsWith(sourcePrefix)) continue;
         const relativePath = snapshotPath.slice(sourcePrefix.length);
-        if (!relativePath) continue;
+        if (!relativePath || relativePath.startsWith("../")) continue;
         files[relativePath] = snapshot[snapshotPath]!;
       }
 
       return files;
     },
   };
+
+  return reader;
+}
+
+async function mapBounded<T, R>(
+  items: readonly T[],
+  run: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array<R>(items.length);
+  let index = 0;
+
+  async function worker() {
+    while (index < items.length) {
+      const current = index++;
+      results[current] = await run(items[current]!);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(READ_CONCURRENCY, items.length) }, () =>
+      worker(),
+    ),
+  );
+
+  return results;
 }
 
 // The tree mirrors the monorepo on disk, so a path that climbs out of it would
 // read the deployment rather than the snapshot.
-function resolveWithin(sourceRoot: string, relativePath: string) {
-  const normalized = path.posix.normalize(relativePath.replaceAll("\\", "/"));
+function normalizeSourcePath(relativePath: string) {
+  const normalized = path.posix
+    .normalize(relativePath.replaceAll("\\", "/"))
+    .replace(/\/+$/, "");
 
   if (
-    !relativePath ||
+    !normalized ||
     normalized.startsWith("/") ||
     normalized === "." ||
     normalized === ".." ||
@@ -111,7 +140,11 @@ function resolveWithin(sourceRoot: string, relativePath: string) {
     throw new Error(`Unsafe repo source path: ${relativePath}`);
   }
 
-  return path.join(sourceRoot, normalized);
+  return normalized;
+}
+
+function resolveWithin(sourceRoot: string, relativePath: string) {
+  return path.join(sourceRoot, normalizeSourcePath(relativePath));
 }
 
 function isMissing(error: unknown) {

--- a/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
+++ b/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
@@ -13,8 +13,10 @@ import {
 import {
   DEMO_DEPENDENCIES,
   DEMO_DEV_DEPENDENCIES,
+  createPackageJsonReader,
   dependencyVersionsFromPackage,
   dependencyVersions,
+  type PackageJsonReader,
 } from "./package-versions";
 import { createZip, type ZipFileMap } from "./zip";
 
@@ -38,13 +40,15 @@ async function buildDemoFileMap(
     throw new Error(`Unsupported demo slug: ${slug}`);
   }
 
+  const readPackageJson = createPackageJsonReader(reader);
+
   if (manifest.target === "node-cli") {
-    return createNodeCliDemoFileMap(manifest, reader);
+    return createNodeCliDemoFileMap(manifest, reader, readPackageJson);
   }
 
   const [demoSource, demoPackageJson] = await Promise.all([
     readSourceFile(reader, manifest.entry).then(flattenUiFlavorImports),
-    packageJson(manifest, reader),
+    packageJson(manifest, readPackageJson),
   ]);
   const files: ZipFileMap = {
     "package.json": demoPackageJson,
@@ -72,9 +76,7 @@ async function buildDemoFileMap(
   };
 
   const extraSourceFiles = manifest.extraSourceFiles ?? [];
-  const extraSources = await Promise.all(
-    extraSourceFiles.map((sourceFile) => readSourceFile(reader, sourceFile)),
-  );
+  const extraSources = await readSourceFiles(reader, extraSourceFiles);
 
   extraSourceFiles.forEach((sourceFile, index) => {
     const target = targetPathForSourceFile(sourceFile);
@@ -98,11 +100,21 @@ export function supportedDemoSlugs() {
 }
 
 async function readSourceFile(reader: RepoSourceReader, snapshotKey: string) {
-  const contents = await reader.readFile(snapshotKey);
-  if (typeof contents !== "string") {
-    throw new Error(`Missing source snapshot entry: ${snapshotKey}`);
-  }
-  return contents;
+  return (await readSourceFiles(reader, [snapshotKey]))[0]!;
+}
+
+async function readSourceFiles(
+  reader: RepoSourceReader,
+  snapshotKeys: readonly string[],
+) {
+  const contents = await reader.readFiles(snapshotKeys);
+
+  return contents.map((value, index) => {
+    if (typeof value !== "string") {
+      throw new Error(`Missing source snapshot entry: ${snapshotKeys[index]}`);
+    }
+    return value;
+  });
 }
 
 function flattenUiFlavorImports(source: string) {
@@ -147,19 +159,16 @@ const REACT_INK_SOURCE_FILES = [
 async function createNodeCliDemoFileMap(
   manifest: DemoDownloadManifest,
   reader: RepoSourceReader,
+  readPackageJson: PackageJsonReader,
 ) {
   if (manifest.slug !== "react-ink") {
     throw new Error(`Unsupported node-cli demo slug: ${manifest.slug}`);
   }
 
   const [demoPackageJson, tsconfig, sources] = await Promise.all([
-    nodeCliPackageJson(manifest, reader),
+    nodeCliPackageJson(manifest, readPackageJson),
     readSourceFile(reader, "examples/with-react-ink/tsconfig.json"),
-    Promise.all(
-      REACT_INK_SOURCE_FILES.map((sourceFile) =>
-        readSourceFile(reader, sourceFile),
-      ),
-    ),
+    readSourceFiles(reader, REACT_INK_SOURCE_FILES),
   ]);
   const files: ZipFileMap = {
     "package.json": demoPackageJson,
@@ -177,17 +186,17 @@ async function createNodeCliDemoFileMap(
 
 async function nodeCliPackageJson(
   manifest: DemoDownloadManifest,
-  reader: RepoSourceReader,
+  readPackageJson: PackageJsonReader,
 ) {
   const packagePath = "examples/with-react-ink/package.json";
   const [dependencies, devDependencies] = await Promise.all([
-    dependencyVersionsFromPackage(reader, packagePath, [
+    dependencyVersionsFromPackage(readPackageJson, packagePath, [
       "@assistant-ui/react-ink",
       "@assistant-ui/react-ink-markdown",
       "ink",
       "react",
     ]),
-    dependencyVersionsFromPackage(reader, packagePath, [
+    dependencyVersionsFromPackage(readPackageJson, packagePath, [
       "@types/react",
       "esbuild",
       "tsx",
@@ -220,11 +229,11 @@ function nodeCliReadme(manifest: DemoDownloadManifest) {
 
 async function packageJson(
   manifest: DemoDownloadManifest,
-  reader: RepoSourceReader,
+  readPackageJson: PackageJsonReader,
 ) {
   const [dependencies, devDependencies] = await Promise.all([
-    dependencyVersions(reader, DEMO_DEPENDENCIES),
-    dependencyVersions(reader, DEMO_DEV_DEPENDENCIES),
+    dependencyVersions(readPackageJson, DEMO_DEPENDENCIES),
+    dependencyVersions(readPackageJson, DEMO_DEV_DEPENDENCIES),
   ]);
 
   return `${JSON.stringify(

--- a/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
+++ b/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
@@ -1,4 +1,9 @@
-import { loadRepoSourceSnapshot } from "@/lib/repo-source";
+import {
+  createRepoSourceReader,
+  snapshotSourceReader,
+  type RepoSourceReader,
+  type RepoSourceSnapshot,
+} from "@/lib/repo-source";
 import {
   DEMO_DOWNLOAD_MANIFESTS,
   getDemoDownloadManifest,
@@ -13,28 +18,36 @@ import {
 } from "./package-versions";
 import { createZip, type ZipFileMap } from "./zip";
 
-type SourceSnapshot = Record<string, string>;
-
 export async function createDemoZip(slug: string) {
-  const snapshot = await loadRepoSourceSnapshot();
-  return createZip(createDemoFileMap(slug, snapshot));
+  return createZip(await buildDemoFileMap(slug, createRepoSourceReader()));
 }
 
-export function createDemoFileMap(slug: string, snapshot: SourceSnapshot) {
+export function createDemoFileMap(
+  slug: string,
+  snapshot: RepoSourceSnapshot,
+): Promise<ZipFileMap> {
+  return buildDemoFileMap(slug, snapshotSourceReader(snapshot));
+}
+
+async function buildDemoFileMap(
+  slug: string,
+  reader: RepoSourceReader,
+): Promise<ZipFileMap> {
   const manifest = getDemoDownloadManifest(slug);
   if (!manifest) {
     throw new Error(`Unsupported demo slug: ${slug}`);
   }
 
   if (manifest.target === "node-cli") {
-    return createNodeCliDemoFileMap(manifest, snapshot);
+    return createNodeCliDemoFileMap(manifest, reader);
   }
 
-  const demoSource = flattenUiFlavorImports(
-    assertSnapshotFile(snapshot, manifest.entry),
-  );
+  const [demoSource, demoPackageJson] = await Promise.all([
+    readSourceFile(reader, manifest.entry).then(flattenUiFlavorImports),
+    packageJson(manifest, reader),
+  ]);
   const files: ZipFileMap = {
-    "package.json": packageJson(manifest, snapshot),
+    "package.json": demoPackageJson,
     "next.config.ts": nextConfigTs(),
     "tsconfig.json": tsconfigJson(),
     "postcss.config.mjs": postcssConfigMjs(),
@@ -58,17 +71,20 @@ export function createDemoFileMap(slug: string, snapshot: SourceSnapshot) {
     [`components/examples/${manifest.slug}.tsx`]: demoSource,
   };
 
-  for (const sourceFile of manifest.extraSourceFiles ?? []) {
+  const extraSourceFiles = manifest.extraSourceFiles ?? [];
+  const extraSources = await Promise.all(
+    extraSourceFiles.map((sourceFile) => readSourceFile(reader, sourceFile)),
+  );
+
+  extraSourceFiles.forEach((sourceFile, index) => {
     const target = targetPathForSourceFile(sourceFile);
     if (target in files) {
       throw new Error(
         `Demo zip target collision: ${sourceFile} flattens onto ${target}`,
       );
     }
-    files[target] = flattenUiFlavorImports(
-      assertSnapshotFile(snapshot, sourceFile),
-    );
-  }
+    files[target] = flattenUiFlavorImports(extraSources[index]!);
+  });
 
   return files;
 }
@@ -81,8 +97,8 @@ export function supportedDemoSlugs() {
   return Object.keys(DEMO_DOWNLOAD_MANIFESTS) as DemoDownloadSlug[];
 }
 
-function assertSnapshotFile(snapshot: SourceSnapshot, snapshotKey: string) {
-  const contents = snapshot[snapshotKey];
+async function readSourceFile(reader: RepoSourceReader, snapshotKey: string) {
+  const contents = await reader.readFile(snapshotKey);
   if (typeof contents !== "string") {
     throw new Error(`Missing source snapshot entry: ${snapshotKey}`);
   }
@@ -128,47 +144,55 @@ const REACT_INK_SOURCE_FILES = [
   "examples/with-react-ink/src/tools.tsx",
 ] as const;
 
-function createNodeCliDemoFileMap(
+async function createNodeCliDemoFileMap(
   manifest: DemoDownloadManifest,
-  snapshot: SourceSnapshot,
+  reader: RepoSourceReader,
 ) {
   if (manifest.slug !== "react-ink") {
     throw new Error(`Unsupported node-cli demo slug: ${manifest.slug}`);
   }
 
-  const files: ZipFileMap = {
-    "package.json": nodeCliPackageJson(manifest, snapshot),
-    "tsconfig.json": assertSnapshotFile(
-      snapshot,
-      "examples/with-react-ink/tsconfig.json",
+  const [demoPackageJson, tsconfig, sources] = await Promise.all([
+    nodeCliPackageJson(manifest, reader),
+    readSourceFile(reader, "examples/with-react-ink/tsconfig.json"),
+    Promise.all(
+      REACT_INK_SOURCE_FILES.map((sourceFile) =>
+        readSourceFile(reader, sourceFile),
+      ),
     ),
+  ]);
+  const files: ZipFileMap = {
+    "package.json": demoPackageJson,
+    "tsconfig.json": tsconfig,
     "README.md": nodeCliReadme(manifest),
   };
 
-  for (const sourceFile of REACT_INK_SOURCE_FILES) {
+  REACT_INK_SOURCE_FILES.forEach((sourceFile, index) => {
     files[sourceFile.replace(/^examples\/with-react-ink\//, "")] =
-      assertSnapshotFile(snapshot, sourceFile);
-  }
+      sources[index]!;
+  });
 
   return files;
 }
 
-function nodeCliPackageJson(
+async function nodeCliPackageJson(
   manifest: DemoDownloadManifest,
-  snapshot: SourceSnapshot,
+  reader: RepoSourceReader,
 ) {
   const packagePath = "examples/with-react-ink/package.json";
-  const dependencies = dependencyVersionsFromPackage(snapshot, packagePath, [
-    "@assistant-ui/react-ink",
-    "@assistant-ui/react-ink-markdown",
-    "ink",
-    "react",
-  ]);
-  const devDependencies = dependencyVersionsFromPackage(snapshot, packagePath, [
-    "@types/react",
-    "esbuild",
-    "tsx",
-    "typescript",
+  const [dependencies, devDependencies] = await Promise.all([
+    dependencyVersionsFromPackage(reader, packagePath, [
+      "@assistant-ui/react-ink",
+      "@assistant-ui/react-ink-markdown",
+      "ink",
+      "react",
+    ]),
+    dependencyVersionsFromPackage(reader, packagePath, [
+      "@types/react",
+      "esbuild",
+      "tsx",
+      "typescript",
+    ]),
   ]);
 
   return `${JSON.stringify(
@@ -194,7 +218,15 @@ function nodeCliReadme(manifest: DemoDownloadManifest) {
   return `# Xulux ${manifest.name}\n\n${manifest.description}\n\nThis is a Node.js terminal app. It renders a Claude Code or Codex CLI-style assistant UI with React Ink and assistant-ui terminal primitives.\n\n## Run\n\n\`\`\`bash\nnpm install\nnpm run dev\n\`\`\`\n\n## Build\n\n\`\`\`bash\nnpm run build\nnpm start\n\`\`\`\n\nSource demo: \`${manifest.sourcePath ?? "examples/with-react-ink"}\`\n`;
 }
 
-function packageJson(manifest: DemoDownloadManifest, snapshot: SourceSnapshot) {
+async function packageJson(
+  manifest: DemoDownloadManifest,
+  reader: RepoSourceReader,
+) {
+  const [dependencies, devDependencies] = await Promise.all([
+    dependencyVersions(reader, DEMO_DEPENDENCIES),
+    dependencyVersions(reader, DEMO_DEV_DEPENDENCIES),
+  ]);
+
   return `${JSON.stringify(
     {
       name: `xulux-${manifest.slug}-demo`,
@@ -206,8 +238,8 @@ function packageJson(manifest: DemoDownloadManifest, snapshot: SourceSnapshot) {
         build: "next build",
         start: "next start",
       },
-      dependencies: dependencyVersions(snapshot, DEMO_DEPENDENCIES),
-      devDependencies: dependencyVersions(snapshot, DEMO_DEV_DEPENDENCIES),
+      dependencies,
+      devDependencies,
     },
     null,
     2,

--- a/apps/docs/lib/xulux/demo-downloads/package-versions.ts
+++ b/apps/docs/lib/xulux/demo-downloads/package-versions.ts
@@ -7,7 +7,7 @@ type PackageJson = {
   peerDependencies?: Record<string, string>;
 };
 
-type PackageJsonReader = (snapshotKey: string) => Promise<PackageJson>;
+export type PackageJsonReader = (snapshotKey: string) => Promise<PackageJson>;
 
 const WORKSPACE_PACKAGE_JSON: Record<string, string> = {
   "@assistant-ui/ai-sdk": "packages/ai-sdk/package.json",
@@ -50,10 +50,9 @@ export const DEMO_DEV_DEPENDENCIES = [
 ] as const;
 
 export async function dependencyVersions(
-  reader: RepoSourceReader,
+  readPackageJson: PackageJsonReader,
   names: readonly string[],
 ) {
-  const readPackageJson = createPackageJsonReader(reader);
   return Object.fromEntries(
     await Promise.all(
       names.map(async (name): Promise<[string, string]> => [
@@ -65,11 +64,10 @@ export async function dependencyVersions(
 }
 
 export async function dependencyVersionsFromPackage(
-  reader: RepoSourceReader,
+  readPackageJson: PackageJsonReader,
   packagePath: string,
   names: readonly string[],
 ) {
-  const readPackageJson = createPackageJsonReader(reader);
   const pkg = await readPackageJson(packagePath);
   return Object.fromEntries(
     await Promise.all(
@@ -120,9 +118,11 @@ function isInstallableVersion(version: unknown): version is string {
   );
 }
 
-// Every dependency falls back to the docs manifest, so one resolution pass
-// would otherwise read and parse the same file once per name.
-function createPackageJsonReader(reader: RepoSourceReader): PackageJsonReader {
+// Every dependency falls back to the docs manifest, so a request would
+// otherwise read and parse the same file once per name.
+export function createPackageJsonReader(
+  reader: RepoSourceReader,
+): PackageJsonReader {
   const parsed = new Map<string, Promise<PackageJson>>();
 
   return (snapshotKey) => {

--- a/apps/docs/lib/xulux/demo-downloads/package-versions.ts
+++ b/apps/docs/lib/xulux/demo-downloads/package-versions.ts
@@ -1,4 +1,13 @@
-type Snapshot = Record<string, string>;
+import type { RepoSourceReader } from "@/lib/repo-source";
+
+type PackageJson = {
+  version?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+type PackageJsonReader = (snapshotKey: string) => Promise<PackageJson>;
 
 const WORKSPACE_PACKAGE_JSON: Record<string, string> = {
   "@assistant-ui/ai-sdk": "packages/ai-sdk/package.json",
@@ -40,45 +49,57 @@ export const DEMO_DEV_DEPENDENCIES = [
   "typescript",
 ] as const;
 
-export function dependencyVersions(
-  snapshot: Snapshot,
+export async function dependencyVersions(
+  reader: RepoSourceReader,
   names: readonly string[],
 ) {
+  const readPackageJson = createPackageJsonReader(reader);
   return Object.fromEntries(
-    names.map((name) => [name, dependencyVersion(snapshot, name)]),
+    await Promise.all(
+      names.map(async (name): Promise<[string, string]> => [
+        name,
+        await dependencyVersion(readPackageJson, name),
+      ]),
+    ),
   );
 }
 
-export function dependencyVersionsFromPackage(
-  snapshot: Snapshot,
+export async function dependencyVersionsFromPackage(
+  reader: RepoSourceReader,
   packagePath: string,
   names: readonly string[],
 ) {
-  const pkg = packageJsonFromSnapshot(snapshot, packagePath);
+  const readPackageJson = createPackageJsonReader(reader);
+  const pkg = await readPackageJson(packagePath);
   return Object.fromEntries(
-    names.map((name) => {
-      const version =
-        pkg.dependencies?.[name] ??
-        pkg.devDependencies?.[name] ??
-        pkg.peerDependencies?.[name];
-      if (isInstallableVersion(version)) {
-        return [name, version];
-      }
-      return [name, dependencyVersion(snapshot, name)];
-    }),
+    await Promise.all(
+      names.map(async (name): Promise<[string, string]> => {
+        const version =
+          pkg.dependencies?.[name] ??
+          pkg.devDependencies?.[name] ??
+          pkg.peerDependencies?.[name];
+        if (isInstallableVersion(version)) {
+          return [name, version];
+        }
+        return [name, await dependencyVersion(readPackageJson, name)];
+      }),
+    ),
   );
 }
 
-function dependencyVersion(snapshot: Snapshot, name: string) {
+async function dependencyVersion(
+  readPackageJson: PackageJsonReader,
+  name: string,
+) {
   const workspacePackagePath = WORKSPACE_PACKAGE_JSON[name];
   if (workspacePackagePath) {
-    const pkg = packageJsonFromSnapshot(snapshot, workspacePackagePath);
+    const pkg = await readPackageJson(workspacePackagePath);
     if (typeof pkg.version === "string" && pkg.version) {
       return `^${pkg.version}`;
     }
   }
 
-  const docsPkg = packageJsonFromSnapshot(snapshot, "apps/docs/package.json");
+  const docsPkg = await readPackageJson("apps/docs/package.json");
   const version =
     docsPkg.dependencies?.[name] ??
     docsPkg.devDependencies?.[name] ??
@@ -99,17 +120,30 @@ function isInstallableVersion(version: unknown): version is string {
   );
 }
 
-function packageJsonFromSnapshot(snapshot: Snapshot, snapshotKey: string) {
-  const raw = snapshot[snapshotKey];
+// Every dependency falls back to the docs manifest, so one resolution pass
+// would otherwise read and parse the same file once per name.
+function createPackageJsonReader(reader: RepoSourceReader): PackageJsonReader {
+  const parsed = new Map<string, Promise<PackageJson>>();
+
+  return (snapshotKey) => {
+    const cached = parsed.get(snapshotKey);
+    if (cached) return cached;
+
+    const pending = readPackageJson(reader, snapshotKey);
+    parsed.set(snapshotKey, pending);
+    return pending;
+  };
+}
+
+async function readPackageJson(
+  reader: RepoSourceReader,
+  snapshotKey: string,
+): Promise<PackageJson> {
+  const raw = await reader.readFile(snapshotKey);
   if (typeof raw !== "string") {
     throw new Error(
       `Missing package metadata in source snapshot: ${snapshotKey}`,
     );
   }
-  return JSON.parse(raw) as {
-    version?: string;
-    dependencies?: Record<string, string>;
-    devDependencies?: Record<string, string>;
-    peerDependencies?: Record<string, string>;
-  };
+  return JSON.parse(raw) as PackageJson;
 }

--- a/apps/docs/lib/xulux/learn/next-step-result.ts
+++ b/apps/docs/lib/xulux/learn/next-step-result.ts
@@ -1,6 +1,6 @@
-import { loadRepoSourceSnapshot } from "@/lib/repo-source";
+import { createRepoSourceReader } from "@/lib/repo-source";
 import { compareStageFiles } from "./stage-diff";
-import { resolveStageFilesFromSnapshot } from "./stage-source";
+import { resolveStageFilesFromReader } from "./stage-source";
 import { getNextStep } from "./registry";
 import { getLearnCourse, getLearnStage } from "./registry";
 import type { LearnContext, LearnCourseStepResult } from "./types";
@@ -27,21 +27,21 @@ export async function resolveNextCourseStep(
 
   const stepIndex = course.steps.findIndex(({ id }) => id === next.step.id);
   const stage = getLearnStage(context.courseId, next.step.stageId);
-  const snapshot = await loadRepoSourceSnapshot();
-  const currentFiles = resolveStageFilesFromSnapshot(
+  const reader = createRepoSourceReader();
+  const currentFiles = await resolveStageFilesFromReader(
     context.courseId,
     stage.id,
-    snapshot,
+    reader,
   );
   const previousStep = course.steps[stepIndex - 1];
   const previousFiles = previousStep
-    ? resolveStageFilesFromSnapshot(
+    ? await resolveStageFilesFromReader(
         context.courseId,
         previousStep.stageId,
-        snapshot,
+        reader,
       )
     : currentFiles;
-  const content = snapshot[next.step.lessonPath];
+  const content = await reader.readFile(next.step.lessonPath);
   if (typeof content !== "string") {
     throw new Error(`Missing Learn lesson: ${next.step.lessonPath}`);
   }

--- a/apps/docs/lib/xulux/learn/stage-source.test.ts
+++ b/apps/docs/lib/xulux/learn/stage-source.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./stage-source";
 
 describe("resolveStageFiles", () => {
-  it("materializes shared files and selects only the registered project root", () => {
+  it("materializes shared files and selects only the registered project root", async () => {
     const course = getLearnCourse(DEFAULT_LEARN_COURSE_ID);
     const stage = getLearnStage(DEFAULT_LEARN_COURSE_ID, "S0");
     const snapshot = {
@@ -24,9 +24,9 @@ describe("resolveStageFiles", () => {
       "apps/docs/lib/xulux/learn/registry.ts": "unrelated monorepo source",
     };
 
-    expect(
+    await expect(
       resolveStageFilesFromSnapshot(DEFAULT_LEARN_COURSE_ID, "S0", snapshot),
-    ).toEqual({
+    ).resolves.toEqual({
       ".env.example": "course shared",
       "README.md": "course shared",
       "app/page.tsx": "export default function Page() {}",
@@ -38,7 +38,7 @@ describe("resolveStageFiles", () => {
     });
   });
 
-  it("lets stage-local source override a shared file", () => {
+  it("lets stage-local source override a shared file", async () => {
     const course = getLearnCourse(DEFAULT_LEARN_COURSE_ID);
     const stage = getLearnStage(DEFAULT_LEARN_COURSE_ID, "S0");
     const snapshot = {
@@ -47,14 +47,16 @@ describe("resolveStageFiles", () => {
       [`${stage.sourceRoot}/next.config.ts`]: "stage local",
     };
 
-    expect(
-      resolveStageFilesFromSnapshot(DEFAULT_LEARN_COURSE_ID, "S0", snapshot)[
-        "next.config.ts"
-      ],
-    ).toBe("stage local");
+    const files = await resolveStageFilesFromSnapshot(
+      DEFAULT_LEARN_COURSE_ID,
+      "S0",
+      snapshot,
+    );
+
+    expect(files["next.config.ts"]).toBe("stage local");
   });
 
-  it("inherits and overlays each earlier stage", () => {
+  it("inherits and overlays each earlier stage", async () => {
     const course = getLearnCourse(DEFAULT_LEARN_COURSE_ID);
     const snapshot = {
       ...sharedSourceSnapshot(course.sharedFiles, "course shared"),
@@ -70,7 +72,7 @@ describe("resolveStageFiles", () => {
       ),
     };
 
-    const files = resolveStageFilesFromSnapshot(
+    const files = await resolveStageFilesFromSnapshot(
       DEFAULT_LEARN_COURSE_ID,
       "S7",
       snapshot,
@@ -82,7 +84,7 @@ describe("resolveStageFiles", () => {
     expect(files["next.config.ts"]).toBe("config S7");
   });
 
-  it("normalizes preview-only cross-stage imports in materialized source", () => {
+  it("normalizes preview-only cross-stage imports in materialized source", async () => {
     const course = getLearnCourse(DEFAULT_LEARN_COURSE_ID);
     const stageS0 = getLearnStage(DEFAULT_LEARN_COURSE_ID, "S0");
     const stageS1 = getLearnStage(DEFAULT_LEARN_COURSE_ID, "S1");
@@ -95,44 +97,48 @@ describe("resolveStageFiles", () => {
         'import { tool } from "@/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S0/project/components/tool";',
     };
 
-    expect(
-      resolveStageFilesFromSnapshot(DEFAULT_LEARN_COURSE_ID, "S1", snapshot)[
-        "app/page.tsx"
-      ],
-    ).toBe('import { tool } from "../components/tool";');
+    const files = await resolveStageFilesFromSnapshot(
+      DEFAULT_LEARN_COURSE_ID,
+      "S1",
+      snapshot,
+    );
+
+    expect(files["app/page.tsx"]).toBe(
+      'import { tool } from "../components/tool";',
+    );
   });
 
-  it("rejects unregistered IDs before reading the snapshot", () => {
-    expect(() =>
+  it("rejects unregistered IDs before reading the snapshot", async () => {
+    await expect(
       resolveStageFilesFromSnapshot("missing-course", "S0", {}),
-    ).toThrow(/Unregistered Learn course/);
-    expect(() =>
+    ).rejects.toThrow(/Unregistered Learn course/);
+    await expect(
       resolveStageFilesFromSnapshot(
         DEFAULT_LEARN_COURSE_ID,
         "missing-stage",
         {},
       ),
-    ).toThrow(/Unregistered Learn stage/);
+    ).rejects.toThrow(/Unregistered Learn stage/);
   });
 
-  it("fails when a registered stage has no tracked source", () => {
+  it("fails when a registered stage has no tracked source", async () => {
     const course = getLearnCourse(DEFAULT_LEARN_COURSE_ID);
     const stage = getLearnStage(DEFAULT_LEARN_COURSE_ID, "S0");
-    expect(() =>
+    await expect(
       resolveStageFilesFromSnapshot(DEFAULT_LEARN_COURSE_ID, "S0", {
         ...sharedSourceSnapshot(course.sharedFiles, "shared"),
         ...sharedSourceSnapshot(stage.sharedFiles, "shared"),
       }),
-    ).toThrow(/No source snapshot files found/);
+    ).rejects.toThrow(/No source snapshot files found/);
   });
 
-  it("fails when a registered shared source is missing", () => {
-    expect(() =>
+  it("fails when a registered shared source is missing", async () => {
+    await expect(
       resolveStageFilesFromSnapshot(DEFAULT_LEARN_COURSE_ID, "S0", {}),
-    ).toThrow(/Missing shared Learn source snapshot file/);
+    ).rejects.toThrow(/Missing shared Learn source snapshot file/);
   });
 
-  it("packages the exact materialized stage file map", () => {
+  it("packages the exact materialized stage file map", async () => {
     const course = getLearnCourse(DEFAULT_LEARN_COURSE_ID);
     const stage = getLearnStage(DEFAULT_LEARN_COURSE_ID, "S7");
     const snapshot = {
@@ -148,12 +154,12 @@ describe("resolveStageFiles", () => {
       ),
       [`${stage.sourceRoot}/app/page.tsx`]: "page",
     };
-    const files = resolveStageFilesFromSnapshot(
+    const files = await resolveStageFilesFromSnapshot(
       DEFAULT_LEARN_COURSE_ID,
       "S7",
       snapshot,
     );
-    const zip = createLearnStageZipFromSnapshot(
+    const zip = await createLearnStageZipFromSnapshot(
       DEFAULT_LEARN_COURSE_ID,
       "S7",
       snapshot,
@@ -165,14 +171,14 @@ describe("resolveStageFiles", () => {
     );
   });
 
-  it("rejects unregistered stage downloads", () => {
-    expect(() =>
+  it("rejects unregistered stage downloads", async () => {
+    await expect(
       createLearnStageZipFromSnapshot(
         DEFAULT_LEARN_COURSE_ID,
         "missing-stage",
         {},
       ),
-    ).toThrow(LearnRegistryError);
+    ).rejects.toThrow(LearnRegistryError);
   });
 });
 

--- a/apps/docs/lib/xulux/learn/stage-source.ts
+++ b/apps/docs/lib/xulux/learn/stage-source.ts
@@ -141,8 +141,8 @@ async function resolveSharedFiles(
       ([outputPath, snapshotPath]) =>
         [normalizeOutputPath(outputPath), snapshotPath] as const,
     );
-  const sources = await Promise.all(
-    entries.map(([, snapshotPath]) => reader.readFile(snapshotPath)),
+  const sources = await reader.readFiles(
+    entries.map(([, snapshotPath]) => snapshotPath),
   );
   const files: LearnStageFiles = {};
 

--- a/apps/docs/lib/xulux/learn/stage-source.ts
+++ b/apps/docs/lib/xulux/learn/stage-source.ts
@@ -1,4 +1,8 @@
-import { loadRepoSourceSnapshot } from "@/lib/repo-source";
+import {
+  createRepoSourceReader,
+  snapshotSourceReader,
+  type RepoSourceReader,
+} from "@/lib/repo-source";
 import { createZip } from "../demo-downloads/zip";
 import { getLearnCourse, getLearnStage } from "./registry";
 import type { LearnCourseDefinition } from "./types";
@@ -10,10 +14,10 @@ export async function resolveStageFiles(
   courseId: string,
   stageId: string,
 ): Promise<LearnStageFiles> {
-  return resolveStageFilesFromSnapshot(
+  return resolveStageFilesFromReader(
     courseId,
     stageId,
-    await loadRepoSourceSnapshot(),
+    createRepoSourceReader(),
   );
 }
 
@@ -21,12 +25,14 @@ export async function createLearnStageZip(courseId: string, stageId: string) {
   return createZip(await resolveStageFiles(courseId, stageId));
 }
 
-export function createLearnStageZipFromSnapshot(
+export async function createLearnStageZipFromSnapshot(
   courseId: string,
   stageId: string,
   snapshot: LearnSourceSnapshot,
 ) {
-  return createZip(resolveStageFilesFromSnapshot(courseId, stageId, snapshot));
+  return createZip(
+    await resolveStageFilesFromSnapshot(courseId, stageId, snapshot),
+  );
 }
 
 export function getLearnStageArchiveFilename(
@@ -42,17 +48,29 @@ export function resolveStageFilesFromSnapshot(
   courseId: string,
   stageId: string,
   snapshot: LearnSourceSnapshot,
-): LearnStageFiles {
-  const course = getLearnCourse(courseId);
-  return resolveStage(course, stageId, snapshot, new Set());
+): Promise<LearnStageFiles> {
+  return resolveStageFilesFromReader(
+    courseId,
+    stageId,
+    snapshotSourceReader(snapshot),
+  );
 }
 
-function resolveStage(
+export async function resolveStageFilesFromReader(
+  courseId: string,
+  stageId: string,
+  reader: RepoSourceReader,
+): Promise<LearnStageFiles> {
+  const course = getLearnCourse(courseId);
+  return resolveStage(course, stageId, reader, new Set());
+}
+
+async function resolveStage(
   course: LearnCourseDefinition,
   stageId: string,
-  snapshot: LearnSourceSnapshot,
+  reader: RepoSourceReader,
   resolvingStageIds: Set<string>,
-): LearnStageFiles {
+): Promise<LearnStageFiles> {
   const stage = getLearnStage(course.id, stageId);
   if (resolvingStageIds.has(stageId)) {
     throw new Error(`Cyclic Learn stage inheritance: ${course.id}/${stageId}`);
@@ -60,28 +78,30 @@ function resolveStage(
 
   resolvingStageIds.add(stageId);
   const sourceRoot = normalizeSourceRoot(stage.sourceRoot);
-  const sourcePrefix = `${sourceRoot}/`;
   const files: LearnStageFiles = stage.previousStageId
-    ? resolveStage(course, stage.previousStageId, snapshot, resolvingStageIds)
-    : resolveSharedFiles(course.sharedFiles, snapshot);
+    ? await resolveStage(
+        course,
+        stage.previousStageId,
+        reader,
+        resolvingStageIds,
+      )
+    : await resolveSharedFiles(course.sharedFiles, reader);
 
-  Object.assign(files, resolveSharedFiles(stage.sharedFiles, snapshot));
-  let stageFileCount = 0;
+  Object.assign(files, await resolveSharedFiles(stage.sharedFiles, reader));
 
-  for (const snapshotPath of Object.keys(snapshot).sort()) {
-    if (!snapshotPath.startsWith(sourcePrefix)) continue;
-    const relativePath = snapshotPath.slice(sourcePrefix.length);
-    if (!relativePath || relativePath.startsWith("../")) continue;
-    files[relativePath] = normalizePreviewImports(
-      snapshot[snapshotPath]!,
-      relativePath,
-    );
-    stageFileCount += 1;
-  }
+  const stageFiles = await reader.readUnder(sourceRoot);
+  const relativePaths = Object.keys(stageFiles).sort();
 
-  if (stageFileCount === 0) {
+  if (relativePaths.length === 0) {
     throw new Error(
       `No source snapshot files found for Learn stage: ${course.id}/${stageId}`,
+    );
+  }
+
+  for (const relativePath of relativePaths) {
+    files[relativePath] = normalizePreviewImports(
+      stageFiles[relativePath]!,
+      relativePath,
     );
   }
 
@@ -111,24 +131,30 @@ function relativeImport(outputPath: string, targetPath: string) {
   return relative.startsWith(".") ? relative : `./${relative}`;
 }
 
-function resolveSharedFiles(
+async function resolveSharedFiles(
   sharedFiles: Record<string, string> | undefined,
-  snapshot: LearnSourceSnapshot,
-): LearnStageFiles {
+  reader: RepoSourceReader,
+): Promise<LearnStageFiles> {
+  const entries = Object.entries(sharedFiles ?? {})
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(
+      ([outputPath, snapshotPath]) =>
+        [normalizeOutputPath(outputPath), snapshotPath] as const,
+    );
+  const sources = await Promise.all(
+    entries.map(([, snapshotPath]) => reader.readFile(snapshotPath)),
+  );
   const files: LearnStageFiles = {};
 
-  for (const [outputPath, snapshotPath] of Object.entries(
-    sharedFiles ?? {},
-  ).sort(([left], [right]) => left.localeCompare(right))) {
-    const normalizedOutputPath = normalizeOutputPath(outputPath);
-    const source = snapshot[snapshotPath];
+  entries.forEach(([outputPath, snapshotPath], index) => {
+    const source = sources[index];
     if (source === undefined) {
       throw new Error(
         `Missing shared Learn source snapshot file: ${snapshotPath}`,
       );
     }
-    files[normalizedOutputPath] = source;
-  }
+    files[outputPath] = source;
+  });
 
   return files;
 }


### PR DESCRIPTION
closes #6752

## Problem

`loadRepoSourceSnapshot` materialized every file of `generated/.repo-source` into a `Record<string, string>`, and four request paths called it per request: `/api/xulux/demo-download`, `/api/xulux/learn/source`, `/api/xulux/learn/download`, and `getNextCourseStep` on `/api/xulux/{chat,learn/chat}`.

none of them wanted the tree. measured against the current tree (5215 files, 26.7 MB):

| path | files referenced |
|---|---|
| demo download (base) | 35 |
| demo download (chatgpt, claude, gemini, perplexity) | 17 |
| demo download (react-ink) | 10 |
| learn stage S0 to S7 | 9 to 48 |

the whole-tree read costs 108.7 ms per request on this machine. #6749 made the `/repo` sandbox O(1) in tree size and left this term untouched, so it is where the monorepo's growth still lands on a request path.

## Root cause

the loader was the only reader, so every caller had to take a `Record` even though each one wanted a handful of named entries. `resolveStageFilesFromSnapshot` in particular scanned `Object.keys(snapshot)` by prefix rather than naming its files, which is what forced the whole map to exist before a stage could resolve.

## Change

a `RepoSourceReader` interface (`readFile(path)`, `readUnder(prefix)`) replaces the snapshot as what those functions take. `readUnder` returns the subtree's contents keyed relative to the prefix rather than only listing it, which keeps the 32-way read bound inside the reader instead of asking each caller to maintain it (the bound exists because an unbounded tree read exhausts a 1024 descriptor limit).

two implementations: `createRepoSourceReader` over the deployed tree, and `snapshotSourceReader` over a literal map, which is what keeps the existing `*FromSnapshot` signatures working for the tests that exercise them with literal maps. the reader is inherently async, so those functions now return a promise.

- `resolveStageFilesFromReader` is the new entry the Learn paths take; `resolveStageFilesFromSnapshot` stays as its literal-map adapter.
- `createDemoFileMap` keeps its `(slug, snapshot)` shape over the same adapter, with the reader-taking build private to the module.
- `dependencyVersion` falls back to `apps/docs/package.json` for every name, so one resolution pass would read and parse the same manifest once per dependency. `createPackageJsonReader` memoizes the parse per call.
- `loadRepoSourceSnapshot` has no callers left and is gone.

turning `Record` lookups into filesystem reads gives `..` a meaning it did not have before, so `resolveWithin` rejects a path that climbs out of the tree.

## Verification

byte-level parity against the old whole-snapshot path, run on the real generated tree: all 7 demo zips and all 8 learn stage zips are identical between `createRepoSourceReader` and a reader over the fully materialized snapshot (`Buffer.compare === 0`).

```
tree: 5215 files, 26.7 MB
base         referenced= 35 / 5215
react-ink    referenced= 10 / 5215
S0   read=   9 / 5215   S7   read=  48 / 5215
PARITY OK
```

the descriptor bound holds: peak concurrent `readFile` measured on the real tree is 29 across all demo downloads and 7 across all learn stages, both under 32.

`getNextCourseStep` end to end returns step 4 `add-weather-tool`, stage S3, a 1088 byte lesson, and the full S2 to S3 diff.

latency, same machine, 5 rounds after a warmup:

```
whole-tree load (old per-request read) 108.7 ms
createDemoZip(base)                      1.8 ms
resolveStageFiles(S7)                    2.9 ms
resolveNextCourseStep                    2.4 ms
```

`vitest run` in `apps/docs`: 769 passed. the one failing file is `lib/conversation-limit.redis.test.ts`, which needs a local `redis` package this machine does not have; it fails the same way on an untouched `main`. `tsc --noEmit`, `oxlint`, and `oxfmt --check` are clean on the touched files.

## Public surface

none. `@assistant-ui/docs` is `private: true`, so no changeset. no exports, api-reference output, or templates touched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.NGXXA_o0KIDbCVRMjx9W57tbnZIjOebaWHiyBGWAh5LBX2BkVz56lSp7yiA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->