### PR TITLE
fix(assistant-stream): use final message token usage

### DIFF
--- a/.changeset/final-message-token-usage.md
+++ b/.changeset/final-message-token-usage.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: use final message usage for token counts when the stream reports a positive output total

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -105,6 +105,47 @@ describe("AssistantMessageAccumulator timing", () => {
     expect(timing.totalStreamTime).toBeGreaterThanOrEqual(0);
   });
 
+  it.each([
+    { stepTokens: [], finalTokens: 20, expected: 20 },
+    { stepTokens: [7], finalTokens: 20, expected: 20 },
+    { stepTokens: [3, 4], finalTokens: 0, expected: 7 },
+    { stepTokens: [3, 4], finalTokens: undefined, expected: 7 },
+  ])(
+    "uses $expected tokens for steps $stepTokens and final usage $finalTokens",
+    async ({ stepTokens, finalTokens, expected }) => {
+      const chunks: AssistantStreamChunk[] = [
+        { type: "part-start", path: [], part: { type: "text" } },
+        { type: "text-delta", path: [0], textDelta: "test" },
+        { type: "part-finish", path: [0] },
+      ];
+      for (const outputTokens of stepTokens) {
+        chunks.push({
+          type: "step-finish",
+          path: [],
+          finishReason: "stop",
+          usage: { inputTokens: 5, outputTokens },
+          isContinued: false,
+        });
+      }
+      if (finalTokens !== undefined) {
+        chunks.push({
+          type: "message-finish",
+          path: [],
+          finishReason: "stop",
+          usage: { inputTokens: 5, outputTokens: finalTokens },
+        });
+      }
+      chunks.push({ type: "annotations", path: [], annotations: ["done"] });
+
+      const messages = await collectStream(chunks);
+
+      expect(messages.at(-1)?.metadata.timing?.tokenCount).toBe(expected);
+      if (finalTokens !== undefined) {
+        expect(messages.at(-2)?.metadata.timing?.tokenCount).toBe(expected);
+      }
+    },
+  );
+
   it("should track tool calls in timing", async () => {
     const chunks: AssistantStreamChunk[] = [
       {

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -147,6 +147,28 @@ describe("AssistantMessageAccumulator timing", () => {
     },
   );
 
+  it("falls back to the step total when message-finish omits usage", async () => {
+    const messages = await collectStream([
+      { type: "part-start", path: [], part: { type: "text" } },
+      { type: "text-delta", path: [0], textDelta: "test" },
+      { type: "part-finish", path: [0] },
+      {
+        type: "step-finish",
+        path: [],
+        finishReason: "stop",
+        usage: { inputTokens: 5, outputTokens: 9 },
+        isContinued: false,
+      },
+      {
+        type: "message-finish",
+        path: [],
+        finishReason: "stop",
+      } as unknown as AssistantStreamChunk,
+    ]);
+
+    expect(messages.at(-1)?.metadata.timing?.tokenCount).toBe(9);
+  });
+
   it("should track tool calls in timing", async () => {
     const chunks: AssistantStreamChunk[] = [
       {

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -138,10 +138,11 @@ describe("AssistantMessageAccumulator timing", () => {
       chunks.push({ type: "annotations", path: [], annotations: ["done"] });
 
       const messages = await collectStream(chunks);
+      const timed = messages.filter((m) => m.metadata.timing !== undefined);
 
-      expect(messages.at(-1)?.metadata.timing?.tokenCount).toBe(expected);
-      if (finalTokens !== undefined) {
-        expect(messages.at(-2)?.metadata.timing?.tokenCount).toBe(expected);
+      expect(timed.length).toBeGreaterThan(0);
+      for (const message of timed) {
+        expect(message.metadata.timing?.tokenCount).toBe(expected);
       }
     },
   );

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -423,19 +423,26 @@ const handleUpdateState = (
   };
 };
 
-const computeTiming = (
-  tracker: TimingTracker,
-  message: AssistantMessage,
-  finalOutputTokens = 0,
-): AssistantMessageTiming => {
-  if (finalOutputTokens > 0) return tracker.getTiming(finalOutputTokens);
-
+const sumFinishedStepOutputTokens = (message: AssistantMessage): number => {
   let outputTokens = 0;
   for (const step of message.metadata.steps) {
     if (step.state === "finished" && step.usage) {
       outputTokens += step.usage.outputTokens;
     }
   }
+  return outputTokens;
+};
+
+const computeTiming = (
+  tracker: TimingTracker,
+  message: AssistantMessage,
+  finalOutputTokens = 0,
+): AssistantMessageTiming => {
+  const outputTokens =
+    finalOutputTokens > 0
+      ? finalOutputTokens
+      : sumFinishedStepOutputTokens(message);
+  if (outputTokens > 0) return tracker.getTiming(outputTokens);
 
   let totalText = "";
   for (const part of message.parts) {
@@ -444,10 +451,7 @@ const computeTiming = (
     }
   }
 
-  return tracker.getTiming(
-    outputTokens > 0 ? outputTokens : undefined,
-    totalText || undefined,
-  );
+  return tracker.getTiming(undefined, totalText || undefined);
 };
 
 const throttleCallback = (callback: () => void) => {

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -426,7 +426,10 @@ const handleUpdateState = (
 const computeTiming = (
   tracker: TimingTracker,
   message: AssistantMessage,
+  finalOutputTokens = 0,
 ): AssistantMessageTiming => {
+  if (finalOutputTokens > 0) return tracker.getTiming(finalOutputTokens);
+
   let outputTokens = 0;
   for (const step of message.metadata.steps) {
     if (step.state === "finished" && step.usage) {
@@ -476,6 +479,7 @@ export class AssistantMessageAccumulator extends TransformStream<
   } = {}) {
     let message = initialMessage ?? createInitialMessage();
     let stateAccumulator: GorpStreamAccumulator | undefined;
+    let finalOutputTokens: number | undefined;
     const tracker = new TimingTracker();
     const warnedKeys = new Set<string>();
     const warnOnce: WarnOnce = (key, warning) => {
@@ -526,6 +530,7 @@ export class AssistantMessageAccumulator extends TransformStream<
             message = handleResult(message, chunk, warnOnce);
             break;
           case "message-finish":
+            finalOutputTokens = chunk.usage?.outputTokens;
             message = handleMessageFinish(message, chunk);
             break;
           case "annotations":
@@ -562,7 +567,7 @@ export class AssistantMessageAccumulator extends TransformStream<
             ...message,
             metadata: {
               ...message.metadata,
-              timing: computeTiming(tracker, message),
+              timing: computeTiming(tracker, message, finalOutputTokens),
             },
           };
         }
@@ -593,7 +598,7 @@ export class AssistantMessageAccumulator extends TransformStream<
             ...message,
             metadata: {
               ...message.metadata,
-              timing: computeTiming(tracker, message),
+              timing: computeTiming(tracker, message, finalOutputTokens),
             },
           };
 


### PR DESCRIPTION
## Problem

A stream can report 20 output tokens in its final message, but timing metadata shows a text estimate of 1 token instead.

This reproduction returns 1 instead of 20 on base `55c34a62512f901194470c6ad6fc561d69be207b` (`assistant-stream` 0.3.41). It runs with Bun from the repository root:

```js
import assert from "node:assert/strict";
import { AssistantMessageAccumulator } from "./packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts";

const chunks = [
  { type: "part-start", path: [], part: { type: "text" } },
  { type: "text-delta", path: [0], textDelta: "test" },
  { type: "part-finish", path: [0] },
  { type: "message-finish", path: [], finishReason: "stop",
    usage: { inputTokens: 5, outputTokens: 20 } },
];
let last;
await new ReadableStream({
  start(controller) {
    for (const chunk of chunks) controller.enqueue(chunk);
    controller.close();
  },
}).pipeThrough(new AssistantMessageAccumulator()).pipeTo(
  new WritableStream({ write(message) { last = message; } }),
);
assert.equal(last.metadata.timing.tokenCount, 20);
```

## Root cause

The accumulator discards final usage. Its timing calculation only reads step usage before it estimates tokens from text.

## Change

Timing uses a positive final output total without adding step counts to it. Zero or absent final usage keeps the existing step-total and text-estimate fallback.

## Verification

The reproduction returns 20 after the correction. Two regression cases fail before the correction, then pass afterward.

The focused accumulator suite passes all 38 tests. The adjacent message-stream, data-stream decoder, and UI-message decoder suites pass all 67 tests.

The package build, scoped Oxlint and formatting checks, and `pnpm changesets:check` pass. A smoke check through the rebuilt public decoder and accumulator confirms final usage and missing-usage fallback.

## Public surface

`assistant-stream` receives a patch changeset. Public signatures and exports stay unchanged. Existing documentation and generated API pages remain applicable. No template changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.I9WapVmch5ws9ieraqRlD9wEvbQ9r3esifjvNlyMc-p8NOGwB1qx8YFtoTA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->