### PR TITLE
fix(react-streamdown): keep remend escapes out of settled fences and math

### DIFF
--- a/.changeset/streamdown-remend-protect-fences-math.md
+++ b/.changeset/streamdown-remend-protect-fences-math.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: keep remend escapes out of settled `~~~` fences and `$$` math blocks

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -217,6 +217,12 @@ describe("tailBoundedRemend", () => {
     );
   });
 
+  it("opens a new root fence at a root marker inside a quoted fence", () => {
+    const text = "> ```js\n> foo() 1~2\n```\nx~y\n\nTail **bold";
+    expect(findRemendWindowStart(text)).toBe(0);
+    expect(tailBoundedRemend(text)).toBe(text);
+  });
+
   it("reads a backtick run with a backtick in its info string as inline code", () => {
     const text = "```code```\n\n20~25\n\nTail";
     expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));
@@ -250,6 +256,22 @@ describe("tailBoundedRemend", () => {
         ],
       }),
     ).toBe("Final\n\n~~~\nDraft\n~~~\n\nFinal\n\nTail");
+  });
+
+  it("hands custom handlers each prose segment and the final block in order", () => {
+    const calls: string[] = [];
+    tailBoundedRemend("Draft\n\n~~~\nDraft\n~~~\n\nDraft\n\nTail", {
+      handlers: [
+        {
+          name: "record",
+          handle: (text) => {
+            calls.push(text);
+            return text;
+          },
+        },
+      ],
+    });
+    expect(calls).toEqual(["Draft\n\n", "\n\nDraft\n\n", "Tail"]);
   });
 
   it("keeps an unclosed fence inside the window", () => {

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -219,6 +219,15 @@ describe("tailBoundedRemend", () => {
     expect(tailBoundedRemend(tilde)).toBe(tilde);
   });
 
+  it("keeps the boundary out of math when a quoted fence ends inside it", () => {
+    const closed = "$$\n> ```js\n> a~b\nmore\n$$\n\nTail";
+    expect(findRemendWindowStart(closed)).toBe(closed.indexOf("Tail"));
+    expect(tailBoundedRemend(closed)).toBe(closed);
+    const open = "$$\n> ```js\n> a~b\nmore";
+    expect(findRemendWindowStart(open)).toBe(0);
+    expect(blocksOf(tailBoundedRemend(open))).toEqual(blocksOf(remend(open)));
+  });
+
   it("closes a quoted fence on a quoted marker", () => {
     expect(tailBoundedRemend("> ```js\n> foo() 1~2\n> ```\n\nx~y **bold")).toBe(
       "> ```js\n> foo() 1~2\n> ```\n\nx\\~y **bold**",

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -123,6 +123,37 @@ describe("tailBoundedRemend", () => {
     expect(tailBoundedRemend(text)).toBe(text);
   });
 
+  it.each([
+    ["tilde fence", "Intro\n\n~~~r\nlm(y~x)\n~~~"],
+    ["display math", "Intro\n\n$$\na~b\n$$"],
+    ["tilde fence with trailing newline", "Intro\n\n~~~r\nlm(y~x)\n~~~\n"],
+  ])("leaves a closed %s untouched when it is the final block", (_, text) => {
+    expect(tailBoundedRemend(text)).toBe(text);
+  });
+
+  it("repairs text that follows a closed final-block fence", () => {
+    expect(tailBoundedRemend("Intro\n\n~~~r\nlm(y~x)\n~~~\nafter **bold")).toBe(
+      "Intro\n\n~~~r\nlm(y~x)\n~~~\nafter **bold**",
+    );
+  });
+
+  it("still repairs a final block that starts with prose before a fence", () => {
+    const text = "intro\n\npara **bold\n~~~\nx~y\n~~~";
+    expect(tailBoundedRemend(text)).toBe(remend(text));
+  });
+
+  it("ignores $$ inside inline code when placing math blocks", () => {
+    const text = "`$$`\n\n$$\na~b\n$$\n\nTail";
+    expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));
+    expect(tailBoundedRemend(text)).toBe(text);
+  });
+
+  it("reads a backtick run with a backtick in its info string as inline code", () => {
+    const text = "```code```\n\n20~25\n\nTail";
+    expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));
+    expect(tailBoundedRemend(text)).toBe("```code```\n\n20\\~25\n\nTail");
+  });
+
   it("escapes prose on both sides of protected blocks", () => {
     expect(
       tailBoundedRemend(

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -153,6 +153,30 @@ describe("tailBoundedRemend", () => {
     expect(tailBoundedRemend(text)).toBe(text);
   });
 
+  it("does not open a code span at an escaped backtick", () => {
+    const text = "x \\` $$ a ` $$ b\n\n$$\nc~d\n$$\n\nTail";
+    expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));
+    expect(tailBoundedRemend(text)).toBe(text);
+  });
+
+  it("carries an open code span across lines of its paragraph", () => {
+    const text = "a `x\n1 $$ 2` b\n\n$$\na~b\n$$\n\nTail";
+    expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));
+    expect(tailBoundedRemend(text)).toBe(text);
+  });
+
+  it("ends an open code span at a blank line", () => {
+    const text = "a `x\n\n$$\n1~2\n$$\n\nTail";
+    expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));
+    expect(tailBoundedRemend(text)).toBe(text);
+  });
+
+  it("lets a line-start $$ interrupt an open code span", () => {
+    const text = "a `code\n$$` b\n\n$$\nx~y\n$$\n\nTail";
+    expect(tailBoundedRemend(text)).toBe(remend(text));
+    expect(tailBoundedRemend(text)).toContain("x\\~y");
+  });
+
   it("reads a backtick run with a backtick in its info string as inline code", () => {
     const text = "```code```\n\n20~25\n\nTail";
     expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -199,6 +199,24 @@ describe("tailBoundedRemend", () => {
     );
   });
 
+  it("does not close a root fence on a quoted marker", () => {
+    const text = "```md\n> ```\n\n> x~y\n> ```\n```\n\nTail";
+    expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));
+    expect(tailBoundedRemend(text)).toBe(text);
+  });
+
+  it("ends a quoted fence with its blockquote", () => {
+    expect(
+      tailBoundedRemend("> ```js\n> foo() 1~2\n\nBack x~y and **bold"),
+    ).toBe("> ```js\n> foo() 1~2\n\nBack x\\~y and **bold**");
+  });
+
+  it("closes a quoted fence on a quoted marker", () => {
+    expect(tailBoundedRemend("> ```js\n> foo() 1~2\n> ```\n\nx~y **bold")).toBe(
+      "> ```js\n> foo() 1~2\n> ```\n\nx\\~y **bold**",
+    );
+  });
+
   it("reads a backtick run with a backtick in its info string as inline code", () => {
     const text = "```code```\n\n20~25\n\nTail";
     expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -211,6 +211,14 @@ describe("tailBoundedRemend", () => {
     ).toBe("> ```js\n> foo() 1~2\n\nBack x\\~y and **bold**");
   });
 
+  it("moves the boundary past a quoted fence that ends with its blockquote", () => {
+    const text = "para\n\n> intro **bold\n> ```js\n> foo()\n\nTail";
+    expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));
+    expect(tailBoundedRemend(text)).toBe(text);
+    const tilde = "para\n\n> intro\n> ~~~r\n> lm(y~x)\n\nTail";
+    expect(tailBoundedRemend(tilde)).toBe(tilde);
+  });
+
   it("closes a quoted fence on a quoted marker", () => {
     expect(tailBoundedRemend("> ```js\n> foo() 1~2\n> ```\n\nx~y **bold")).toBe(
       "> ```js\n> foo() 1~2\n> ```\n\nx\\~y **bold**",
@@ -219,7 +227,7 @@ describe("tailBoundedRemend", () => {
 
   it("opens a new root fence at a root marker inside a quoted fence", () => {
     const text = "> ```js\n> foo() 1~2\n```\nx~y\n\nTail **bold";
-    expect(findRemendWindowStart(text)).toBe(0);
+    expect(findRemendWindowStart(text)).toBe(text.indexOf("```\nx"));
     expect(tailBoundedRemend(text)).toBe(text);
   });
 

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -142,8 +142,13 @@ describe("tailBoundedRemend", () => {
     expect(tailBoundedRemend(text)).toBe(remend(text));
   });
 
-  it("ignores $$ inside inline code when placing math blocks", () => {
-    const text = "`$$`\n\n$$\na~b\n$$\n\nTail";
+  it.each([
+    ["single backtick", "`$$`"],
+    ["double backtick", "``$$``"],
+    ["double backtick holding a single one", "``a ` $$``"],
+    ["double backtick around a single-backtick span", "`` `$$` ``"],
+  ])("ignores $$ inside a %s code span when placing math blocks", (_, span) => {
+    const text = `${span}\n\n$$\na~b\n$$\n\nTail`;
     expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));
     expect(tailBoundedRemend(text)).toBe(text);
   });

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -98,6 +98,60 @@ describe("tailBoundedRemend", () => {
     );
   });
 
+  it.each([
+    ["Costs $5 today. Use lm(y~x) now.", "Costs $5 today. Use lm(y\\~x) now."],
+    [
+      "Price is $5.\n\nUse lm(y~x) here.",
+      "Price is $5.\n\nUse lm(y\\~x) here.",
+    ],
+    ["Some prose\n    lm(y~x)", "Some prose\n    lm(y\\~x)"],
+    ["- a\n    - b uses x~y", "- a\n    - b uses x\\~y"],
+  ])("keeps escaping prose near currency and indentation: %j", (text, out) => {
+    expect(tailBoundedRemend(text)).toBe(out);
+    expect(tailBoundedRemend(`${text}\n\nTail`)).toBe(`${out}\n\nTail`);
+  });
+
+  it.each([
+    ["backtick fence", "```r\nlm(y~x)\n```"],
+    ["tilde fence", "~~~r\nlm(y~x)\n~~~"],
+    ["display math", "$$\na~b\n$$"],
+    ["single-line display math", "$$a~b$$"],
+    ["fence with a list comparison", "~~~\n- > 25\n~~~"],
+    ["fence inside display math", "$$\n```\na~b\n```\n$$"],
+  ])("leaves a settled %s untouched", (_, block) => {
+    const text = `${block}\n\nTail`;
+    expect(tailBoundedRemend(text)).toBe(text);
+  });
+
+  it("escapes prose on both sides of protected blocks", () => {
+    expect(
+      tailBoundedRemend(
+        "20~25\n\n~~~\nx~y\n~~~\n\n$$\na~b\n$$ and 1~2\n\n30~35\n\n- > 25\n\nTail",
+      ),
+    ).toBe(
+      "20\\~25\n\n~~~\nx~y\n~~~\n\n$$\na~b\n$$ and 1\\~2\n\n30\\~35\n\n- \\> 25\n\nTail",
+    );
+  });
+
+  it("protects only $$ blocks that open a line", () => {
+    expect(tailBoundedRemend("See $$a~b$$ here\n\nTail")).toBe(
+      "See $$a\\~b$$ here\n\nTail",
+    );
+    expect(tailBoundedRemend("`$$` x~y\n\n`$$` 1~2\n\nTail")).toBe(
+      "`$$` x\\~y\n\n`$$` 1\\~2\n\nTail",
+    );
+  });
+
+  it("runs custom handlers on the prose between protected blocks", () => {
+    expect(
+      tailBoundedRemend("Draft\n\n~~~\nDraft\n~~~\n\nDraft\n\nTail", {
+        handlers: [
+          { name: "rename", handle: (text) => text.replace("Draft", "Final") },
+        ],
+      }),
+    ).toBe("Final\n\n~~~\nDraft\n~~~\n\nFinal\n\nTail");
+  });
+
   it("keeps an unclosed fence inside the window", () => {
     const text = `intro\n\n\`\`\`python\n${"x = 1\n".repeat(500)}print("$dollar")`;
     expect(findRemendWindowStart(text)).toBe(text.indexOf("```python"));

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -177,6 +177,28 @@ describe("tailBoundedRemend", () => {
     expect(tailBoundedRemend(text)).toContain("x\\~y");
   });
 
+  it("opens a code span at a backtick after an escaped backslash", () => {
+    const text = "x \\\\` $$ ` y\n\n$$\nc~d\n$$\n\nTail";
+    expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));
+    expect(tailBoundedRemend(text)).toBe(text);
+  });
+
+  it.each([
+    ["tilde fence", "~~~r\nlm(y~x)\n~~~"],
+    ["display math", "$$\na~b\n$$"],
+    ["blockquoted display math", "> $$\n> a~b\n> $$"],
+    ["blockquoted tilde fence", "> ~~~r\n> lm(y~x)\n> ~~~"],
+  ])("leaves a %s untouched when it is the whole message", (_, text) => {
+    expect(tailBoundedRemend(text)).toBe(text);
+    expect(tailBoundedRemend(`${text}\n\nTail`)).toBe(`${text}\n\nTail`);
+  });
+
+  it("repairs text that follows a whole-message fence without a blank line", () => {
+    expect(tailBoundedRemend("~~~r\nlm(y~x)\n~~~\nafter **bold")).toBe(
+      "~~~r\nlm(y~x)\n~~~\nafter **bold**",
+    );
+  });
+
   it("reads a backtick run with a backtick in its info string as inline code", () => {
     const text = "```code```\n\n20~25\n\nTail";
     expect(findRemendWindowStart(text)).toBe(text.indexOf("Tail"));

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -21,18 +21,24 @@ function backtickRun(text: string, from: number, to: number): number {
   return end;
 }
 
-function skipCodeSpan(text: string, from: number, lineEnd: number): number {
-  const open = backtickRun(text, from, lineEnd);
-  const length = open - from;
-  for (let s = open; s < lineEnd;) {
+function closeCodeSpan(
+  text: string,
+  from: number,
+  lineEnd: number,
+  length: number,
+): number {
+  for (let s = from; s < lineEnd;) {
     const next = text.indexOf("`", s);
-    if (next === -1 || next >= lineEnd) break;
+    if (next === -1 || next >= lineEnd) return -1;
     const end = backtickRun(text, next, lineEnd);
     if (end - next === length) return end;
     s = end;
   }
-  return open;
+  return -1;
 }
+
+const isEscaped = (text: string, at: number) =>
+  at > 0 && text.charCodeAt(at - 1) === BACKSLASH;
 
 function onlyWhitespace(text: string, from: number, to: number): boolean {
   for (let i = from; i < to; i += 1) {
@@ -53,8 +59,11 @@ type BlockScan = {
  * at a line start because remend drops a single trailing space from its input,
  * so a cut inside a line would lose the space before the range; that rule also
  * keeps a `$$` inside a backtick span at a line start out of the set. Backtick
- * spans are skipped while scanning a line for `$$`, and a backtick run whose
- * info string holds another backtick is a code span, not a fence opener.
+ * spans are skipped while scanning for `$$`; an unclosed span carries into the
+ * following lines of its paragraph, and a blank line, a fence marker, or a
+ * line-start `$$` ends it the way they end a paragraph. An escaped backtick
+ * opens no span, and a backtick run whose info string holds another backtick
+ * is a code span, not a fence opener.
  */
 function scanBlocks(text: string): BlockScan {
   const n = text.length;
@@ -64,6 +73,7 @@ function scanBlocks(text: string): BlockScan {
   let fenceStart = 0;
   let inMath = false;
   let mathStart = -1;
+  let spanRun = 0;
   let boundary = 0;
   let pending = -1;
   const protectedRanges: number[] = [];
@@ -86,6 +96,7 @@ function scanBlocks(text: string): BlockScan {
         (inFence || first === TILDE || !hasBacktick(text, run, lineEnd))
       ) {
         marker = true;
+        spanRun = 0;
         if (!inFence) {
           inFence = true;
           fenceChar = first;
@@ -104,14 +115,35 @@ function scanBlocks(text: string): BlockScan {
 
     if (!inFence && !marker) {
       let s = lineStart;
-      while (s < lineEnd - 1) {
-        if (text.charCodeAt(s) === BACKTICK) {
-          s = skipCodeSpan(text, s, lineEnd);
-        } else if (
-          text.charCodeAt(s) === DOLLAR &&
-          text.charCodeAt(s + 1) === DOLLAR
+      if (spanRun !== 0) {
+        if (
+          first === -1 ||
+          (first === DOLLAR && text.charCodeAt(i + 1) === DOLLAR)
         ) {
-          if (s === 0 || text.charCodeAt(s - 1) !== BACKSLASH) {
+          spanRun = 0;
+        } else {
+          const end = closeCodeSpan(text, lineStart, lineEnd, spanRun);
+          if (end === -1) {
+            s = lineEnd;
+          } else {
+            s = end;
+            spanRun = 0;
+          }
+        }
+      }
+      while (s < lineEnd - 1) {
+        const c = text.charCodeAt(s);
+        if (c === BACKTICK && !inMath && !isEscaped(text, s)) {
+          const open = backtickRun(text, s, lineEnd);
+          const end = closeCodeSpan(text, open, lineEnd, open - s);
+          if (end === -1) {
+            spanRun = open - s;
+            s = lineEnd;
+          } else {
+            s = end;
+          }
+        } else if (c === DOLLAR && text.charCodeAt(s + 1) === DOLLAR) {
+          if (!isEscaped(text, s)) {
             if (inMath) {
               if (mathStart !== -1) protectedRanges.push(mathStart, s + 2);
             } else {

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -66,7 +66,9 @@ type BlockScan = {
  * so a cut inside a line would lose the space before the range; that rule also
  * keeps a `$$` inside a backtick span at a line start out of the set. A line
  * start may carry blockquote markers, the one container prefix
- * `normalizeMathDelimiters` emits around display math. Backtick
+ * `normalizeMathDelimiters` emits around display math; a fence closes only on
+ * a marker in its own container and a quoted fence ends with its blockquote,
+ * as `fenceEnd` in preprocess reads them. Backtick
  * spans are skipped while scanning for `$$`; an unclosed span carries into the
  * following lines of its paragraph, and a blank line, a fence marker, or a
  * line-start `$$` ends it the way they end a paragraph. An escaped backtick
@@ -79,6 +81,7 @@ function scanBlocks(text: string): BlockScan {
   let fenceChar = 0;
   let fenceRun = 0;
   let fenceStart = 0;
+  let fenceQuoted = false;
   let inMath = false;
   let mathStart = -1;
   let spanRun = 0;
@@ -91,14 +94,21 @@ function scanBlocks(text: string): BlockScan {
     if (lineEnd === -1) lineEnd = n;
 
     let i = lineStart;
+    let quoted = false;
     while (i < lineEnd) {
       const c = text.charCodeAt(i);
-      if (!isSpace(c) && c !== GT) break;
+      if (c === GT) quoted = true;
+      else if (!isSpace(c)) break;
       i += 1;
     }
 
     const first = i < lineEnd ? text.charCodeAt(i) : -1;
     let marker = false;
+
+    if (inFence && fenceQuoted && !quoted && first !== -1) {
+      inFence = false;
+      if (!inMath) protectedRanges.push(fenceStart, lineStart - 1);
+    }
 
     if ((first === BACKTICK || first === TILDE) && i - lineStart <= 3) {
       let run = i;
@@ -114,8 +124,10 @@ function scanBlocks(text: string): BlockScan {
           fenceChar = first;
           fenceRun = run - i;
           fenceStart = lineStart;
+          fenceQuoted = quoted;
         } else if (
           first === fenceChar &&
+          quoted === fenceQuoted &&
           run - i >= fenceRun &&
           onlyWhitespace(text, run, lineEnd)
         ) {

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -108,6 +108,8 @@ function scanBlocks(text: string): BlockScan {
     if (inFence && fenceQuoted && !quoted && first !== -1) {
       inFence = false;
       if (!inMath) protectedRanges.push(fenceStart, lineStart - 1);
+      boundary = lineStart;
+      pending = -1;
     }
 
     if ((first === BACKTICK || first === TILDE) && i - lineStart <= 3) {

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -107,9 +107,11 @@ function scanBlocks(text: string): BlockScan {
 
     if (inFence && fenceQuoted && !quoted && first !== -1) {
       inFence = false;
-      if (!inMath) protectedRanges.push(fenceStart, lineStart - 1);
-      boundary = lineStart;
-      pending = -1;
+      if (!inMath) {
+        protectedRanges.push(fenceStart, lineStart - 1);
+        boundary = lineStart;
+        pending = -1;
+      }
     }
 
     if ((first === BACKTICK || first === TILDE) && i - lineStart <= 3) {

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -7,6 +7,7 @@ const TAB = 9;
 const CR = 13;
 const BACKSLASH = 92;
 const DOLLAR = 36;
+const GT = 62;
 
 const isSpace = (c: number) => c === SPACE || c === TAB || c === CR;
 
@@ -37,8 +38,13 @@ function closeCodeSpan(
   return -1;
 }
 
-const isEscaped = (text: string, at: number) =>
-  at > 0 && text.charCodeAt(at - 1) === BACKSLASH;
+function isEscaped(text: string, at: number): boolean {
+  let backslashes = 0;
+  for (let i = at - 1; i >= 0 && text.charCodeAt(i) === BACKSLASH; i -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
 
 function onlyWhitespace(text: string, from: number, to: number): boolean {
   for (let i = from; i < to; i += 1) {
@@ -58,7 +64,9 @@ type BlockScan = {
  * fences and closed `$$` blocks as flat start/end pairs. A range always starts
  * at a line start because remend drops a single trailing space from its input,
  * so a cut inside a line would lose the space before the range; that rule also
- * keeps a `$$` inside a backtick span at a line start out of the set. Backtick
+ * keeps a `$$` inside a backtick span at a line start out of the set. A line
+ * start may carry blockquote markers, the one container prefix
+ * `normalizeMathDelimiters` emits around display math. Backtick
  * spans are skipped while scanning for `$$`; an unclosed span carries into the
  * following lines of its paragraph, and a blank line, a fence marker, or a
  * line-start `$$` ends it the way they end a paragraph. An escaped backtick
@@ -83,7 +91,11 @@ function scanBlocks(text: string): BlockScan {
     if (lineEnd === -1) lineEnd = n;
 
     let i = lineStart;
-    while (i < lineEnd && isSpace(text.charCodeAt(i))) i += 1;
+    while (i < lineEnd) {
+      const c = text.charCodeAt(i);
+      if (!isSpace(c) && c !== GT) break;
+      i += 1;
+    }
 
     const first = i < lineEnd ? text.charCodeAt(i) : -1;
     let marker = false;
@@ -219,7 +231,7 @@ export function tailBoundedRemend(
   options?: RemendOptions,
 ): string {
   const { boundary: start, protectedRanges } = scanBlocks(text);
-  if (start <= 0) return remend(text, options);
+  if (start <= 0 && protectedRanges[0] !== 0) return remend(text, options);
 
   const prefixOptions = { ...options, ...COMPLETION_OFF };
   let out = "";

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -17,18 +17,30 @@ function onlyWhitespace(text: string, from: number, to: number): boolean {
   return true;
 }
 
+type BlockScan = {
+  boundary: number;
+  protectedRanges: number[];
+};
+
 /**
- * Returns the start of the last block outside open code fences and `$$` math.
- * Completion can use this boundary, but escapes must also reach earlier text.
+ * Single pass over the message. `boundary` is the start of the last block
+ * outside open code fences and `$$` math. `protectedRanges` holds closed
+ * fences and closed `$$` blocks as flat start/end pairs. A range always starts
+ * at a line start because remend drops a single trailing space from its input,
+ * so a cut inside a line would lose the space before the range; that rule also
+ * keeps a `$$` inside a backtick span at a line start out of the set.
  */
-export function findRemendWindowStart(text: string): number {
+function scanBlocks(text: string): BlockScan {
   const n = text.length;
   let inFence = false;
   let fenceChar = 0;
   let fenceRun = 0;
+  let fenceStart = 0;
   let inMath = false;
+  let mathStart = -1;
   let boundary = 0;
   let pending = -1;
+  const protectedRanges: number[] = [];
 
   for (let lineStart = 0; lineStart <= n;) {
     let lineEnd = text.indexOf("\n", lineStart);
@@ -49,12 +61,14 @@ export function findRemendWindowStart(text: string): number {
           inFence = true;
           fenceChar = first;
           fenceRun = run - i;
+          fenceStart = lineStart;
         } else if (
           first === fenceChar &&
           run - i >= fenceRun &&
           onlyWhitespace(text, run, lineEnd)
         ) {
           inFence = false;
+          if (!inMath) protectedRanges.push(fenceStart, lineEnd);
         }
       }
     }
@@ -67,6 +81,11 @@ export function findRemendWindowStart(text: string): number {
           text.charCodeAt(s + 1) === DOLLAR
         ) {
           if (s === 0 || text.charCodeAt(s - 1) !== BACKSLASH) {
+            if (inMath) {
+              if (mathStart !== -1) protectedRanges.push(mathStart, s + 2);
+            } else {
+              mathStart = s === i ? lineStart : -1;
+            }
             inMath = !inMath;
           }
           s += 2;
@@ -86,7 +105,15 @@ export function findRemendWindowStart(text: string): number {
     lineStart = lineEnd + 1;
   }
 
-  return boundary;
+  return { boundary, protectedRanges };
+}
+
+/**
+ * Returns the start of the last block outside open code fences and `$$` math.
+ * Completion can use this boundary, but escapes must also reach earlier text.
+ */
+export function findRemendWindowStart(text: string): number {
+  return scanBlocks(text).boundary;
 }
 
 /**
@@ -95,7 +122,8 @@ export function findRemendWindowStart(text: string): number {
  * disabled `links` handler. Every other option completes a dangling opener,
  * which mutates or deletes a block that has already settled, so the prefix pass
  * disables all of them. The two escapes skip backtick fences and inline spans
- * but not `~~~` fences, indented code, or math.
+ * but not `~~~` fences or math, so the prefix pass hands remend only the text
+ * between the closed fences and `$$` blocks the scan found.
  */
 type PrefixSafeOption =
   | "singleTilde"
@@ -119,17 +147,34 @@ const COMPLETION_OFF = {
 
 /**
  * Repairs incomplete Markdown in the final block and applies text escapes to
- * earlier blocks. Custom handlers receive the prefix and final block separately.
+ * earlier blocks. Custom handlers receive the final block and each run of
+ * earlier prose between protected blocks as separate calls.
  */
 export function tailBoundedRemend(
   text: string,
   options?: RemendOptions,
 ): string {
-  const start = findRemendWindowStart(text);
+  const { boundary: start, protectedRanges } = scanBlocks(text);
   if (start <= 0) return remend(text, options);
 
+  const prefixOptions = { ...options, ...COMPLETION_OFF };
+  let out = "";
+  let cursor = 0;
+  for (
+    let k = 0;
+    k + 1 < protectedRanges.length && protectedRanges[k + 1]! <= start;
+    k += 2
+  ) {
+    const from = protectedRanges[k]!;
+    const to = protectedRanges[k + 1]!;
+    out +=
+      remend(text.slice(cursor, from), prefixOptions) + text.slice(from, to);
+    cursor = to;
+  }
+
   return (
-    remend(text.slice(0, start), { ...options, ...COMPLETION_OFF }) +
+    out +
+    remend(text.slice(cursor, start), prefixOptions) +
     remend(text.slice(start), options)
   );
 }

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -10,6 +10,11 @@ const DOLLAR = 36;
 
 const isSpace = (c: number) => c === SPACE || c === TAB || c === CR;
 
+function hasBacktick(text: string, from: number, to: number): boolean {
+  const i = text.indexOf("`", from);
+  return i !== -1 && i < to;
+}
+
 function onlyWhitespace(text: string, from: number, to: number): boolean {
   for (let i = from; i < to; i += 1) {
     if (!isSpace(text.charCodeAt(i))) return false;
@@ -28,7 +33,9 @@ type BlockScan = {
  * fences and closed `$$` blocks as flat start/end pairs. A range always starts
  * at a line start because remend drops a single trailing space from its input,
  * so a cut inside a line would lose the space before the range; that rule also
- * keeps a `$$` inside a backtick span at a line start out of the set.
+ * keeps a `$$` inside a backtick span at a line start out of the set. Backtick
+ * spans are skipped while scanning a line for `$$`, and a backtick run whose
+ * info string holds another backtick is a code span, not a fence opener.
  */
 function scanBlocks(text: string): BlockScan {
   const n = text.length;
@@ -55,7 +62,10 @@ function scanBlocks(text: string): BlockScan {
     if ((first === BACKTICK || first === TILDE) && i - lineStart <= 3) {
       let run = i;
       while (run < lineEnd && text.charCodeAt(run) === first) run += 1;
-      if (run - i >= 3) {
+      if (
+        run - i >= 3 &&
+        (inFence || first === TILDE || !hasBacktick(text, run, lineEnd))
+      ) {
         marker = true;
         if (!inFence) {
           inFence = true;
@@ -76,7 +86,10 @@ function scanBlocks(text: string): BlockScan {
     if (!inFence && !marker) {
       let s = lineStart;
       while (s < lineEnd - 1) {
-        if (
+        if (text.charCodeAt(s) === BACKTICK) {
+          const close = text.indexOf("`", s + 1);
+          s = close === -1 || close > lineEnd ? lineEnd : close + 1;
+        } else if (
           text.charCodeAt(s) === DOLLAR &&
           text.charCodeAt(s + 1) === DOLLAR
         ) {
@@ -147,7 +160,8 @@ const COMPLETION_OFF = {
 
 /**
  * Repairs incomplete Markdown in the final block and applies text escapes to
- * earlier blocks. Custom handlers receive the final block and each run of
+ * earlier blocks. A closed fence or `$$` block that opens the final block is
+ * copied raw and only the text after it is repaired. Custom handlers receive the final block and each run of
  * earlier prose between protected blocks as separate calls.
  */
 export function tailBoundedRemend(
@@ -172,9 +186,13 @@ export function tailBoundedRemend(
     cursor = to;
   }
 
-  return (
-    out +
-    remend(text.slice(cursor, start), prefixOptions) +
-    remend(text.slice(start), options)
-  );
+  out += remend(text.slice(cursor, start), prefixOptions);
+
+  const tailRange = protectedRanges.indexOf(start);
+  if (tailRange !== -1 && tailRange % 2 === 0) {
+    const to = protectedRanges[tailRange + 1]!;
+    return out + text.slice(start, to) + remend(text.slice(to), options);
+  }
+
+  return out + remend(text.slice(start), options);
 }

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -15,6 +15,25 @@ function hasBacktick(text: string, from: number, to: number): boolean {
   return i !== -1 && i < to;
 }
 
+function backtickRun(text: string, from: number, to: number): number {
+  let end = from;
+  while (end < to && text.charCodeAt(end) === BACKTICK) end += 1;
+  return end;
+}
+
+function skipCodeSpan(text: string, from: number, lineEnd: number): number {
+  const open = backtickRun(text, from, lineEnd);
+  const length = open - from;
+  for (let s = open; s < lineEnd;) {
+    const next = text.indexOf("`", s);
+    if (next === -1 || next >= lineEnd) break;
+    const end = backtickRun(text, next, lineEnd);
+    if (end - next === length) return end;
+    s = end;
+  }
+  return open;
+}
+
 function onlyWhitespace(text: string, from: number, to: number): boolean {
   for (let i = from; i < to; i += 1) {
     if (!isSpace(text.charCodeAt(i))) return false;
@@ -87,8 +106,7 @@ function scanBlocks(text: string): BlockScan {
       let s = lineStart;
       while (s < lineEnd - 1) {
         if (text.charCodeAt(s) === BACKTICK) {
-          const close = text.indexOf("`", s + 1);
-          s = close === -1 || close > lineEnd ? lineEnd : close + 1;
+          s = skipCodeSpan(text, s, lineEnd);
         } else if (
           text.charCodeAt(s) === DOLLAR &&
           text.charCodeAt(s + 1) === DOLLAR
@@ -174,13 +192,11 @@ export function tailBoundedRemend(
   const prefixOptions = { ...options, ...COMPLETION_OFF };
   let out = "";
   let cursor = 0;
-  for (
-    let k = 0;
-    k + 1 < protectedRanges.length && protectedRanges[k + 1]! <= start;
-    k += 2
-  ) {
+  let k = 0;
+  for (; k + 1 < protectedRanges.length; k += 2) {
     const from = protectedRanges[k]!;
     const to = protectedRanges[k + 1]!;
+    if (to > start) break;
     out +=
       remend(text.slice(cursor, from), prefixOptions) + text.slice(from, to);
     cursor = to;
@@ -188,9 +204,8 @@ export function tailBoundedRemend(
 
   out += remend(text.slice(cursor, start), prefixOptions);
 
-  const tailRange = protectedRanges.indexOf(start);
-  if (tailRange !== -1 && tailRange % 2 === 0) {
-    const to = protectedRanges[tailRange + 1]!;
+  if (protectedRanges[k] === start) {
+    const to = protectedRanges[k + 1]!;
     return out + text.slice(start, to) + remend(text.slice(to), options);
   }
 

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -201,8 +201,8 @@
   },
   "@assistant-ui/react-streamdown": {
     ".": {
-      "min": 10856,
-      "gzip": 4454
+      "min": 12016,
+      "gzip": 4929
     }
   },
   "@assistant-ui/react-syntax-highlighter": {


### PR DESCRIPTION
## Problem

During streaming, `tailBoundedRemend` hands every settled block of the message to `remend` with completion disabled so the `singleTilde` and `comparisonOperators` escapes persist across paragraphs. `remend@1.3.1`'s code lookup recognizes backtick fences and inline backtick spans only, so a settled `~~~` fence or `$$` math block has every word-adjacent `~` rewritten to `\~` for the rest of the stream: `lm(y~x)` inside `~~~r` renders as `lm(y\~x)`, and `a~b` inside `$$` renders as `a\~b`.

Closes #6938

## Root cause

`findRemendWindowStart` already tracks fence open and close and `$$` toggles line by line, but only to place the completion boundary. The prefix pass then trusted remend's own lookup for the whole prefix string, and that lookup is backtick-only.

## Change

The scan loop moves into an internal `scanBlocks` that returns the boundary plus the closed fenced blocks (backtick or tilde) and closed `$$` blocks it passed as flat start and end pairs. `findRemendWindowStart` is a one-line wrapper with the same signature and result. `tailBoundedRemend` emits the prefix as prose segments handed to remend with completion off, alternating with the protected ranges copied raw, then runs the tail exactly as before. Same single pass; every backtick search stops at the line end, so a span that stays open through a long paragraph keeps the scan linear; one extra array that stays empty on paragraph-only messages.

A range always starts at a line start. remend drops one trailing space from any input, so a cut mid-line (`See $$a~b$$`) would lose the space before the range; the rule also keeps a `$$` inside a backtick span at a line start (`` `$$` ``) out of the set. remend's exported `isWithinMathBlock` was not reused because it treats a lone `$` as an inline math opener, which would leave `Costs $5 today. Use lm(y~x) now.` unescaped.

- Indented code and fences opened inside list items are not protected: a line scan has no list context, and `Some prose\n    lm(y~x)` and `- a\n    - b uses x~y` are paragraph continuation and a nested list item, not code. Indented code blocks and fences indented four spaces inside list items therefore keep the escape, as on main; #7449 tracks them.
- Single-`$` inline math is not protected for the same ambiguity with currency that makes remend default `inlineKatex` to false.
- A closed fence or `$$` block that opens the final block is copied raw and only the text after it is repaired, so a message that ends in a fence (the reported shape, and `mode` defaults to `"streaming"` so repair keeps running after the stream ends) no longer shows the escape. A fence that starts later in the final block (`para **bold` + `~~~`) is left to full remend as before, because protecting it would move the completion markers before the fence.
- Backtick spans are skipped while scanning for `$$`, matching the closing run to the opening run's length as CommonMark does, so a literal `` `$$` `` or `` ``$$`` `` no longer toggles the math state and hides a later `$$` block. A span that does not close on its line carries into the following lines of its paragraph; a blank line, a fence marker, or a line-start `$$` ends it, because each of those ends the paragraph in remark-math too. An escaped backtick opens no span, using backslash parity so `\\` followed by a backtick still opens one, and backticks inside a `$$` block are math text, not spans. An unmatched mid-line `$$` still opens math, as on main. A backtick run whose info string holds another backtick (```` ```code``` ````) is inline code, not a fence opener, matching CommonMark and upstream streamdown; on main that line pinned the boundary at zero.
- An opener backtick that is the last character of its line is not seen, because the line loop stops one character early for the two-character `$$` check; visiting it cost a measurable share of the scan on short lines and its absence only falls back to main's reading of the next line.
- A line start may carry blockquote markers, so `> $$` and `> ~~~` blocks are protected. A fence closes only on a marker in its own container, so a quoted marker inside a root fence stays content, and a quoted fence ends with its blockquote on the first non-blank line that drops the marker, which also starts the next block so the boundary moves there, the two rules `fenceEnd` in preprocess applies; `normalizeMathDelimiters` in this package emits that shape for display math written inside a blockquote. A bare `>` line reads as blank inside a blockquote but opens a new block after a blank line, so the first chunk of a new blockquote still settles the blocks before it. Fence indentation counts from the content after the last `>` and its optional space, so a quoted opener and its closer are read the same way. List markers are not read, because preprocess blanks them to spaces on its continuation lines and the scan already skips indentation.
- The scan stays its own pass rather than building on `rewriteOutsideCode` in `preprocess.ts`: it computes the boundary and the ranges in one `charCodeAt` pass per flush, while the preprocess walker is private, copies only backtick and tilde code verbatim with no notion of `$$` blocks, and walks with per-character string indexing plus a regex slice per fence, so reusing it would add a second full pass over the prefix on every flush and the `$$` half would still need this scanner. The leaf rules match: info-string check, exact run length, paragraph-bounded spans, and backslash parity for escapes.
- A whole message that is one closed fence or `$$` block, or such a block followed by text with no blank line, has its boundary at zero; the range path still runs when a protected range starts there.
- A fence line inside a `$$` block is fence content of that math range, not its own range, so the range list stays ascending; a test pins `$$` + backtick fence + `$$` unchanged.
- Custom `handlers` now receive each prose segment between protected ranges separately, the same split the prefix and tail pass already had; a test records the exact call sequence.
- Upstream, vercel/streamdown#571 (open) moves remend to a region scanner that recognizes `~~~` fences at any indentation; its tilde escape still ignores math regions, so the `$$` half is not covered there.

## Verification

Raw output of `tailBoundedRemend` on the issue table and the review probes, main versus this branch:

| input | main | this PR |
| --- | --- | --- |
| ` ```r ` fence + blank line + `Tail` | `lm(y~x)` | `lm(y~x)` |
| `` `lm(y~x)` `` + blank line + `Tail` | `lm(y~x)` | `lm(y~x)` |
| `~~~r` fence + blank line + `Tail` | `lm(y\~x)` | `lm(y~x)` |
| `$$` block + blank line + `Tail` | `a\~b` | `a~b` |
| `$$a~b$$ trailing c~d` + blank line + `Tail` | `a\~b`, `c\~d` | `a~b`, `c\~d` |
| 4-space indented + blank line + `Tail` | `lm(y\~x)` | `lm(y\~x)` (non-goal) |
| `$a~b$` + blank line + `Tail` | `a\~b` | `a\~b` (non-goal) |
| `Intro` + blank line + `~~~r` fence as the final block | `lm(y\~x)` | `lm(y~x)` |
| `Intro` + blank line + `$$` block as the final block | `a\~b` | `a~b` |
| `~~~r` fence as the final block + newline + `after **bold` | `lm(y\~x)`, `**bold**` | `lm(y~x)`, `**bold**` |
| `para **bold` + newline + `~~~` fence as the final block | full remend | full remend (unchanged) |
| `` `$$` `` + blank line + `$$` block + blank line + `Tail` | `a\~b` | `a~b` |
| `` x \` $$ a ` $$ b `` + blank line + `$$` block with `c~d` + blank line + `Tail` | `c~d` | `c~d` (before the review fix: `c~d` plus a stray `` ` `` and `$$` appended) |
| `` a `x `` + newline + `` 1 $$ 2` b `` + blank line + `$$` block with `a~b` + blank line + `Tail` | `a\~b` | `a~b` |
| `` x \\` $$ ` y `` + blank line + `$$` block with `c~d` + blank line + `Tail` | `c~d` plus a stray `` ` `` appended | `c~d` |
| `~~~r` fence with `lm(y~x)` as the whole message | `lm(y\~x)` | `lm(y~x)` |
| `$$` block with `a~b` as the whole message | `a\~b` | `a~b` |
| `> $$` block with `a~b` + blank line + `Tail` | `a\~b` | `a~b` |
| `> ```js` fence with `1~2` + blank line + `Back x~y and **bold` | `1~2`, `x\~y`, `**bold**` | `1~2`, `x\~y`, `**bold**` (before the review fix: nothing escaped or completed) |

Raw output on the currency and indentation acceptance inputs, `tailBoundedRemend` on main versus this branch, verified by running both versions in one process:

| input | main | this PR |
| --- | --- | --- |
| `Costs $5 today. Use lm(y~x) now.` | `Costs $5 today. Use lm(y\~x) now.` | same |
| `Price is $5.\n\nUse lm(y~x) here.` | `Price is $5.\n\nUse lm(y\~x) here.` | same |
| `Some prose\n    lm(y~x)` | `Some prose\n    lm(y\~x)` | same |
| `- a\n    - b uses x~y` | `- a\n    - b uses x\~y` | same |

The same four inputs with a `\n\nTail` suffix also match main, and the test `keeps escaping prose near currency and indentation` pins all eight.

- `packages/react-streamdown`: `pnpm exec vitest run src/__tests__/remend.test.ts` exits 0 (60 tests). With `src/remend.ts` restored to main, the same file exits 1, all failures in the protection tests.
- `packages/react-streamdown`: `pnpm --filter @assistant-ui/react-streamdown test` exits 0 (11 files, 289 tests).
- `pnpm exec oxlint` and `pnpm exec oxfmt --check` on the two files exit 0; `pnpm exec tsc --noEmit -p tsconfig.json` in the package exits 0.
- `pnpm changesets:check` exits 0.
- Bench, `tailBoundedRemend` on main's `remend.ts` and this branch's in one vitest bench process (p50 ops/s, rme under 1% on every row). The three paragraph corpora are the ones in `remend.bench.ts`; mixed is 500 repeats of a code-span line, a `~~~` fence and a `$$` block (34 KB, 1000 protected ranges).

| corpus | main | this PR | full remend |
| --- | --- | --- | --- |
| 732 paragraphs | 6436 | 6431 | 3248 |
| 2926 paragraphs | 1501 | 1575 | 870 |
| 7315 paragraphs | 658 | 660 | 345 |
| mixed 500 blocks | 1485 | 1159 | 33 |

The paragraph rows are within noise of main. The mixed row is the cost of one `remend` call per prose segment between protected ranges; main makes one call there and produces the escaped output this PR fixes.

`remend.bench.ts` also covers an unclosed backtick span followed by a long list with no blank line, the shape where a per-line search that runs past the line end turns quadratic (p50 ops/s, `b072bcc81` against the current head):

| corpus | window scan before | window scan after | tail-bounded before | tail-bounded after |
| --- | --- | --- | --- | --- |
| 1250 list lines | 11887 | 56338 | 7355 | 13808 |
| 5000 list lines | 1034 | 14457 | 858 | 3565 |
| 12500 list lines | 188 | 5479 | 167 | 1427 |

- `pnpm size:check`: `@assistant-ui/react-streamdown .` measures 4990 gzip bytes against the 4454 recorded on main; `pnpm size:update` re-recorded 4929 and touched only this entry, and the review rounds since sit inside tolerance. On the same toolchain main's `remend.ts` measures 4557, so about 400 B is this change (273 B for the protection, the rest for the review fixes) and 103 B is drift already on main. The scanner is a workaround for remend's backtick-only code lookup, so this is the code that shrinks once remend reads fences and math regions itself.

## Public surface

`@assistant-ui/react-streamdown`, patch changeset. `findRemendWindowStart` and `tailBoundedRemend` keep their signatures and results; `scanBlocks` is not exported. No docs, api-reference, or template changes.


