### PR TITLE
fix(assistant-stream): remove nested partial schema requirements

### DIFF
--- a/.changeset/partial-schema-nested-required.md
+++ b/.changeset/partial-schema-nested-required.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: remove nested required constraints from partial schemas without properties

--- a/packages/assistant-stream/src/core/tool/schema-utils.test.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.test.ts
@@ -175,6 +175,31 @@ describe("toPartialJSONSchema", () => {
     expect(address.required).toBeUndefined();
   });
 
+  it("removes nested required without properties and preserves value constraints", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        settings: {
+          type: "object" as const,
+          required: ["name"],
+          additionalProperties: { type: "string" as const },
+        },
+      },
+      required: ["settings"],
+    };
+
+    expect(toPartialJSONSchema(schema)).toEqual({
+      type: "object",
+      properties: {
+        settings: {
+          type: "object",
+          additionalProperties: { type: "string" },
+        },
+      },
+    });
+    expect(schema.properties.settings.required).toEqual(["name"]);
+  });
+
   it("leaves array item schemas unchanged", () => {
     const schema = {
       type: "object" as const,

--- a/packages/assistant-stream/src/core/tool/schema-utils.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.ts
@@ -120,8 +120,7 @@ export function toPartialJSONSchema(schema: JSONSchema7): JSONSchema7 {
     result.properties = Object.fromEntries(
       Object.entries(result.properties).map(([key, prop]) => {
         if (typeof prop === "object" && prop !== null && !Array.isArray(prop)) {
-          const p = prop as JSONSchema7;
-          return [key, p.properties != null ? toPartialJSONSchema(p) : prop];
+          return [key, toPartialJSONSchema(prop)];
         }
         return [key, prop];
       }),


### PR DESCRIPTION
## Problem

Partial update schemas still require nested fields when the nested object has no `properties` keyword. For example, `{ settings: {} }` still requires `settings.name`.

This reproduction fails at base `55c34a62512f901194470c6ad6fc561d69be207b` (`assistant-stream` 0.3.41). It passes after the correction:

```js
import assert from "node:assert/strict";
import { toPartialJSONSchema } from "./packages/assistant-stream/src/core/tool/schema-utils.ts";

const partial = toPartialJSONSchema({
  type: "object",
  properties: {
    settings: {
      type: "object",
      required: ["name"],
      additionalProperties: { type: "string" },
    },
  },
  required: ["settings"],
});

assert.equal(partial.properties.settings.required, undefined);
assert.deepEqual(partial.properties.settings.additionalProperties, { type: "string" });
```

The snippet runs with `bun` from the repository root.

## Root cause

Nested conversion depended on the presence of `properties`, but JSON Schema does not require that keyword beside `required`.

## Change

The shared utility removes `required` from each nested property schema. It retains `additionalProperties` and leaves array-item schemas unchanged.

## Verification

The original reproduction and the new regression failed before the correction and passed afterward. All 38 tests passed with `pnpm --filter assistant-stream exec vitest run src/core/tool/schema-utils.test.ts`.

`pnpm --filter assistant-stream build`, scoped Oxlint and format checks, and `pnpm changesets:check` passed. The reproduction also passed through the built `assistant-stream` export in Node.

## Public surface

The correction affects `assistant-stream` and includes a patch changeset. Public exports and signatures are unchanged. No documentation, API-reference output, or template changes are necessary.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.PKYuz9EjdqFIEpgDW2sr0i5pBp6YrsrXezLGUfgpNqYePeIUSINBgs74cz4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->