### PR TITLE
fix(docs): index example pages in the site search box

### DIFF
--- a/apps/docs/lib/search/content-index.ts
+++ b/apps/docs/lib/search/content-index.ts
@@ -1,26 +1,8 @@
-import {
-  design,
-  elementsDocs,
-  examples,
-  getTapDocsPages,
-  source,
-} from "@/lib/source";
 import type { ContentRecord } from "./content-search";
+import { searchablePages, type SearchablePage } from "./corpus";
 import { headingsFrom } from "./pages";
 
-type StructuredData = {
-  headings?: { id?: string; content?: string }[];
-  contents?: { content?: string }[];
-};
-
-function toRecord(page: {
-  url: string;
-  data: {
-    title: string;
-    description?: string | undefined;
-    structuredData: () => StructuredData | Promise<StructuredData>;
-  };
-}): Promise<ContentRecord> {
+function toRecord(page: SearchablePage): Promise<ContentRecord> {
   return Promise.resolve(page.data.structuredData()).then((structured) => {
     return {
       url: page.url,
@@ -35,20 +17,12 @@ function toRecord(page: {
 }
 
 /**
- * The server-only search corpus: every page with the prose fumadocs already
- * extracted for the browser index. The browser index served by `/api/search`
- * deliberately carries metadata alone so its payload stays small.
+ * The server-only search corpus. It carries each page's prose, which the
+ * browser index served by `/api/search` deliberately omits so its payload
+ * stays small.
  */
 function collectPages(): Promise<ContentRecord[]> {
-  return Promise.all(
-    [
-      ...source.getPages(),
-      ...getTapDocsPages(),
-      ...design.getPages(),
-      ...elementsDocs.getPages(),
-      ...examples.getPages(),
-    ].map((page) => toRecord(page as Parameters<typeof toRecord>[0])),
-  );
+  return Promise.all(searchablePages().map(toRecord));
 }
 
 let indexPromise: Promise<ContentRecord[]> | undefined;

--- a/apps/docs/lib/search/corpus.test.ts
+++ b/apps/docs/lib/search/corpus.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const page = (
+    url: string,
+    title: string,
+    description: string,
+    headings: string[],
+    contents: string[],
+  ) => ({
+    url,
+    data: {
+      title,
+      description,
+      structuredData: () => ({
+        headings: headings.map((content) => ({
+          id: content.toLowerCase(),
+          content,
+        })),
+        contents: contents.map((content) => ({ content })),
+      }),
+    },
+  });
+
+  return {
+    docs: [
+      page(
+        "/docs/ui/thread",
+        "Thread",
+        "Render a conversation.",
+        ["Usage"],
+        ["Render a thread beside your composer."],
+      ),
+    ],
+    tap: [
+      page(
+        "/tap/docs/overview/introduction",
+        "Introduction",
+        "Run React hooks as headless resources.",
+        [],
+        ["A resource runs the hooks you already know."],
+      ),
+    ],
+    design: [
+      page(
+        "/design/components/sheet",
+        "Sheet",
+        "A panel that slides in from an edge.",
+        [],
+        ["The sheet slides in over the page."],
+      ),
+    ],
+    elements: [
+      page(
+        "/elements/thread",
+        "Thread",
+        "The thread element.",
+        [],
+        ["The thread element renders a conversation."],
+      ),
+    ],
+    examples: [
+      page(
+        "/examples",
+        "Examples",
+        "Production-ready examples of AI chat in React.",
+        [],
+        ["Production-ready examples of AI chat in React."],
+      ),
+      page(
+        "/examples/perplexity",
+        "Perplexity Clone",
+        "Open-source Perplexity-style chat in React.",
+        ["Features"],
+        ["The Perplexity Clone demonstrates how to customize assistant-ui."],
+      ),
+    ],
+  };
+});
+
+vi.mock("@/lib/source", () => ({
+  source: { getPages: () => mocks.docs },
+  design: { getPages: () => mocks.design },
+  elementsDocs: { getPages: () => mocks.elements },
+  examples: { getPages: () => mocks.examples },
+  getTapDocsPages: () => mocks.tap,
+}));
+
+import { buildContentIndex } from "./content-index";
+import { buildSearchIndex } from "./pages";
+
+describe("search corpora", () => {
+  it("covers the same pages in the browser index and the content index", async () => {
+    const browser = await buildSearchIndex();
+    const content = await buildContentIndex();
+
+    expect(browser.map((record) => record.url).sort()).toEqual(
+      content.map((record) => record.url).sort(),
+    );
+  });
+
+  it("reaches an example page from both corpora", async () => {
+    const browser = await buildSearchIndex();
+    const content = await buildContentIndex();
+
+    expect(browser.map((record) => record.url)).toContain(
+      "/examples/perplexity",
+    );
+    expect(content.map((record) => record.url)).toContain(
+      "/examples/perplexity",
+    );
+  });
+
+  it("keeps the browser records metadata-only", async () => {
+    const browser = await buildSearchIndex();
+
+    expect(browser[0]).toEqual({
+      url: "/docs/ui/thread",
+      title: "Thread",
+      description: "Render a conversation.",
+      headings: [{ id: "usage", content: "Usage" }],
+    });
+  });
+});

--- a/apps/docs/lib/search/corpus.test.ts
+++ b/apps/docs/lib/search/corpus.test.ts
@@ -78,6 +78,9 @@ const mocks = vi.hoisted(() => {
   };
 });
 
+// @/lib/source imports the build-generated "fumadocs-mdx:collections/server"
+// module, which does not resolve in the test environment, so this mock fully
+// replaces the module instead of spreading importOriginal().
 vi.mock("@/lib/source", () => ({
   source: { getPages: () => mocks.docs },
   design: { getPages: () => mocks.design },

--- a/apps/docs/lib/search/corpus.ts
+++ b/apps/docs/lib/search/corpus.ts
@@ -1,0 +1,37 @@
+import {
+  design,
+  elementsDocs,
+  examples,
+  getTapDocsPages,
+  source,
+} from "@/lib/source";
+
+export type StructuredData = {
+  headings?: { id?: string; content?: string }[];
+  contents?: { content?: string }[];
+};
+
+export type SearchablePage = {
+  url: string;
+  data: {
+    title: string;
+    description?: string | undefined;
+    structuredData: () => StructuredData | Promise<StructuredData>;
+  };
+};
+
+/**
+ * The single page list both search corpora index. The browser index served by
+ * `/api/search` and the server-only content index behind `search_docs` derive
+ * different records from it, but a page missing from one and present in the
+ * other is a result that exists for agents and not for readers, or the reverse.
+ */
+export function searchablePages(): SearchablePage[] {
+  return [
+    ...source.getPages(),
+    ...getTapDocsPages(),
+    ...design.getPages(),
+    ...elementsDocs.getPages(),
+    ...examples.getPages(),
+  ];
+}

--- a/apps/docs/lib/search/pages.ts
+++ b/apps/docs/lib/search/pages.ts
@@ -1,4 +1,4 @@
-import { design, elementsDocs, getTapDocsPages, source } from "@/lib/source";
+import { searchablePages } from "./corpus";
 import type { SearchHeading, SearchRecord } from "./types";
 
 type StructuredHeading = {
@@ -25,12 +25,7 @@ export function headingsFrom(structuredData: {
 
 export function buildSearchIndex(): Promise<SearchRecord[]> {
   return Promise.all(
-    [
-      ...source.getPages(),
-      ...getTapDocsPages(),
-      ...design.getPages(),
-      ...elementsDocs.getPages(),
-    ].map(async (page) => ({
+    searchablePages().map(async (page) => ({
       url: page.url,
       title: page.data.title,
       description: page.data.description ?? "",


### PR DESCRIPTION
closes #7042

## Problem

typing an example's name into the docs site search box finds nothing. `/examples/perplexity` and the twelve other example pages are absent from the index `/api/search` serves, while an agent calling the `search_docs` MCP tool finds them. `list_pages`, `get_navigation` and the sitemap all cover examples too, so the browser search box was the only surface pretending they do not exist.

## Root cause

the corpus was built twice, from two hand-written page lists that had drifted apart.

`buildSearchIndex` (`lib/search/pages.ts`), which `/api/search` serves to `SearchDialog`, listed docs, tap docs, design and elements. `buildContentIndex` (`lib/search/content-index.ts`), behind `search_docs` and the landing-page demo, listed those same four plus `examples.getPages()`. nothing tied the two lists to each other, so a collection added to one and not the other diverged silently.

## Change

both builders now derive from one `searchablePages()` list in `lib/search/corpus.ts`. each still shapes its own record: the browser index keeps carrying metadata alone so its payload stays small, and the content index keeps the extracted prose. the shared list is what makes the parity structural instead of something to remember, which answers the half of the issue asking for the missing corpus to be recorded as a decision.

`content-index.ts` also drops a per-page cast it needed only because it declared its own page type by hand. `SearchablePage` types the shared list once and both builders check against it with no cast.

`/examples` stays in the corpus rather than being filtered out as an index stub. the tap docs root is filtered (`getTapDocsPages`) because it redirects and renders nothing of its own; `/examples` renders the gallery under exactly the title and description its MDX frontmatter carries, so searching "examples" should reach it.

## Verification

`apps/docs` vitest: 96 files, 794 tests, green (7 skipped).

the new `lib/search/corpus.test.ts` is the reproduction. removing `examples.getPages()` from the shared list fails it:

```
FAIL  lib/search/corpus.test.ts > search corpora > reaches an example page from both corpora
AssertionError: expected [ '/docs/ui/thread', …(3) ] to include '/examples/perplexity'
```

it also pins the parity itself (both corpora cover the same URLs) so a future builder cannot go back to its own literal list, and pins the browser record staying metadata-only.

`tsc --noEmit` over `apps/docs` reports nothing under `lib/search`. `oxlint` and `oxfmt` clean on the touched files.

## Public surface

none. `@assistant-ui/docs` is private, so no changeset. no published package, export, api-reference page or template is touched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Fm2gR-v-pM1nGXCkFq_7LUJ38Iy-U_FDRuzEMA4AeRU_lM3tBvBPhhXQpjI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->