### PR TITLE
docs(python): point state-test setup at the routes it actually serves

### DIFF
--- a/python/state-test/README.md
+++ b/python/state-test/README.md
@@ -41,6 +41,7 @@ Each response streams the state operations as `aui-state:` lines, one batch per 
 ```
 aui-state:[{"type": "set", "path": ["message"], "value": "Hello"}]
 aui-state:[{"type": "append-text", "path": ["message"], "value": " world"}]
+aui-state:[{"type": "append-text", "path": ["message"], "value": "!"}]
 aui-state:[{"type": "set", "path": ["uppercase"], "value": "HELLO WORLD!"}]
 ```
 

--- a/python/state-test/README.md
+++ b/python/state-test/README.md
@@ -21,12 +21,30 @@ This is a test project for the `assistant-stream` state management functionality
 2. Run the server:
 
    ```
-   python server.py
+   uv run python server.py
    ```
 
-3. Open your browser to [http://localhost:8000](http://localhost:8000)
+3. Exercise the endpoints. The server has no page of its own; it exposes five `POST` routes. Either open the interactive API docs FastAPI serves at [http://localhost:8000/docs](http://localhost:8000/docs) and run a route from there, or call one directly:
 
-4. Click on the different test buttons to see state updates in action
+   ```
+   curl -N -X POST http://localhost:8000/simple-test
+   curl -N -X POST http://localhost:8000/complex-test
+   curl -N -X POST http://localhost:8000/string-test
+   curl -N -X POST http://localhost:8000/list-test
+   curl -N -X POST http://localhost:8000/dict-test
+   ```
+
+   `-N` keeps curl from buffering, so the state operations appear as the server emits them. `string-test`, `list-test`, and `dict-test` sleep between steps and take several seconds to finish.
+
+Each response streams the state operations as `aui-state:` lines, one batch per flush:
+
+```
+aui-state:[{"type": "set", "path": ["message"], "value": "Hello"}]
+aui-state:[{"type": "append-text", "path": ["message"], "value": " world"}]
+aui-state:[{"type": "set", "path": ["uppercase"], "value": "HELLO WORLD!"}]
+```
+
+Applying them in order reconstructs the state the run built up.
 
 ## Implementation Details
 


### PR DESCRIPTION
closes #7004

## Problem

`python/state-test/README.md` told the reader to open http://localhost:8000 and click test buttons. neither exists. `server.py` builds a FastAPI app with five POST routes (`/simple-test`, `/complex-test`, `/string-test`, `/list-test`, `/dict-test`) and nothing else: no `GET /`, no `StaticFiles` mount, no template. following the setup steps returns `{"detail":"Not Found"}` and leaves no way to exercise the demo. nothing in the repo requests those five paths either, so there is no paired frontend living elsewhere.

the run command was wrong in the same section: `python server.py` right after `uv sync` fails with `ModuleNotFoundError: No module named 'fastapi'`, because uv installs into `.venv` and nothing activates it.

## Root cause

the README describes a UI that was never written. the server is fine; the documentation is the part that drifted.

## Change

the setup steps now drive what the server actually serves. FastAPI already publishes an interactive page with a run button per route at `/docs`, so the browser path points there instead of at `/`, and a curl line per route covers the terminal path. `-N` is named because the point of the demo is watching the operations arrive rather than reading a buffered dump, and the three routes that sleep between steps are called out so a reader does not read the pause as a hang. a short sample of the streamed `aui-state:` output shows what to look for, since that stream is the whole observable result. the run command becomes `uv run python server.py`.

no code change. serving a small static page was the other way out named in the issue, and it would mean writing a frontend that decodes the `aui-state:` wire format into a test harness nothing else consumes, which is more surface than this directory earns.

## Verification

every command the README now gives was run end to end in a clean checkout of this branch, in `python/state-test`:

- `uv sync`, then `uv run python server.py`: server up on port 8000.
- reproduction of the reported failure: `curl -i http://localhost:8000/` returns `HTTP/1.1 404 Not Found` with `{"detail":"Not Found"}`, which is what the old steps 3 and 4 walked into.
- `curl -o /dev/null -w '%{http_code}' http://localhost:8000/docs` returns `200`, so the browser path in the new step 3 resolves.
- all five documented curl commands run to completion and stream their state operations, ending at `simple-test` -> `{"final": true, ...}` plus `0:"hi"`, `complex-test` -> `["completed"] = true`, `string-test` -> `["length"] = 12`, `list-test` -> `["items"] = []`, `dict-test` -> `["config"] = {}`.
- the sample output block in the README is copied from an actual `POST /string-test` response, not written by hand.

## Public surface

none. `python/state-test` is a local test harness with no package.json, so nothing is published and no changeset applies. docs-only otherwise.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.qmDgCht-VMpecvMeAI6ng3Wh3DRAaXlerUpWOz6HbGjmiYBjZSdnV7LwU6c?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->