### PR TITLE
fix(assistant-stream): mark tool arguments complete

### DIFF
--- a/.changeset/tool-argument-completion-status.md
+++ b/.changeset/tool-argument-completion-status.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: mark tool arguments complete when their text stream ends

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -97,6 +97,24 @@ describe("AssistantMessageAccumulator tool argument status", () => {
       status: { type: "complete", reason: "stop" },
     });
   });
+
+  it("preserves completed status when argument text finishes after the part", async () => {
+    const messages = await collectStream([
+      {
+        type: "part-start",
+        path: [],
+        part: { type: "tool-call", toolCallId: "tc-1", toolName: "search" },
+      },
+      { type: "text-delta", path: [0], textDelta: '{"q":"test"}' },
+      { type: "part-finish", path: [0] },
+      { type: "tool-call-args-text-finish", path: [0] },
+    ]);
+
+    expect(messages[3]?.parts[0]).toMatchObject({
+      state: "call",
+      status: { type: "complete", reason: "unknown" },
+    });
+  });
 });
 
 describe("AssistantMessageAccumulator timing", () => {

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -78,7 +78,7 @@ describe("AssistantMessageAccumulator tool argument status", () => {
       },
       { type: "text-delta", path: [0], textDelta: '{"q":"test"}' },
       { type: "tool-call-args-text-finish", path: [0] },
-      { type: "result", path: [0], result: "found" },
+      { type: "result", path: [0], result: "found", isError: false },
       { type: "tool-call-args-text-finish", path: [0] },
     ]);
 

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -68,6 +68,37 @@ describe("AssistantMessageAccumulator reasoning summaries", () => {
   });
 });
 
+describe("AssistantMessageAccumulator tool argument status", () => {
+  it("marks arguments complete before the result and preserves a settled result", async () => {
+    const messages = await collectStream([
+      {
+        type: "part-start",
+        path: [],
+        part: { type: "tool-call", toolCallId: "tc-1", toolName: "search" },
+      },
+      { type: "text-delta", path: [0], textDelta: '{"q":"test"}' },
+      { type: "tool-call-args-text-finish", path: [0] },
+      { type: "result", path: [0], result: "found" },
+      { type: "tool-call-args-text-finish", path: [0] },
+    ]);
+
+    expect(messages[1]?.parts[0]).toMatchObject({
+      state: "partial-call",
+      status: { type: "running", isArgsComplete: false },
+    });
+    expect(messages[2]?.parts[0]).toMatchObject({
+      state: "call",
+      args: { q: "test" },
+      status: { type: "running", isArgsComplete: true },
+    });
+    expect(messages.at(-1)?.parts[0]).toMatchObject({
+      state: "result",
+      result: "found",
+      status: { type: "complete", reason: "stop" },
+    });
+  });
+});
+
 describe("AssistantMessageAccumulator timing", () => {
   it("should include timing on message-finish", async () => {
     const chunks: AssistantStreamChunk[] = [

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -176,7 +176,7 @@ const handleToolCallArgsTextFinish = (
       return part;
     }
 
-    if (part.state !== "partial-call") return { ...part };
+    if (part.state !== "partial-call") return part;
 
     return {
       ...part,

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -183,6 +183,7 @@ const handleToolCallArgsTextFinish = (
     return {
       ...part,
       state: "call",
+      status: { type: "running", isArgsComplete: true },
     };
   });
 };

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -176,14 +176,15 @@ const handleToolCallArgsTextFinish = (
       return part;
     }
 
-    // TODO this should never be hit; this happens if args-text-finish is emitted after result
     if (part.state !== "partial-call") return { ...part };
-    // throw new Error("Last is not a partial call");
 
     return {
       ...part,
       state: "call",
-      status: { type: "running", isArgsComplete: true },
+      status:
+        part.status.type === "running"
+          ? { type: "running", isArgsComplete: true }
+          : part.status,
     };
   });
 };


### PR DESCRIPTION
## Problem

A tool call still reports incomplete arguments after its argument text ends, until a result or part-finish event arrives.

Reproduced on base `55c34a62512f901194470c6ad6fc561d69be207b`, with manifest version `assistant-stream@0.3.41`. After dependency installation, this Bun snippet runs from the repository root:

```js
import assert from "node:assert/strict";
import { AssistantMessageAccumulator } from "./packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts";

const chunks = [
  { type: "part-start", path: [], part: { type: "tool-call", toolCallId: "t", toolName: "slow" } },
  { type: "text-delta", path: [0], textDelta: "{}" },
  { type: "tool-call-args-text-finish", path: [0] },
];
const seen = [];
await new ReadableStream({
  start(controller) {
    for (const chunk of chunks) controller.enqueue(chunk);
    controller.close();
  },
}).pipeThrough(new AssistantMessageAccumulator()).pipeTo(
  new WritableStream({ write(message) { seen.push(message); } }),
);
const call = seen.find(message => message.parts[0]?.state === "call").parts[0];
assert.deepEqual(call.status, { type: "running", isArgsComplete: true });
```

The assertion receives `isArgsComplete: false` on the base.

## Root cause

The argument-finish handler changes `partial-call` to `call` but keeps the initial status.

## Change

The same transition sets `isArgsComplete: true`. The tool remains in the running state until its result arrives. Late argument-finish events keep completed results unchanged.

## Verification

The reproduction and focused regression failed before the correction and pass afterward. All 44 tests passed across the accumulator, message stream, tool-call module, and transport interop suites.

The focused regression command, from `packages/assistant-stream`, was `./node_modules/.bin/vitest run src/core/accumulators/assistant-message-accumulator.test.ts -t 'marks arguments complete'`.

`pnpm --filter assistant-stream build` and scoped `oxlint` and `oxfmt --check` passed. The same reproduction also passed through the freshly built public entry in Node.

## Public surface

`assistant-stream` includes a patch changeset. Public exports and signatures stay unchanged. No documentation, API-reference output, or template changes are necessary.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.vWTYd7kExVtt6qzsnjoKrkOTENinShkn7CIG7SIBVdpfCNF2vjJb90WwTeA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->