### PR TITLE
fix(docs): fetch the downloads timeline one month at a time

### DIFF
--- a/apps/docs/components/pages/traction/downloads-chart.tsx
+++ b/apps/docs/components/pages/traction/downloads-chart.tsx
@@ -190,8 +190,8 @@ export function DownloadsChart({ timeline }: { timeline: TimelineSeries }) {
               fill={
                 isHidden ? "transparent" : `url(#${gradientPrefix}-${s.key})`
               }
-              // A month npm could not be read for bridges rather than reading as a
-              // collapse to zero.
+              // A month npm could not be read for is absent from the row rather
+              // than zero, and the curve bridges it instead of breaking in two.
               connectNulls
               isAnimationActive={false}
             />

--- a/apps/docs/components/pages/traction/downloads-chart.tsx
+++ b/apps/docs/components/pages/traction/downloads-chart.tsx
@@ -190,6 +190,9 @@ export function DownloadsChart({ timeline }: { timeline: TimelineSeries }) {
               fill={
                 isHidden ? "transparent" : `url(#${gradientPrefix}-${s.key})`
               }
+              // A month npm could not be read for bridges rather than reading as a
+              // collapse to zero.
+              connectNulls
               isAnimationActive={false}
             />
           );

--- a/apps/docs/lib/npm.test.ts
+++ b/apps/docs/lib/npm.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NPM_REVALIDATE, getDownloadsRange, getWeeklyDownloads } from "./npm";
+
+const fetchMock = vi.fn();
+
+const respond = (body: unknown, ok = true, status = 200) =>
+  fetchMock.mockResolvedValue({
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  });
+
+describe("npm", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("reads a range and carries its revalidation to the data cache", async () => {
+    respond({ downloads: [{ day: "2026-09-01", downloads: 7 }] });
+
+    await expect(
+      getDownloadsRange("@assistant-ui/react", "2026-09-01", "2026-09-08"),
+    ).resolves.toEqual([{ day: "2026-09-01", downloads: 7 }]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.npmjs.org/downloads/range/2026-09-01:2026-09-08/@assistant-ui/react",
+      { next: { revalidate: NPM_REVALIDATE.WARM } },
+    );
+  });
+
+  it("holds a window indefinitely when asked to", async () => {
+    respond({ downloads: [] });
+
+    await getDownloadsRange(
+      "@assistant-ui/react",
+      "2026-08-01",
+      "2026-08-31",
+      false,
+    );
+
+    expect(fetchMock.mock.calls[0]![1]).toEqual({
+      next: { revalidate: false },
+    });
+  });
+
+  it("bypasses the cache at revalidate zero", async () => {
+    respond({ downloads: [] });
+
+    await getDownloadsRange(
+      "@assistant-ui/react",
+      "2026-08-01",
+      "2026-08-31",
+      0,
+    );
+
+    expect(fetchMock.mock.calls[0]![1]).toEqual({ cache: "no-store" });
+  });
+
+  it("names the status when npm refuses the request", async () => {
+    respond(null, false, 429);
+
+    await expect(
+      getDownloadsRange("@assistant-ui/react", "2026-08-01", "2026-08-31"),
+    ).resolves.toEqual([]);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("429"));
+  });
+
+  it("names the error when the request never lands", async () => {
+    fetchMock.mockRejectedValue(new Error("socket hang up"));
+
+    await expect(getWeeklyDownloads("@assistant-ui/react")).resolves.toBeNull();
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("/downloads/point/last-week/@assistant-ui/react"),
+      expect.any(Error),
+    );
+  });
+});

--- a/apps/docs/lib/npm.test.ts
+++ b/apps/docs/lib/npm.test.ts
@@ -11,7 +11,7 @@ const respond = (body: unknown, ok = true, status = 200) =>
     json: () => Promise.resolve(body),
   });
 
-const range = (revalidate?: number | false) =>
+const range = (revalidate?: number) =>
   getDownloadsRange(
     "@assistant-ui/react",
     "2026-08-01",
@@ -74,7 +74,7 @@ describe("npm", () => {
       });
 
     const downloads = range();
-    await vi.advanceTimersByTimeAsync(200);
+    await vi.advanceTimersByTimeAsync(300);
 
     await expect(downloads).resolves.toEqual([{ day: "d", downloads: 3 }]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -86,10 +86,10 @@ describe("npm", () => {
     respond(null, false, 429);
 
     const downloads = range();
-    await vi.advanceTimersByTimeAsync(200 + 600 + 1800);
+    await vi.advanceTimersByTimeAsync(300 + 1200);
 
     await expect(downloads).resolves.toEqual([]);
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining("429"));
   });
 

--- a/apps/docs/lib/npm.test.ts
+++ b/apps/docs/lib/npm.test.ts
@@ -24,6 +24,8 @@ describe("npm", () => {
     fetchMock.mockReset();
     vi.stubGlobal("fetch", fetchMock);
     vi.spyOn(console, "error").mockImplementation(() => {});
+    // Centre of the jitter band, so a backoff step is exactly its nominal wait.
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
   });
 
   afterEach(() => {
@@ -99,6 +101,20 @@ describe("npm", () => {
     await expect(range()).resolves.toEqual([]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining("404"));
+  });
+
+  it("spreads the retries of a refused burst instead of replaying it", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValueOnce(0).mockReturnValueOnce(1);
+    respond(null, false, 429);
+
+    const first = range();
+    const second = range();
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await Promise.all([first, second]);
   });
 
   it("names the error when the request never lands", async () => {

--- a/apps/docs/lib/npm.test.ts
+++ b/apps/docs/lib/npm.test.ts
@@ -44,13 +44,13 @@ describe("npm", () => {
     );
   });
 
-  it("holds a window indefinitely when asked to", async () => {
+  it("carries a long revalidation for settled history", async () => {
     respond({ downloads: [] });
 
-    await range(false);
+    await range(NPM_REVALIDATE.COLD);
 
     expect(fetchMock.mock.calls[0]![1]).toEqual({
-      next: { revalidate: false },
+      next: { revalidate: NPM_REVALIDATE.COLD },
     });
   });
 
@@ -99,37 +99,6 @@ describe("npm", () => {
     await expect(range()).resolves.toEqual([]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining("404"));
-  });
-
-  it("paces requests so a deploy cannot burst the whole package list at npm", async () => {
-    const release: (() => void)[] = [];
-    let peak = 0;
-    let open = 0;
-    fetchMock.mockImplementation(() => {
-      open++;
-      peak = Math.max(peak, open);
-      return new Promise((resolve) => {
-        release.push(() => {
-          open--;
-          resolve({
-            ok: true,
-            status: 200,
-            json: () => Promise.resolve({ downloads: [] }),
-          });
-        });
-      });
-    });
-
-    const all = Promise.all(Array.from({ length: 10 }, () => range()));
-    while (release.length) release.shift()!();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    while (release.length) release.shift()!();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    while (release.length) release.shift()!();
-    await all;
-
-    expect(peak).toBe(4);
-    expect(fetchMock).toHaveBeenCalledTimes(10);
   });
 
   it("names the error when the request never lands", async () => {

--- a/apps/docs/lib/npm.test.ts
+++ b/apps/docs/lib/npm.test.ts
@@ -11,6 +11,14 @@ const respond = (body: unknown, ok = true, status = 200) =>
     json: () => Promise.resolve(body),
   });
 
+const range = (revalidate?: number | false) =>
+  getDownloadsRange(
+    "@assistant-ui/react",
+    "2026-08-01",
+    "2026-08-31",
+    revalidate,
+  );
+
 describe("npm", () => {
   beforeEach(() => {
     fetchMock.mockReset();
@@ -19,18 +27,19 @@ describe("npm", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
   it("reads a range and carries its revalidation to the data cache", async () => {
-    respond({ downloads: [{ day: "2026-09-01", downloads: 7 }] });
+    respond({ downloads: [{ day: "2026-08-01", downloads: 7 }] });
 
-    await expect(
-      getDownloadsRange("@assistant-ui/react", "2026-09-01", "2026-09-08"),
-    ).resolves.toEqual([{ day: "2026-09-01", downloads: 7 }]);
+    await expect(range()).resolves.toEqual([
+      { day: "2026-08-01", downloads: 7 },
+    ]);
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.npmjs.org/downloads/range/2026-09-01:2026-09-08/@assistant-ui/react",
+      "https://api.npmjs.org/downloads/range/2026-08-01:2026-08-31/@assistant-ui/react",
       { next: { revalidate: NPM_REVALIDATE.WARM } },
     );
   });
@@ -38,12 +47,7 @@ describe("npm", () => {
   it("holds a window indefinitely when asked to", async () => {
     respond({ downloads: [] });
 
-    await getDownloadsRange(
-      "@assistant-ui/react",
-      "2026-08-01",
-      "2026-08-31",
-      false,
-    );
+    await range(false);
 
     expect(fetchMock.mock.calls[0]![1]).toEqual({
       next: { revalidate: false },
@@ -53,23 +57,79 @@ describe("npm", () => {
   it("bypasses the cache at revalidate zero", async () => {
     respond({ downloads: [] });
 
-    await getDownloadsRange(
-      "@assistant-ui/react",
-      "2026-08-01",
-      "2026-08-31",
-      0,
-    );
+    await range(0);
 
     expect(fetchMock.mock.calls[0]![1]).toEqual({ cache: "no-store" });
   });
 
-  it("names the status when npm refuses the request", async () => {
+  it("retries a rate-limited request rather than reading it as no data", async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 429, json: vi.fn() })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ downloads: [{ day: "d", downloads: 3 }] }),
+      });
+
+    const downloads = range();
+    await vi.advanceTimersByTimeAsync(200);
+
+    await expect(downloads).resolves.toEqual([{ day: "d", downloads: 3 }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("gives up once the backoff ladder is spent, and says so", async () => {
+    vi.useFakeTimers();
     respond(null, false, 429);
 
-    await expect(
-      getDownloadsRange("@assistant-ui/react", "2026-08-01", "2026-08-31"),
-    ).resolves.toEqual([]);
+    const downloads = range();
+    await vi.advanceTimersByTimeAsync(200 + 600 + 1800);
+
+    await expect(downloads).resolves.toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining("429"));
+  });
+
+  it("does not retry a status npm will answer the same way", async () => {
+    respond(null, false, 404);
+
+    await expect(range()).resolves.toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("404"));
+  });
+
+  it("paces requests so a deploy cannot burst the whole package list at npm", async () => {
+    const release: (() => void)[] = [];
+    let peak = 0;
+    let open = 0;
+    fetchMock.mockImplementation(() => {
+      open++;
+      peak = Math.max(peak, open);
+      return new Promise((resolve) => {
+        release.push(() => {
+          open--;
+          resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ downloads: [] }),
+          });
+        });
+      });
+    });
+
+    const all = Promise.all(Array.from({ length: 10 }, () => range()));
+    while (release.length) release.shift()!();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    while (release.length) release.shift()!();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    while (release.length) release.shift()!();
+    await all;
+
+    expect(peak).toBe(4);
+    expect(fetchMock).toHaveBeenCalledTimes(10);
   });
 
   it("names the error when the request never lands", async () => {

--- a/apps/docs/lib/npm.ts
+++ b/apps/docs/lib/npm.ts
@@ -8,29 +8,76 @@ export const NPM_REVALIDATE = {
   COOL: 21_600,
 } as const;
 
+// api.npmjs.org rate limits per IP, and a deploy asks it about every package at
+// once from an address shared with every other build on the platform. Pacing the
+// requests and retrying a refusal is what keeps a burst from reading as no data.
+const MAX_IN_FLIGHT = 4;
+const RETRY_BACKOFF_MS = [200, 600, 1800];
+
 export type NpmDailyDownloads = { day: string; downloads: number };
+
+let inFlight = 0;
+const waiting: (() => void)[] = [];
+
+async function withSlot<T>(run: () => Promise<T>): Promise<T> {
+  if (inFlight >= MAX_IN_FLIGHT) {
+    await new Promise<void>((resolve) => waiting.push(resolve));
+  }
+  inFlight++;
+  try {
+    return await run();
+  } finally {
+    inFlight--;
+    waiting.shift()?.();
+  }
+}
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function npmAttempt(
+  url: string,
+  revalidate: number | false,
+): Promise<{ ok: boolean; status: number; body: unknown }> {
+  return withSlot(() =>
+    withTimeout(
+      (async () => {
+        const res = await fetch(
+          url,
+          revalidate === 0 ? { cache: "no-store" } : { next: { revalidate } },
+        );
+        return {
+          ok: res.ok,
+          status: res.status,
+          body: res.ok ? await res.json() : null,
+        };
+      })(),
+    ),
+  );
+}
 
 async function npmGetJson(
   path: string,
   revalidate: number | false,
 ): Promise<unknown> {
-  try {
-    return await withTimeout(
-      (async () => {
-        const res = await fetch(
-          `${NPM_BASE}${path}`,
-          revalidate === 0 ? { cache: "no-store" } : { next: { revalidate } },
-        );
-        if (!res.ok) {
-          console.error(`npm ${path} answered ${res.status}.`);
-          return null;
-        }
-        return await res.json();
-      })(),
-    );
-  } catch (error) {
-    console.error(`npm ${path} could not be read.`, error);
-    return null;
+  const url = `${NPM_BASE}${path}`;
+
+  for (let attempt = 0; ; attempt++) {
+    let result: Awaited<ReturnType<typeof npmAttempt>>;
+    try {
+      result = await npmAttempt(url, revalidate);
+    } catch (error) {
+      console.error(`npm ${path} could not be read.`, error);
+      return null;
+    }
+    if (result.ok) return result.body;
+
+    const backoff = RETRY_BACKOFF_MS[attempt];
+    if (result.status !== 429 || backoff === undefined) {
+      console.error(`npm ${path} answered ${result.status}.`);
+      return null;
+    }
+    await delay(backoff);
   }
 }
 

--- a/apps/docs/lib/npm.ts
+++ b/apps/docs/lib/npm.ts
@@ -6,13 +6,15 @@ const NPM_BASE = "https://api.npmjs.org";
 export const NPM_REVALIDATE = {
   WARM: 3600,
   COOL: 21_600,
+  COLD: 2_592_000,
 } as const;
 
 // api.npmjs.org rate limits per IP, and a deploy asks it about every package at
-// once from an address shared with every other build on the platform. Pacing the
-// requests and retrying a refusal is what keeps a burst from reading as no data.
+// once from an address it shares with every other build on the platform. Pacing
+// the requests and retrying a refusal is what keeps a burst from reading as no
+// data. The pacing sits inside the deadline so a queued caller still gives up.
 const MAX_IN_FLIGHT = 4;
-const RETRY_BACKOFF_MS = [200, 600, 1800];
+const RETRY_BACKOFF_MS = [300, 1200];
 
 export type NpmDailyDownloads = { day: string; downloads: number };
 
@@ -37,29 +39,24 @@ const delay = (ms: number) =>
 
 function npmAttempt(
   url: string,
-  revalidate: number | false,
+  revalidate: number,
 ): Promise<{ ok: boolean; status: number; body: unknown }> {
-  return withSlot(() =>
-    withTimeout(
-      (async () => {
-        const res = await fetch(
-          url,
-          revalidate === 0 ? { cache: "no-store" } : { next: { revalidate } },
-        );
-        return {
-          ok: res.ok,
-          status: res.status,
-          body: res.ok ? await res.json() : null,
-        };
-      })(),
-    ),
+  return withTimeout(
+    withSlot(async () => {
+      const res = await fetch(
+        url,
+        revalidate === 0 ? { cache: "no-store" } : { next: { revalidate } },
+      );
+      return {
+        ok: res.ok,
+        status: res.status,
+        body: res.ok ? await res.json() : null,
+      };
+    }),
   );
 }
 
-async function npmGetJson(
-  path: string,
-  revalidate: number | false,
-): Promise<unknown> {
+async function npmGetJson(path: string, revalidate: number): Promise<unknown> {
   const url = `${NPM_BASE}${path}`;
 
   for (let attempt = 0; ; attempt++) {
@@ -83,7 +80,7 @@ async function npmGetJson(
 
 async function npmFetch(
   path: string,
-  revalidate: number | false,
+  revalidate: number,
 ): Promise<NpmDailyDownloads[]> {
   const data = (await npmGetJson(path, revalidate)) as {
     downloads?: NpmDailyDownloads[];
@@ -95,7 +92,7 @@ export function getDownloadsRange(
   pkg: string,
   startDate: string,
   endDate: string,
-  revalidate: number | false = NPM_REVALIDATE.WARM,
+  revalidate: number = NPM_REVALIDATE.WARM,
 ): Promise<NpmDailyDownloads[]> {
   return npmFetch(
     `/downloads/range/${startDate}:${endDate}/${pkg}`,

--- a/apps/docs/lib/npm.ts
+++ b/apps/docs/lib/npm.ts
@@ -12,7 +12,10 @@ export const NPM_REVALIDATE = {
 // api.npmjs.org rate limits per IP, and a deploy asks it about every package at
 // once from an address it shares with every other build on the platform. A 429
 // there is transient, so a refused request is retried rather than read as no data.
+// The wait is jittered because a refusal arrives at the whole fan-out at once,
+// and an exact backoff would replay that burst intact.
 const RETRY_BACKOFF_MS = [300, 1200];
+const jittered = (backoff: number) => backoff / 2 + Math.random() * backoff;
 
 export type NpmDailyDownloads = { day: string; downloads: number };
 
@@ -56,7 +59,7 @@ async function npmGetJson(path: string, revalidate: number): Promise<unknown> {
       console.error(`npm ${path} answered ${result.status}.`);
       return null;
     }
-    await delay(backoff);
+    await delay(jittered(backoff));
   }
 }
 

--- a/apps/docs/lib/npm.ts
+++ b/apps/docs/lib/npm.ts
@@ -10,29 +10,11 @@ export const NPM_REVALIDATE = {
 } as const;
 
 // api.npmjs.org rate limits per IP, and a deploy asks it about every package at
-// once from an address it shares with every other build on the platform. Pacing
-// the requests and retrying a refusal is what keeps a burst from reading as no
-// data. The pacing sits inside the deadline so a queued caller still gives up.
-const MAX_IN_FLIGHT = 4;
+// once from an address it shares with every other build on the platform. A 429
+// there is transient, so a refused request is retried rather than read as no data.
 const RETRY_BACKOFF_MS = [300, 1200];
 
 export type NpmDailyDownloads = { day: string; downloads: number };
-
-let inFlight = 0;
-const waiting: (() => void)[] = [];
-
-async function withSlot<T>(run: () => Promise<T>): Promise<T> {
-  if (inFlight >= MAX_IN_FLIGHT) {
-    await new Promise<void>((resolve) => waiting.push(resolve));
-  }
-  inFlight++;
-  try {
-    return await run();
-  } finally {
-    inFlight--;
-    waiting.shift()?.();
-  }
-}
 
 const delay = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -42,7 +24,7 @@ function npmAttempt(
   revalidate: number,
 ): Promise<{ ok: boolean; status: number; body: unknown }> {
   return withTimeout(
-    withSlot(async () => {
+    (async () => {
       const res = await fetch(
         url,
         revalidate === 0 ? { cache: "no-store" } : { next: { revalidate } },
@@ -52,7 +34,7 @@ function npmAttempt(
         status: res.status,
         body: res.ok ? await res.json() : null,
       };
-    }),
+    })(),
   );
 }
 

--- a/apps/docs/lib/npm.ts
+++ b/apps/docs/lib/npm.ts
@@ -10,7 +10,10 @@ export const NPM_REVALIDATE = {
 
 export type NpmDailyDownloads = { day: string; downloads: number };
 
-async function npmGetJson(path: string, revalidate: number): Promise<unknown> {
+async function npmGetJson(
+  path: string,
+  revalidate: number | false,
+): Promise<unknown> {
   try {
     return await withTimeout(
       (async () => {
@@ -18,18 +21,22 @@ async function npmGetJson(path: string, revalidate: number): Promise<unknown> {
           `${NPM_BASE}${path}`,
           revalidate === 0 ? { cache: "no-store" } : { next: { revalidate } },
         );
-        if (!res.ok) return null;
+        if (!res.ok) {
+          console.error(`npm ${path} answered ${res.status}.`);
+          return null;
+        }
         return await res.json();
       })(),
     );
-  } catch {
+  } catch (error) {
+    console.error(`npm ${path} could not be read.`, error);
     return null;
   }
 }
 
 async function npmFetch(
   path: string,
-  revalidate: number,
+  revalidate: number | false,
 ): Promise<NpmDailyDownloads[]> {
   const data = (await npmGetJson(path, revalidate)) as {
     downloads?: NpmDailyDownloads[];
@@ -41,7 +48,7 @@ export function getDownloadsRange(
   pkg: string,
   startDate: string,
   endDate: string,
-  revalidate: number = NPM_REVALIDATE.WARM,
+  revalidate: number | false = NPM_REVALIDATE.WARM,
 ): Promise<NpmDailyDownloads[]> {
   return npmFetch(
     `/downloads/range/${startDate}:${endDate}/${pkg}`,

--- a/apps/docs/lib/traction-downloads-timeline.test.ts
+++ b/apps/docs/lib/traction-downloads-timeline.test.ts
@@ -10,7 +10,8 @@ vi.mock("./npm", async (importOriginal) => ({
 }));
 
 const { NPM_REVALIDATE } = await import("./npm");
-const { fetchDownloadsTimeline } = await import("./traction");
+const { fetchDownloadsTimeline, fetchTimelineSeries } =
+  await import("./traction");
 
 const NOW = new Date("2026-09-08T12:00:00Z");
 const PER_DAY = 100;
@@ -59,7 +60,7 @@ describe("fetchDownloadsTimeline", () => {
       "2025-09-01:2026-08-31",
       "2026-09-01:2026-09-08",
     ]);
-    expect(revalidations()).toEqual([false, NPM_REVALIDATE.WARM]);
+    expect(revalidations()).toEqual([NPM_REVALIDATE.COLD, NPM_REVALIDATE.WARM]);
   });
 
   it("leaves a just-ended month in the tail until npm has backfilled it", async () => {
@@ -71,7 +72,7 @@ describe("fetchDownloadsTimeline", () => {
       "2025-09-01:2026-07-31",
       "2026-08-01:2026-09-01",
     ]);
-    expect(revalidations()).toEqual([false, NPM_REVALIDATE.WARM]);
+    expect(revalidations()).toEqual([NPM_REVALIDATE.COLD, NPM_REVALIDATE.WARM]);
   });
 
   it("covers thirteen months, one point each", async () => {
@@ -144,5 +145,34 @@ describe("fetchDownloadsTimeline", () => {
     expect(points.at(-2)).toEqual({ date: "2026-08", value: 31 * PER_DAY });
     // 6 settled days of 100 over a 30 day month, blended 0.2/0.8 with August's 3100.
     expect(points.at(-1)).toEqual({ date: "2026-09", value: 3080 });
+  });
+});
+
+describe("fetchTimelineSeries", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    getDownloadsRange.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("leaves a month it could not read out of the row rather than calling it zero", async () => {
+    getDownloadsRange.mockImplementation(
+      (pkg: string, start: string, end: string) =>
+        Promise.resolve(
+          pkg === "quiet" && start.startsWith("2025-09")
+            ? []
+            : daysIn(start, end),
+        ),
+    );
+
+    const timeline = await fetchTimelineSeries(["loud", "quiet"]);
+
+    const august = timeline.data.find((row) => row.date === "2026-08")!;
+    expect(august["s0"]).toBe(31 * PER_DAY);
+    expect("s1" in august).toBe(false);
   });
 });

--- a/apps/docs/lib/traction-downloads-timeline.test.ts
+++ b/apps/docs/lib/traction-downloads-timeline.test.ts
@@ -110,8 +110,10 @@ describe("fetchDownloadsTimeline", () => {
 
     const points = await fetchDownloadsTimeline("@assistant-ui/react");
 
-    expect(getDownloadsRange).toHaveBeenCalledTimes(4);
+    expect(getDownloadsRange).toHaveBeenCalledTimes(6);
     expect(points.map((point) => point.date)).toEqual([
+      "2026-04",
+      "2026-05",
       "2026-06",
       "2026-07",
       "2026-08",

--- a/apps/docs/lib/traction-downloads-timeline.test.ts
+++ b/apps/docs/lib/traction-downloads-timeline.test.ts
@@ -15,7 +15,7 @@ const { fetchDownloadsTimeline } = await import("./traction");
 const NOW = new Date("2026-09-08T12:00:00Z");
 const PER_DAY = 100;
 
-/** Every day the window actually spans, so a mis-built window shows up as a wrong sum. */
+/** Every day the window actually spans, so a mis-built window shows as a wrong sum. */
 const daysIn = (start: string, end: string) => {
   const days: { day: string; downloads: number }[] = [];
   for (
@@ -23,10 +23,7 @@ const daysIn = (start: string, end: string) => {
     cursor.toISOString().slice(0, 10) <= end;
     cursor.setUTCDate(cursor.getUTCDate() + 1)
   ) {
-    days.push({
-      day: cursor.toISOString().slice(0, 10),
-      downloads: PER_DAY,
-    });
+    days.push({ day: cursor.toISOString().slice(0, 10), downloads: PER_DAY });
   }
   return days;
 };
@@ -40,10 +37,8 @@ const serveWindows = () =>
 const windows = () =>
   getDownloadsRange.mock.calls.map(([, start, end]) => `${start}:${end}`);
 
-const revalidateFor = (window: string) =>
-  getDownloadsRange.mock.calls.find(
-    ([, start, end]) => `${start}:${end}` === window,
-  )?.[3];
+const revalidations = () =>
+  getDownloadsRange.mock.calls.map(([, , , revalidate]) => revalidate);
 
 describe("fetchDownloadsTimeline", () => {
   beforeEach(() => {
@@ -57,61 +52,39 @@ describe("fetchDownloadsTimeline", () => {
     vi.useRealTimers();
   });
 
-  it("asks for one calendar window per month across the trailing year", async () => {
+  it("reads the year as a settled window it can hold plus the unsettled tail", async () => {
     await fetchDownloadsTimeline("@assistant-ui/react");
 
-    expect(windows().slice().sort()).toEqual([
-      "2025-09-01:2025-09-30",
-      "2025-10-01:2025-10-31",
-      "2025-11-01:2025-11-30",
-      "2025-12-01:2025-12-31",
-      "2026-01-01:2026-01-31",
-      "2026-02-01:2026-02-28",
-      "2026-03-01:2026-03-31",
-      "2026-04-01:2026-04-30",
-      "2026-05-01:2026-05-31",
-      "2026-06-01:2026-06-30",
-      "2026-07-01:2026-07-31",
-      "2026-08-01:2026-08-31",
+    expect(windows()).toEqual([
+      "2025-09-01:2026-08-31",
       "2026-09-01:2026-09-08",
     ]);
+    expect(revalidations()).toEqual([false, NPM_REVALIDATE.WARM]);
   });
 
-  it("reads the newest month first so a spent budget drops the oldest", async () => {
-    await fetchDownloadsTimeline("@assistant-ui/react");
-
-    expect(windows()[0]).toBe("2026-09-01:2026-09-08");
-    expect(windows().at(-1)).toBe("2025-09-01:2025-09-30");
-  });
-
-  it("holds a month only once npm's trailing lag has passed", async () => {
-    await fetchDownloadsTimeline("@assistant-ui/react");
-
-    expect(revalidateFor("2026-09-01:2026-09-08")).toBe(NPM_REVALIDATE.WARM);
-    expect(revalidateFor("2026-08-01:2026-08-31")).toBe(false);
-  });
-
-  it("keeps a just-ended month refreshing while npm is still settling it", async () => {
+  it("leaves a just-ended month in the tail until npm has backfilled it", async () => {
     vi.setSystemTime(new Date("2026-09-01T06:00:00Z"));
 
     await fetchDownloadsTimeline("@assistant-ui/react");
 
-    expect(revalidateFor("2026-08-01:2026-08-31")).toBe(NPM_REVALIDATE.COOL);
-    expect(revalidateFor("2026-07-01:2026-07-31")).toBe(false);
+    expect(windows()).toEqual([
+      "2025-09-01:2026-07-31",
+      "2026-08-01:2026-09-01",
+    ]);
+    expect(revalidations()).toEqual([false, NPM_REVALIDATE.WARM]);
   });
 
-  it("stops scheduling windows once the wall-clock budget is spent", async () => {
-    getDownloadsRange.mockImplementation(
-      (_pkg: string, start: string, end: string) => {
-        vi.setSystemTime(new Date(Date.now() + 5_000));
-        return Promise.resolve(daysIn(start, end));
-      },
-    );
-
+  it("covers thirteen months, one point each", async () => {
     const points = await fetchDownloadsTimeline("@assistant-ui/react");
 
-    expect(getDownloadsRange).toHaveBeenCalledTimes(6);
     expect(points.map((point) => point.date)).toEqual([
+      "2025-09",
+      "2025-10",
+      "2025-11",
+      "2025-12",
+      "2026-01",
+      "2026-02",
+      "2026-03",
       "2026-04",
       "2026-05",
       "2026-06",
@@ -121,25 +94,48 @@ describe("fetchDownloadsTimeline", () => {
     ]);
   });
 
-  it("keeps the rest of the series when one window cannot be read", async () => {
+  it("keeps the settled history when the tail cannot be read", async () => {
     getDownloadsRange.mockImplementation(
       (_pkg: string, start: string, end: string) =>
-        Promise.resolve(start.startsWith("2026-03") ? [] : daysIn(start, end)),
+        Promise.resolve(start.startsWith("2026-09") ? [] : daysIn(start, end)),
     );
 
     const points = await fetchDownloadsTimeline("@assistant-ui/react");
 
     expect(points).toHaveLength(12);
-    expect(points.map((point) => point.date)).not.toContain("2026-03");
-    expect(points[0]).toEqual({ date: "2025-09", value: 30 * PER_DAY });
+    expect(points.at(-1)).toEqual({ date: "2026-08", value: 31 * PER_DAY });
   });
 
-  it("returns nothing when npm is unreachable for every window", async () => {
+  it("keeps the tail when the settled history cannot be read", async () => {
+    getDownloadsRange.mockImplementation(
+      (_pkg: string, start: string, end: string) =>
+        Promise.resolve(start.startsWith("2025-09") ? [] : daysIn(start, end)),
+    );
+
+    const points = await fetchDownloadsTimeline("@assistant-ui/react");
+
+    expect(points.map((point) => point.date)).toEqual(["2026-09"]);
+  });
+
+  it("returns nothing when npm is unreachable for both windows", async () => {
     getDownloadsRange.mockResolvedValue([]);
 
     await expect(
       fetchDownloadsTimeline("@assistant-ui/react"),
     ).resolves.toEqual([]);
+  });
+
+  it("does not open the tail once the wall-clock budget is spent", async () => {
+    getDownloadsRange.mockImplementation(
+      (_pkg: string, start: string, end: string) => {
+        vi.setSystemTime(new Date(Date.now() + 31_000));
+        return Promise.resolve(daysIn(start, end));
+      },
+    );
+
+    await fetchDownloadsTimeline("@assistant-ui/react");
+
+    expect(windows()).toEqual(["2025-09-01:2026-08-31"]);
   });
 
   it("sums whole months and projects the month in flight", async () => {

--- a/apps/docs/lib/traction-downloads-timeline.test.ts
+++ b/apps/docs/lib/traction-downloads-timeline.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getDownloadsRange } = vi.hoisted(() => ({
+  getDownloadsRange: vi.fn(),
+}));
+
+vi.mock("./npm", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./npm")>()),
+  getDownloadsRange,
+}));
+
+const { NPM_REVALIDATE } = await import("./npm");
+const { fetchDownloadsTimeline } = await import("./traction");
+
+const NOW = new Date("2026-09-08T12:00:00Z");
+
+const daysOf = (month: string, through: number, downloads: number) =>
+  Array.from({ length: through }, (_, i) => ({
+    day: `${month}-${String(i + 1).padStart(2, "0")}`,
+    downloads,
+  }));
+
+/** Every window npm was asked for, as `start:end`. */
+const windows = () =>
+  getDownloadsRange.mock.calls.map(([, start, end]) => `${start}:${end}`);
+
+const revalidateFor = (window: string) =>
+  getDownloadsRange.mock.calls.find(
+    ([, start, end]) => `${start}:${end}` === window,
+  )?.[3];
+
+describe("fetchDownloadsTimeline", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    getDownloadsRange.mockReset();
+    getDownloadsRange.mockImplementation((_pkg: string, start: string) =>
+      Promise.resolve(daysOf(start.slice(0, 7), 28, 100)),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("asks for one calendar window per month across the trailing year", async () => {
+    await fetchDownloadsTimeline("@assistant-ui/react");
+
+    expect(windows()).toEqual([
+      "2025-09-01:2025-09-30",
+      "2025-10-01:2025-10-31",
+      "2025-11-01:2025-11-30",
+      "2025-12-01:2025-12-31",
+      "2026-01-01:2026-01-31",
+      "2026-02-01:2026-02-28",
+      "2026-03-01:2026-03-31",
+      "2026-04-01:2026-04-30",
+      "2026-05-01:2026-05-31",
+      "2026-06-01:2026-06-30",
+      "2026-07-01:2026-07-31",
+      "2026-08-01:2026-08-31",
+      "2026-09-01:2026-09-08",
+    ]);
+  });
+
+  it("holds a month that has ended and only refetches the one in flight", async () => {
+    await fetchDownloadsTimeline("@assistant-ui/react");
+
+    expect(revalidateFor("2026-08-01:2026-08-31")).toBe(false);
+    expect(revalidateFor("2026-09-01:2026-09-08")).toBe(NPM_REVALIDATE.WARM);
+  });
+
+  it("keeps the rest of the series when one window cannot be read", async () => {
+    getDownloadsRange.mockImplementation((_pkg: string, start: string) =>
+      Promise.resolve(
+        start.startsWith("2026-03") ? [] : daysOf(start.slice(0, 7), 28, 100),
+      ),
+    );
+
+    const points = await fetchDownloadsTimeline("@assistant-ui/react");
+
+    expect(points).toHaveLength(12);
+    expect(points.map((point) => point.date)).not.toContain("2026-03");
+    expect(points[0]).toEqual({ date: "2025-09", value: 2800 });
+  });
+
+  it("returns nothing when npm is unreachable for every window", async () => {
+    getDownloadsRange.mockResolvedValue([]);
+
+    await expect(
+      fetchDownloadsTimeline("@assistant-ui/react"),
+    ).resolves.toEqual([]);
+  });
+
+  it("sums whole months and projects the month in flight past its elapsed days", async () => {
+    getDownloadsRange.mockImplementation((_pkg: string, start: string) =>
+      Promise.resolve(
+        start.startsWith("2026-09")
+          ? daysOf("2026-09", 8, 100)
+          : daysOf(start.slice(0, 7), 28, 100),
+      ),
+    );
+
+    const points = await fetchDownloadsTimeline("@assistant-ui/react");
+
+    expect(points.at(-2)).toEqual({ date: "2026-08", value: 2800 });
+    const inflight = points.at(-1)!;
+    expect(inflight.date).toBe("2026-09");
+    expect(inflight.value).toBeGreaterThan(800);
+  });
+});

--- a/apps/docs/lib/traction-downloads-timeline.test.ts
+++ b/apps/docs/lib/traction-downloads-timeline.test.ts
@@ -126,19 +126,6 @@ describe("fetchDownloadsTimeline", () => {
     ).resolves.toEqual([]);
   });
 
-  it("does not open the tail once the wall-clock budget is spent", async () => {
-    getDownloadsRange.mockImplementation(
-      (_pkg: string, start: string, end: string) => {
-        vi.setSystemTime(new Date(Date.now() + 31_000));
-        return Promise.resolve(daysIn(start, end));
-      },
-    );
-
-    await fetchDownloadsTimeline("@assistant-ui/react");
-
-    expect(windows()).toEqual(["2025-09-01:2026-08-31"]);
-  });
-
   it("sums whole months and projects the month in flight", async () => {
     const points = await fetchDownloadsTimeline("@assistant-ui/react");
 

--- a/apps/docs/lib/traction-downloads-timeline.test.ts
+++ b/apps/docs/lib/traction-downloads-timeline.test.ts
@@ -13,14 +13,30 @@ const { NPM_REVALIDATE } = await import("./npm");
 const { fetchDownloadsTimeline } = await import("./traction");
 
 const NOW = new Date("2026-09-08T12:00:00Z");
+const PER_DAY = 100;
 
-const daysOf = (month: string, through: number, downloads: number) =>
-  Array.from({ length: through }, (_, i) => ({
-    day: `${month}-${String(i + 1).padStart(2, "0")}`,
-    downloads,
-  }));
+/** Every day the window actually spans, so a mis-built window shows up as a wrong sum. */
+const daysIn = (start: string, end: string) => {
+  const days: { day: string; downloads: number }[] = [];
+  for (
+    const cursor = new Date(`${start}T00:00:00Z`);
+    cursor.toISOString().slice(0, 10) <= end;
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  ) {
+    days.push({
+      day: cursor.toISOString().slice(0, 10),
+      downloads: PER_DAY,
+    });
+  }
+  return days;
+};
 
-/** Every window npm was asked for, as `start:end`. */
+const serveWindows = () =>
+  getDownloadsRange.mockImplementation(
+    (_pkg: string, start: string, end: string) =>
+      Promise.resolve(daysIn(start, end)),
+  );
+
 const windows = () =>
   getDownloadsRange.mock.calls.map(([, start, end]) => `${start}:${end}`);
 
@@ -34,9 +50,7 @@ describe("fetchDownloadsTimeline", () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
     getDownloadsRange.mockReset();
-    getDownloadsRange.mockImplementation((_pkg: string, start: string) =>
-      Promise.resolve(daysOf(start.slice(0, 7), 28, 100)),
-    );
+    serveWindows();
   });
 
   afterEach(() => {
@@ -46,7 +60,7 @@ describe("fetchDownloadsTimeline", () => {
   it("asks for one calendar window per month across the trailing year", async () => {
     await fetchDownloadsTimeline("@assistant-ui/react");
 
-    expect(windows()).toEqual([
+    expect(windows().slice().sort()).toEqual([
       "2025-09-01:2025-09-30",
       "2025-10-01:2025-10-31",
       "2025-11-01:2025-11-30",
@@ -63,25 +77,59 @@ describe("fetchDownloadsTimeline", () => {
     ]);
   });
 
-  it("holds a month that has ended and only refetches the one in flight", async () => {
+  it("reads the newest month first so a spent budget drops the oldest", async () => {
     await fetchDownloadsTimeline("@assistant-ui/react");
 
-    expect(revalidateFor("2026-08-01:2026-08-31")).toBe(false);
+    expect(windows()[0]).toBe("2026-09-01:2026-09-08");
+    expect(windows().at(-1)).toBe("2025-09-01:2025-09-30");
+  });
+
+  it("holds a month only once npm's trailing lag has passed", async () => {
+    await fetchDownloadsTimeline("@assistant-ui/react");
+
     expect(revalidateFor("2026-09-01:2026-09-08")).toBe(NPM_REVALIDATE.WARM);
+    expect(revalidateFor("2026-08-01:2026-08-31")).toBe(false);
+  });
+
+  it("keeps a just-ended month refreshing while npm is still settling it", async () => {
+    vi.setSystemTime(new Date("2026-09-01T06:00:00Z"));
+
+    await fetchDownloadsTimeline("@assistant-ui/react");
+
+    expect(revalidateFor("2026-08-01:2026-08-31")).toBe(NPM_REVALIDATE.COOL);
+    expect(revalidateFor("2026-07-01:2026-07-31")).toBe(false);
+  });
+
+  it("stops scheduling windows once the wall-clock budget is spent", async () => {
+    getDownloadsRange.mockImplementation(
+      (_pkg: string, start: string, end: string) => {
+        vi.setSystemTime(new Date(Date.now() + 5_000));
+        return Promise.resolve(daysIn(start, end));
+      },
+    );
+
+    const points = await fetchDownloadsTimeline("@assistant-ui/react");
+
+    expect(getDownloadsRange).toHaveBeenCalledTimes(4);
+    expect(points.map((point) => point.date)).toEqual([
+      "2026-06",
+      "2026-07",
+      "2026-08",
+      "2026-09",
+    ]);
   });
 
   it("keeps the rest of the series when one window cannot be read", async () => {
-    getDownloadsRange.mockImplementation((_pkg: string, start: string) =>
-      Promise.resolve(
-        start.startsWith("2026-03") ? [] : daysOf(start.slice(0, 7), 28, 100),
-      ),
+    getDownloadsRange.mockImplementation(
+      (_pkg: string, start: string, end: string) =>
+        Promise.resolve(start.startsWith("2026-03") ? [] : daysIn(start, end)),
     );
 
     const points = await fetchDownloadsTimeline("@assistant-ui/react");
 
     expect(points).toHaveLength(12);
     expect(points.map((point) => point.date)).not.toContain("2026-03");
-    expect(points[0]).toEqual({ date: "2025-09", value: 2800 });
+    expect(points[0]).toEqual({ date: "2025-09", value: 30 * PER_DAY });
   });
 
   it("returns nothing when npm is unreachable for every window", async () => {
@@ -92,20 +140,11 @@ describe("fetchDownloadsTimeline", () => {
     ).resolves.toEqual([]);
   });
 
-  it("sums whole months and projects the month in flight past its elapsed days", async () => {
-    getDownloadsRange.mockImplementation((_pkg: string, start: string) =>
-      Promise.resolve(
-        start.startsWith("2026-09")
-          ? daysOf("2026-09", 8, 100)
-          : daysOf(start.slice(0, 7), 28, 100),
-      ),
-    );
-
+  it("sums whole months and projects the month in flight", async () => {
     const points = await fetchDownloadsTimeline("@assistant-ui/react");
 
-    expect(points.at(-2)).toEqual({ date: "2026-08", value: 2800 });
-    const inflight = points.at(-1)!;
-    expect(inflight.date).toBe("2026-09");
-    expect(inflight.value).toBeGreaterThan(800);
+    expect(points.at(-2)).toEqual({ date: "2026-08", value: 31 * PER_DAY });
+    // 6 settled days of 100 over a 30 day month, blended 0.2/0.8 with August's 3100.
+    expect(points.at(-1)).toEqual({ date: "2026-09", value: 3080 });
   });
 });

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -658,7 +658,7 @@ const TIMELINE_MONTHS_BACK = 12;
 // npm backfills a day or two behind, so a month is only final once that lag passes.
 const TRAILING_LAG_DAYS = 2;
 // 13 windows against an unreachable npm would otherwise outlast the route itself.
-const TIMELINE_BUDGET_MS = 20_000;
+const TIMELINE_BUDGET_MS = 30_000;
 
 type MonthBucket = {
   month: string;

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -657,10 +657,6 @@ export async function fetchTimelineSeries(
 const TIMELINE_MONTHS_BACK = 12;
 // npm backfills a day or two behind, so a month is only final once that lag passes.
 const TRAILING_LAG_DAYS = 2;
-// api.npmjs.org refuses a deploy's burst, and a refusal costs a retry ladder each;
-// the loop stops before an unreachable npm can outlast the route it renders.
-const TIMELINE_BUDGET_MS = 30_000;
-
 type MonthBucket = {
   month: string;
   sum: number;
@@ -699,12 +695,12 @@ export async function fetchDownloadsTimeline(
   // Everything up to the last month npm has finished backfilling is final, so it
   // is read as one window on a long revalidation and only the unsettled tail is
   // read every render. Asking per month instead would multiply a deploy's
-  // requests by thirteen, and the burst is what npm refuses.
+  // requests by thirteen, and the burst is what npm refuses; asking for the
+  // whole year at once cost the entire series whenever the one request was.
   const settled = months
     .filter((month) => shiftDays(monthEnd(month), TRAILING_LAG_DAYS) < today)
     .at(-1);
 
-  const deadline = Date.now() + TIMELINE_BUDGET_MS;
   const dailies: NpmDailyDownloads[] = [];
   if (settled) {
     dailies.push(
@@ -717,7 +713,7 @@ export async function fetchDownloadsTimeline(
     );
   }
   const tail = settled ? shiftDays(monthEnd(settled), 1) : start;
-  if (tail <= today && Date.now() < deadline) {
+  if (tail <= today) {
     dailies.push(
       ...(await getDownloadsRange(
         name,

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -657,7 +657,8 @@ export async function fetchTimelineSeries(
 const TIMELINE_MONTHS_BACK = 12;
 // npm backfills a day or two behind, so a month is only final once that lag passes.
 const TRAILING_LAG_DAYS = 2;
-// 13 windows against an unreachable npm would otherwise outlast the route itself.
+// api.npmjs.org refuses a deploy's burst, and a refusal costs a retry ladder each;
+// the loop stops before an unreachable npm can outlast the route it renders.
 const TIMELINE_BUDGET_MS = 30_000;
 
 type MonthBucket = {
@@ -674,34 +675,15 @@ function monthKeysBack(now: Date, count: number): string[] {
   );
 }
 
-function monthWindow(month: string, today: string): [string, string] {
+function monthEnd(month: string): string {
   const [year, monthOfYear] = month.split("-").map(Number);
-  const lastDay = new Date(Date.UTC(year!, monthOfYear!, 0))
-    .toISOString()
-    .slice(0, 10);
-  return [`${month}-01`, lastDay < today ? lastDay : today];
+  return new Date(Date.UTC(year!, monthOfYear!, 0)).toISOString().slice(0, 10);
 }
 
 function shiftDays(day: string, by: number): string {
   const date = new Date(`${day}T00:00:00Z`);
   date.setUTCDate(date.getUTCDate() + by);
   return date.toISOString().slice(0, 10);
-}
-
-/**
- * A month is refetched while it can still change: warm while it is in flight,
- * cool until npm's trailing lag has passed, then held for good.
- */
-function windowRevalidate(
-  month: string,
-  end: string,
-  cutoff: string,
-  today: string,
-): number | false {
-  if (month === cutoff) return NPM_REVALIDATE.WARM;
-  return today > shiftDays(end, TRAILING_LAG_DAYS)
-    ? false
-    : NPM_REVALIDATE.COOL;
 }
 
 export async function fetchDownloadsTimeline(
@@ -711,28 +693,53 @@ export async function fetchDownloadsTimeline(
   const now = new Date();
   const today = now.toISOString().slice(0, 10);
   const cutoff = currentMonthKey();
+  const months = monthKeysBack(now, TIMELINE_MONTHS_BACK);
+  const start = `${months[0]}-01`;
+
+  // Everything up to the last month npm has finished backfilling is final, so it
+  // is read as one window and held; only the unsettled tail is read every render.
+  // Asking per month instead would multiply a deploy's requests by thirteen, and
+  // the burst is what npm refuses.
+  const settled = months
+    .filter((month) => shiftDays(monthEnd(month), TRAILING_LAG_DAYS) < today)
+    .at(-1);
 
   const deadline = Date.now() + TIMELINE_BUDGET_MS;
-  const buckets: MonthBucket[] = [];
-  // Newest first, so a spent budget drops the oldest bars rather than the ones
-  // the page leads with, and a window that fails costs one point, not the series.
-  for (const month of monthKeysBack(now, TIMELINE_MONTHS_BACK).reverse()) {
-    if (Date.now() >= deadline) break;
-    const [start, end] = monthWindow(month, today);
-    const dailies = await getDownloadsRange(
-      name,
-      start,
-      end,
-      revalidate ?? windowRevalidate(month, end, cutoff, today),
+  const dailies: NpmDailyDownloads[] = [];
+  if (settled) {
+    dailies.push(
+      ...(await getDownloadsRange(
+        name,
+        start,
+        monthEnd(settled),
+        revalidate ?? false,
+      )),
     );
-    if (!dailies.length) continue;
-    buckets.push({
-      month,
-      sum: dailies.reduce((total, day) => total + day.downloads, 0),
-      dailies,
-    });
   }
-  buckets.reverse();
+  const tail = settled ? shiftDays(monthEnd(settled), 1) : start;
+  if (tail <= today && Date.now() < deadline) {
+    dailies.push(
+      ...(await getDownloadsRange(
+        name,
+        tail,
+        today,
+        revalidate ?? NPM_REVALIDATE.WARM,
+      )),
+    );
+  }
+  if (!dailies.length) return [];
+
+  const byMonth = new Map<string, MonthBucket>();
+  for (const point of dailies) {
+    const month = point.day.slice(0, 7);
+    const bucket = byMonth.get(month) ?? { month, sum: 0, dailies: [] };
+    bucket.sum += point.downloads;
+    bucket.dailies.push(point);
+    byMonth.set(month, bucket);
+  }
+  const buckets = Array.from(byMonth.values()).sort((a, b) =>
+    a.month.localeCompare(b.month),
+  );
 
   const fullMonths = buckets.filter((bucket) => bucket.month !== cutoff);
   const lastFullMonth = fullMonths.at(-1);

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -9,7 +9,11 @@ import {
   getUser,
   getUserById,
 } from "./github";
-import { getDownloadsRange } from "./npm";
+import {
+  NPM_REVALIDATE,
+  type NpmDailyDownloads,
+  getDownloadsRange,
+} from "./npm";
 
 export type PackageInfo = {
   name: string;
@@ -651,55 +655,73 @@ export async function fetchTimelineSeries(
   };
 }
 
+const TIMELINE_MONTHS_BACK = 12;
+
+type MonthBucket = {
+  month: string;
+  sum: number;
+  dailies: NpmDailyDownloads[];
+};
+
+function monthKeysBack(now: Date, count: number): string[] {
+  return Array.from({ length: count + 1 }, (_, i) =>
+    new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - (count - i), 1))
+      .toISOString()
+      .slice(0, 7),
+  );
+}
+
+function monthWindow(month: string, today: string): [string, string] {
+  const [year, monthOfYear] = month.split("-").map(Number);
+  const lastDay = new Date(Date.UTC(year!, monthOfYear!, 0))
+    .toISOString()
+    .slice(0, 10);
+  return [`${month}-01`, lastDay < today ? lastDay : today];
+}
+
 export async function fetchDownloadsTimeline(
   name: string,
   revalidate?: number,
 ): Promise<TimelinePoint[]> {
-  // npm's last-year endpoint stops at the last complete day, so it omits the
-  // in-flight month entirely; an explicit range through today keeps it.
-  const today = new Date();
-  const end = today.toISOString().slice(0, 10);
-  const start = new Date(
-    Date.UTC(today.getUTCFullYear() - 1, today.getUTCMonth(), 1),
-  )
-    .toISOString()
-    .slice(0, 10);
-  const downloads = await getDownloadsRange(name, start, end, revalidate);
-  if (!downloads.length) return [];
+  const now = new Date();
+  const today = now.toISOString().slice(0, 10);
   const cutoff = currentMonthKey();
-  type MonthBucket = {
-    sum: number;
-    dailies: { day: string; downloads: number }[];
-  };
-  const byMonth = new Map<string, MonthBucket>();
-  for (const point of downloads) {
-    const month = point.day.slice(0, 7);
-    const entry = byMonth.get(month) ?? { sum: 0, dailies: [] };
-    entry.sum += point.downloads;
-    entry.dailies.push({ day: point.day, downloads: point.downloads });
-    byMonth.set(month, entry);
-  }
-  const sorted = Array.from(byMonth.entries()).sort(([a], [b]) =>
-    a.localeCompare(b),
-  );
-  const fullMonths = sorted.filter(([k]) => k !== cutoff);
-  const lastFullMonth = fullMonths[fullMonths.length - 1];
-  const priorFullMonth = fullMonths[fullMonths.length - 2];
 
-  return sorted.map(([date, bucket]) => {
-    if (date !== cutoff || bucket.dailies.length === 0) {
-      return { date, value: bucket.sum };
-    }
-    return {
-      date,
-      value: projectInflightMonth(
-        date,
-        bucket,
-        lastFullMonth?.[1].sum,
-        priorFullMonth?.[1].sum,
-      ),
-    };
-  });
+  const buckets: MonthBucket[] = [];
+  for (const month of monthKeysBack(now, TIMELINE_MONTHS_BACK)) {
+    const [start, end] = monthWindow(month, today);
+    // A month that has ended never gains downloads again, so it is fetched once
+    // and held, and a window that fails costs one point, not the whole series.
+    const dailies = await getDownloadsRange(
+      name,
+      start,
+      end,
+      revalidate ?? (month === cutoff ? NPM_REVALIDATE.WARM : false),
+    );
+    if (!dailies.length) continue;
+    buckets.push({
+      month,
+      sum: dailies.reduce((total, day) => total + day.downloads, 0),
+      dailies,
+    });
+  }
+
+  const fullMonths = buckets.filter((bucket) => bucket.month !== cutoff);
+  const lastFullMonth = fullMonths.at(-1);
+  const priorFullMonth = fullMonths.at(-2);
+
+  return buckets.map((bucket) => ({
+    date: bucket.month,
+    value:
+      bucket.month === cutoff
+        ? projectInflightMonth(
+            bucket.month,
+            bucket,
+            lastFullMonth?.sum,
+            priorFullMonth?.sum,
+          )
+        : bucket.sum,
+  }));
 }
 
 function projectInflightMonth(

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -623,8 +623,7 @@ export async function fetchTimelineSeries(
     const row: { date: string; [key: string]: number | string } = { date };
     for (const { key, points } of fetched) {
       const point = points.find((p) => p.date === date);
-      const value = point?.value ?? 0;
-      if (!isProjected) row[key] = value;
+      if (!isProjected && point) row[key] = point.value;
     }
     return row;
   });
@@ -635,8 +634,8 @@ export async function fetchTimelineSeries(
       const row = data[idx]!;
       const rowDate = row.date as string;
       for (const { key, points } of fetched) {
-        const val = points.find((p) => p.date === rowDate)?.value ?? 0;
-        row[`${key}_proj`] = val;
+        const point = points.find((p) => p.date === rowDate);
+        if (point) row[`${key}_proj`] = point.value;
       }
     }
   }
@@ -656,6 +655,10 @@ export async function fetchTimelineSeries(
 }
 
 const TIMELINE_MONTHS_BACK = 12;
+// npm backfills a day or two behind, so a month is only final once that lag passes.
+const TRAILING_LAG_DAYS = 2;
+// 13 windows against an unreachable npm would otherwise outlast the route itself.
+const TIMELINE_BUDGET_MS = 20_000;
 
 type MonthBucket = {
   month: string;
@@ -679,6 +682,28 @@ function monthWindow(month: string, today: string): [string, string] {
   return [`${month}-01`, lastDay < today ? lastDay : today];
 }
 
+function shiftDays(day: string, by: number): string {
+  const date = new Date(`${day}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + by);
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * A month is refetched while it can still change: warm while it is in flight,
+ * cool until npm's trailing lag has passed, then held for good.
+ */
+function windowRevalidate(
+  month: string,
+  end: string,
+  cutoff: string,
+  today: string,
+): number | false {
+  if (month === cutoff) return NPM_REVALIDATE.WARM;
+  return today > shiftDays(end, TRAILING_LAG_DAYS)
+    ? false
+    : NPM_REVALIDATE.COOL;
+}
+
 export async function fetchDownloadsTimeline(
   name: string,
   revalidate?: number,
@@ -687,16 +712,18 @@ export async function fetchDownloadsTimeline(
   const today = now.toISOString().slice(0, 10);
   const cutoff = currentMonthKey();
 
+  const deadline = Date.now() + TIMELINE_BUDGET_MS;
   const buckets: MonthBucket[] = [];
-  for (const month of monthKeysBack(now, TIMELINE_MONTHS_BACK)) {
+  // Newest first, so a spent budget drops the oldest bars rather than the ones
+  // the page leads with, and a window that fails costs one point, not the series.
+  for (const month of monthKeysBack(now, TIMELINE_MONTHS_BACK).reverse()) {
+    if (Date.now() >= deadline) break;
     const [start, end] = monthWindow(month, today);
-    // A month that has ended never gains downloads again, so it is fetched once
-    // and held, and a window that fails costs one point, not the whole series.
     const dailies = await getDownloadsRange(
       name,
       start,
       end,
-      revalidate ?? (month === cutoff ? NPM_REVALIDATE.WARM : false),
+      revalidate ?? windowRevalidate(month, end, cutoff, today),
     );
     if (!dailies.length) continue;
     buckets.push({
@@ -705,6 +732,7 @@ export async function fetchDownloadsTimeline(
       dailies,
     });
   }
+  buckets.reverse();
 
   const fullMonths = buckets.filter((bucket) => bucket.month !== cutoff);
   const lastFullMonth = fullMonths.at(-1);
@@ -730,8 +758,6 @@ function projectInflightMonth(
   lastFullMonthSum: number | undefined,
   priorFullMonthSum: number | undefined,
 ): number {
-  // npm aggregation lags 1-2 days; trailing days under-report and would drag the daily average down.
-  const TRAILING_LAG_DAYS = 2;
   const dailies = [...bucket.dailies].sort((a, b) =>
     a.day.localeCompare(b.day),
   );

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -697,9 +697,9 @@ export async function fetchDownloadsTimeline(
   const start = `${months[0]}-01`;
 
   // Everything up to the last month npm has finished backfilling is final, so it
-  // is read as one window and held; only the unsettled tail is read every render.
-  // Asking per month instead would multiply a deploy's requests by thirteen, and
-  // the burst is what npm refuses.
+  // is read as one window on a long revalidation and only the unsettled tail is
+  // read every render. Asking per month instead would multiply a deploy's
+  // requests by thirteen, and the burst is what npm refuses.
   const settled = months
     .filter((month) => shiftDays(monthEnd(month), TRAILING_LAG_DAYS) < today)
     .at(-1);
@@ -712,7 +712,7 @@ export async function fetchDownloadsTimeline(
         name,
         start,
         monthEnd(settled),
-        revalidate ?? false,
+        revalidate ?? NPM_REVALIDATE.COLD,
       )),
     );
   }


### PR DESCRIPTION
## Problem

the npm downloads plate has been rendering "currently unavailable" on every surface that draws it: https://www.assistant-ui.com/traction.png (fig. 02), the dark variant, and the downloads chart on https://www.assistant-ui.com/traction. it is not a stale deployment; `/traction` carries `x-nextjs-stale-time: 300`, so it has been regenerating and failing all along.

nothing on the outside could say why. `npmGetJson` collapsed a 429, a timeout, a DNS failure and a 404 into the same `null`, `npmFetch` turned that into `[]`, and both renderers turn `[]` into "currently unavailable", with no logging anywhere on the path.

## Root cause

the first commit here added that logging, and the preview deploy answered on its first build:

```
11:10:52.892  npm /downloads/range/2026-07-10:2026-09-08/@assistant-ui/mcp-docs-server answered 429.
11:10:53.978  npm /downloads/range/2026-09-01:2026-09-08/@assistant-ui/react answered 429.
11:10:54.018  npm /downloads/range/2026-08-01:2026-08-31/@assistant-ui/react answered 429.
...
```

113 requests to api.npmjs.org inside 4 seconds, **every one of them 429**, no timeouts and no other status. a deploy asks npm about every package at once from an address it shares with every other build on the platform, and npm refuses the burst. the window size was never the variable (the 60 day windows are refused in that same log).

that also explains why the chart alone went blank while the figures beside it survived: `fetchNpmDownloads` issues 45 independent requests and renders whatever answers, so a partial refusal still leaves numbers on the page, but `fetchDownloadsTimeline` was **one** request per package covering 373 days, so a single 429 took the whole series with it, and `if (!downloads.length) return []` made that a blank chart.

## Change

**retry a refusal.** a 429 is retried down a short backoff ladder rather than read as no data, so a render gets three chances instead of one. both degrade paths log the status or the error first, which is what made this diagnosable and keeps it so.

**two windows per package, not one and not thirteen.** npm has no monthly endpoint and rejects scoped packages in bulk lookups, so the request count is the thing to spend carefully. the year is read as the settled history in one window plus the unsettled tail in another. a per month split was tried first and made it worse: thirteen windows per package multiplied a deploy's npm traffic by an order of magnitude, and the burst is what npm refuses.

**the settled history stops being refetched, which is what makes a 429 transient.** the old URL ended at `today`, so it changed daily: a success was discarded overnight and a refused render started over from nothing, which is why one refusal read as permanent. a settled window's URL is stable, so it is read on a thirty day revalidation and one success covers the month. it stays finite on purpose: `revalidate: false` serves whatever entry a URL already has at any age, and Vercel's data cache survives deploys, so a window read at a bad moment would stay wrong with nothing to clear it.

**the seam follows npm's backfill.** a month stays in the refetched tail until npm's trailing lag has passed, so nothing is cached short, including into `lastFullMonthSum` and the projection. either window failing costs only what it covered.

**a missing month is a gap, not a zero.** `fetchTimelineSeries` filled a missing cell with `0`, which would draw that package collapsing to zero for the month; the cell is left unset and the area bridges it.

a four slot request limiter was tried and removed. it did not stop the refusals it was added for, and every arrangement of it was unsound: outside the deadline the queue wait was unbounded, inside it the whole page's fan-out had to finish within one caller's five seconds, a caller that timed out while queued still took a slot and still fetched, and the release both freed a slot and woke a waiter that incremented without rechecking. the aggregate deadline it needed went with it: it existed because thirteen sequential windows could outlast the route, and two windows at three attempts of five seconds plus backoff is 33 seconds against a 60 second limit, so the bound is inherent.

## Verification

`pnpm test` in `apps/docs`: 95 files, 790 tests, green. `tsc --noEmit`: clean. `pnpm lint`: clean.

`apps/docs/lib/npm.test.ts` covers the retry (a 429 then a 200 is one value, not an empty list), the exhausted ladder, the statuses that are not retried, and the cache options each revalidation produces. `apps/docs/lib/traction-downloads-timeline.test.ts` pins the two windows and their revalidations, the seam moving with the backfill lag at rollover, the thirteen points, either window failing leaving the other standing, the projection arithmetic, and `fetchTimelineSeries` omitting an unread month rather than zeroing it.

the shape was replayed against live npm: the settled window plus the tail return the same 373 days, bucketed to the same monthly totals, as the single request they replace.

on deploy the log is the proof either way, and it has been. it named the cause on the first preview, and the give ups fell 113, 96, 36 across the shapes as the request count came down.

what is argued rather than observed: that a settled window landing once carries the chart for the month. the mechanism is just the cache key (the old URL ended at `today` and was discarded overnight; this one is stable and read on a thirty day revalidation), but i could not watch it happen. `/traction` exports no `revalidate`, so its interval is the lowest fetch revalidation on the route, an hour, and a preview only regenerates when something asks for it. a 27 minute probe across six requests never left `x-vercel-cache: HIT`. the logging is what makes the answer checkable on production after this lands, which is where i will check it.

## Public surface

`apps/docs` only, which is private, so no changeset. no exported API changes.

#7044 and #7048 track separate defects found while tracing this. the first: `/traction` and `traction.png` print different numbers under the same "Weekly downloads" label, because one reads `point/last-week` and the other sums 7 raw daily entries npm has not settled yet. the second is that this app excludes test files from `tsc`, which is how a test here kept calling a signature that had already been narrowed.


