### PR TITLE
fix(assistant-stream): stop cancelled tools after validation

### DIFF
--- a/.changeset/cancel-tools-after-validation.md
+++ b/.changeset/cancel-tools-after-validation.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: prevent tool execution after cancellation during asynchronous schema validation

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -348,6 +348,7 @@ describe("unstable_runPendingTools", () => {
     expect(execute).not.toHaveBeenCalled();
     expect(settled.parts[0]).toMatchObject({
       state: "result",
+      result: "Tool execution was cancelled.",
       isError: true,
     });
   });

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -317,6 +317,41 @@ describe("unstable_runPendingTools", () => {
     });
   });
 
+  it("does not execute a tool cancelled during async validation", async () => {
+    const abortController = new AbortController();
+    const validation = promiseWithResolvers<{
+      value: Record<string, unknown>;
+    }>();
+    const execute = vi.fn(() => "executed");
+    const pending = unstable_runPendingTools(
+      createPendingToolMessage("async-validation"),
+      {
+        tool: {
+          parameters: {
+            "~standard": {
+              version: 1,
+              vendor: "test",
+              validate: () => validation.promise,
+            },
+          },
+          execute,
+        },
+      },
+      abortController.signal,
+      async () => {},
+    );
+
+    abortController.abort();
+    validation.resolve({ value: {} });
+    const settled = await pending;
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(settled.parts[0]).toMatchObject({
+      state: "result",
+      isError: true,
+    });
+  });
+
   it.each(["resolves", "rejects"] as const)(
     "does not enqueue pending tool output after cancellation when execution %s",
     async (settlement) => {

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -108,6 +108,13 @@ function getToolResponse(
       }
     }
 
+    if (abortSignal.aborted) {
+      return new ToolResponse({
+        result: "Tool execution was cancelled.",
+        isError: true,
+      });
+    }
+
     // Create abort promise that resolves after 2 microtasks
     // This gives tools that handle abort a chance to win the race
     let onAbort!: () => void;

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -66,6 +66,12 @@ const isThenable = (value: unknown): value is PromiseLike<unknown> =>
   typeof (value as PromiseLike<unknown> | null | undefined)?.then ===
   "function";
 
+const cancelledToolResponse = (): ToolResponse<ReadonlyJSONValue> =>
+  new ToolResponse({
+    result: "Tool execution was cancelled.",
+    isError: true,
+  });
+
 function getToolResponse(
   tools: Record<string, Tool> | undefined,
   abortSignal: AbortSignal,
@@ -83,12 +89,8 @@ function getToolResponse(
   const getResult = async (
     toolExecute: ToolExecuteFunction<ReadonlyJSONObject, unknown>,
   ): Promise<ToolResponse<ReadonlyJSONValue>> => {
-    // Check if already aborted before starting
     if (abortSignal.aborted) {
-      return new ToolResponse({
-        result: "Tool execution was cancelled.",
-        isError: true,
-      });
+      return cancelledToolResponse();
     }
 
     let executeFn = toolExecute;
@@ -109,10 +111,7 @@ function getToolResponse(
     }
 
     if (abortSignal.aborted) {
-      return new ToolResponse({
-        result: "Tool execution was cancelled.",
-        isError: true,
-      });
+      return cancelledToolResponse();
     }
 
     // Create abort promise that resolves after 2 microtasks
@@ -123,12 +122,7 @@ function getToolResponse(
         onAbort = () => {
           queueMicrotask(() => {
             queueMicrotask(() => {
-              resolve(
-                new ToolResponse({
-                  result: "Tool execution was cancelled.",
-                  isError: true,
-                }),
-              );
+              resolve(cancelledToolResponse());
             });
           });
         };


### PR DESCRIPTION
## Problem

A cancelled run can still start tool side effects when asynchronous schema validation completes. This occurs in `assistant-stream` 0.3.41 at base `55c34a62512f901194470c6ad6fc561d69be207b`.

The following reproduction runs with Bun from that repository checkout after `pnpm install --frozen-lockfile`. The assertion fails because the tool executes once.

```js
import assert from "node:assert/strict";
import { unstable_runPendingTools } from "./packages/assistant-stream/src/core/tool/toolResultStream.ts";
import { createInitialMessage } from "./packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts";

let finishValidation;
const validation = new Promise(resolve => { finishValidation = resolve; });
let executions = 0;
const part = {
  type: "tool-call", toolCallId: "t", toolName: "save", state: "call",
  status: { type: "running", isArgsComplete: true }, argsText: "{}", args: {},
};
const controller = new AbortController();
const pending = unstable_runPendingTools(
  { ...createInitialMessage(), parts: [part], content: [part] },
  { save: {
    parameters: { "~standard": {
      version: 1, vendor: "example", validate: () => validation,
    } },
    execute: () => { executions++; return "saved"; },
  } },
  controller.signal,
  async () => null,
);
controller.abort();
finishValidation({ value: {} });
await pending;
assert.equal(executions, 0);
```

## Root cause

The cancellation check preceded the validation await. After validation, the cancellation promise did not prevent the immediate call to the tool.

## Change

Cancelled runs return the existing cancellation response before tool execution. The shared correction covers pending and streamed tool calls. Cancellation behavior for tools that already started stays unchanged.

## Verification

The reproduction and new regression failed before the correction and passed afterward. All 28 tests in `toolResultStream.test.ts` passed. The command was `pnpm --filter assistant-stream exec vitest run src/core/tool/toolResultStream.test.ts src/core/tool/ToolExecutionStream.test.ts`. Only `toolResultStream.test.ts` matched.

A Node smoke test against the new build covered pending and streamed calls with valid and invalid arguments. Each case returned cancellation without side effects.

The package build, scoped Oxlint and formatting checks, and `pnpm changesets:check` passed.

## Public surface

The change includes an `assistant-stream` patch changeset. Public exports and signatures stay unchanged. Documentation, API-reference output, and templates need no changes. Validation that never completes remains outside this correction.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.jkpQMH_2jHzqO4bNDp2OeeWehNQtNY_WH3mLpObF2uMEwMOPUU62NhkxKGE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->