### PR TITLE
fix(assistant-stream): prevent standard schema conversion crashes

### DIFF
--- a/.changeset/standard-schema-draft-target.md
+++ b/.changeset/standard-schema-draft-target.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: supply the draft-07 target to Standard JSON Schema converters so tool parameter conversion does not throw on missing options

--- a/packages/assistant-stream/src/core/tool/schema-utils.test.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { StandardJSONSchemaV1 } from "@standard-schema/spec";
 import {
   toJSONSchema,
   toPartialJSONSchema,
@@ -116,25 +117,37 @@ describe("toJSONSchema", () => {
     );
   });
 
-  it("converts StandardSchemaV1 with ~standard.jsonSchema.input()", () => {
-    const mockStandardSchema = {
+  it("converts Standard JSON Schema inputs to draft-07 for tool parameters", () => {
+    const schema = {
       "~standard": {
         version: 1 as const,
         vendor: "test",
         validate: () => ({ value: {} }),
         jsonSchema: {
-          input: () => ({
-            type: "object",
-            properties: { name: { type: "string" } },
-          }),
+          input: ({ target }: StandardJSONSchemaV1.Options) => {
+            expect(target).toBe("draft-07");
+            return {
+              type: "object",
+              properties: { name: { type: "string" } },
+            };
+          },
+          output: () => ({ type: "number" }),
         },
       },
     };
 
-    const result = toJSONSchema(mockStandardSchema);
+    const result = toJSONSchema(schema);
     expect(result).toEqual({
       type: "object",
       properties: { name: { type: "string" } },
+    });
+    expect(toToolsJSONSchema({ example: { parameters: schema } })).toEqual({
+      example: {
+        parameters: {
+          type: "object",
+          properties: { name: { type: "string" } },
+        },
+      },
     });
   });
 });

--- a/packages/assistant-stream/src/core/tool/schema-utils.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.ts
@@ -1,5 +1,8 @@
 import type { JSONSchema7 } from "json-schema";
-import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type {
+  StandardJSONSchemaV1,
+  StandardSchemaV1,
+} from "@standard-schema/spec";
 import type { ProviderOptions, Tool } from "./tool-types";
 
 /**
@@ -24,7 +27,7 @@ export type ToToolsJSONSchemaOptions = {
 function isStandardSchema(schema: unknown): schema is StandardSchemaV1 & {
   "~standard": StandardSchemaV1["~standard"] & {
     toJSONSchema?: () => unknown;
-    jsonSchema?: { input?: () => unknown; output?: () => unknown };
+    jsonSchema?: Partial<StandardJSONSchemaV1.Converter>;
   };
 } {
   return (
@@ -81,7 +84,7 @@ export function toJSONSchema(
       jsonSchema !== null &&
       typeof jsonSchema.input === "function"
     ) {
-      return jsonSchema.input() as JSONSchema7;
+      return jsonSchema.input({ target: "draft-07" }) as JSONSchema7;
     }
   }
 


### PR DESCRIPTION
## Problem

Tool parameter conversion throws when a Standard JSON Schema converter reads its mandatory `target` option. With this correction, the converter receives `draft-07` and returns the tool schema.

This reproduction throws on base `55c34a62512f901194470c6ad6fc561d69be207b` (`assistant-stream` 0.3.41). It runs with Bun from the repository root:

```js
import assert from "node:assert/strict";
import { toToolsJSONSchema } from "./packages/assistant-stream/src/core/tool/schema-utils.ts";

const convert = ({ target }) => {
  assert.equal(target, "draft-07");
  return { type: "object", properties: { name: { type: "string" } } };
};
const parameters = {
  "~standard": {
    version: 1,
    vendor: "local-example",
    validate: (value) => ({ value }),
    jsonSchema: { input: convert, output: convert },
  },
};
const converted = toToolsJSONSchema({ example: { parameters } });
assert.equal(converted.example.parameters.type, "object");
```

## Root cause

The shared `toJSONSchema` function called `jsonSchema.input()` without options. Its private type also described a zero-argument converter, contrary to the Standard JSON Schema contract.

## Change

The shared converter supplies `{ target: "draft-07" }` to match its existing `JSONSchema7` return contract. Its private type uses the installed standard definition. Other conversion methods and their priority remain unchanged.

## Verification

The regression in the existing schema test file throws before the correction. After the correction, `pnpm --filter assistant-stream exec vitest run src/core/tool/schema-utils.test.ts` passes all 37 tests.

The original API reproduction passes against the source and the fresh public build. `pnpm --filter assistant-stream build`, scoped Oxlint, and `pnpm changesets:check` also pass.

## Public surface

`assistant-stream` includes a patch changeset. Public exports and signatures remain unchanged. No documentation claims, generated API pages, or templates change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.HnJFxEtQ0ON1rhdDJjIMS3ZbnU92DmqhdRwPFS9l41arxdIm2V2AbY2RmME?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->