### PR TITLE
fix(core): complete final-only voice transcripts

### DIFF
--- a/.changeset/final-only-voice-transcript.md
+++ b/.changeset/final-only-voice-transcript.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: complete assistant voice messages when the first transcript is final

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -1,11 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  createVoiceSession,
-  type RealtimeVoiceAdapter,
-  type VoiceSessionHelpers,
-} from "../../adapters/voice";
+import type { RealtimeVoiceAdapter } from "../../adapters/voice";
 import type { ModelContextProvider } from "../../model-context/types";
-import { LocalRuntimeCore } from "../../runtimes/local/local-runtime-core";
 import type { AppendMessage } from "../../types/message";
 import { CompositeContextProvider } from "../../utils/composite-context-provider";
 import type {
@@ -21,6 +16,9 @@ import { BaseThreadRuntimeCore } from "./base-thread-runtime-core";
 
 const createVoiceAdapter = () => {
   let volumeCallback: ((volume: number) => void) | undefined;
+  let transcriptCallback:
+    | ((transcript: RealtimeVoiceAdapter.TranscriptItem) => void)
+    | undefined;
   const session: RealtimeVoiceAdapter.Session = {
     status: { type: "running" },
     isMuted: false,
@@ -28,7 +26,12 @@ const createVoiceAdapter = () => {
     mute: vi.fn(),
     unmute: vi.fn(),
     onStatusChange: () => () => {},
-    onTranscript: () => () => {},
+    onTranscript: (callback) => {
+      transcriptCallback = callback;
+      return () => {
+        transcriptCallback = undefined;
+      };
+    },
     onModeChange: () => () => {},
     onVolumeChange: (callback) => {
       volumeCallback = callback;
@@ -41,10 +44,13 @@ const createVoiceAdapter = () => {
   return {
     adapter: { connect: () => session },
     emitVolume: (volume: number) => volumeCallback?.(volume),
+    emitTranscript: (transcript: RealtimeVoiceAdapter.TranscriptItem) =>
+      transcriptCallback?.(transcript),
     session,
   } satisfies {
     adapter: RealtimeVoiceAdapter;
     emitVolume: (volume: number) => void;
+    emitTranscript: (transcript: RealtimeVoiceAdapter.TranscriptItem) => void;
     session: RealtimeVoiceAdapter.Session;
   };
 };
@@ -303,29 +309,13 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
 });
 
 describe("BaseThreadRuntimeCore voice transcripts", () => {
-  it("completes a final-only reply before the next streamed reply", async () => {
-    const { promise, resolve } = Promise.withResolvers<VoiceSessionHelpers>();
-    const core = new LocalRuntimeCore(
-      {
-        adapters: {
-          chatModel: { run: async () => ({ content: [] }) },
-          voice: {
-            connect: (options) =>
-              createVoiceSession(options, async (helpers) => {
-                resolve(helpers);
-                return { disconnect() {}, mute() {}, unmute() {} };
-              }),
-          },
-        },
-      },
-      undefined,
-    );
-    const runtime = core.threads.getMainThreadRuntimeCore();
+  it("completes a final-only reply before the next streamed reply", () => {
+    const voiceAdapter = createVoiceAdapter();
+    const runtime = new TestRuntime(voiceAdapter);
     runtime.connectVoice();
-    const { emitTranscript } = await promise;
 
     try {
-      emitTranscript({
+      voiceAdapter.emitTranscript({
         role: "assistant",
         text: "Finished reply",
         isFinal: true,
@@ -337,10 +327,10 @@ describe("BaseThreadRuntimeCore voice transcripts", () => {
         },
       ]);
 
-      emitTranscript({ role: "assistant", text: "Next" });
+      voiceAdapter.emitTranscript({ role: "assistant", text: "Next" });
       expect(runtime.messages.at(-1)?.status).toEqual({ type: "running" });
 
-      emitTranscript({
+      voiceAdapter.emitTranscript({
         role: "assistant",
         text: "Next reply",
         isFinal: true,

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { RealtimeVoiceAdapter } from "../../adapters/voice";
+import {
+  createVoiceSession,
+  type RealtimeVoiceAdapter,
+  type VoiceSessionHelpers,
+} from "../../adapters/voice";
 import type { ModelContextProvider } from "../../model-context/types";
+import { LocalRuntimeCore } from "../../runtimes/local/local-runtime-core";
 import type { AppendMessage } from "../../types/message";
 import { CompositeContextProvider } from "../../utils/composite-context-provider";
 import type {
@@ -294,5 +299,64 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
         listenerError,
       );
     });
+  });
+});
+
+describe("BaseThreadRuntimeCore voice transcripts", () => {
+  it("completes a final-only reply before the next streamed reply", async () => {
+    const { promise, resolve } = Promise.withResolvers<VoiceSessionHelpers>();
+    const core = new LocalRuntimeCore(
+      {
+        adapters: {
+          chatModel: { run: async () => ({ content: [] }) },
+          voice: {
+            connect: (options) =>
+              createVoiceSession(options, async (helpers) => {
+                resolve(helpers);
+                return { disconnect() {}, mute() {}, unmute() {} };
+              }),
+          },
+        },
+      },
+      undefined,
+    );
+    const runtime = core.threads.getMainThreadRuntimeCore();
+    runtime.connectVoice();
+    const { emitTranscript } = await promise;
+
+    try {
+      emitTranscript({
+        role: "assistant",
+        text: "Finished reply",
+        isFinal: true,
+      });
+      expect(runtime.messages).toMatchObject([
+        {
+          content: [{ type: "text", text: "Finished reply" }],
+          status: { type: "complete", reason: "stop" },
+        },
+      ]);
+
+      emitTranscript({ role: "assistant", text: "Next" });
+      expect(runtime.messages.at(-1)?.status).toEqual({ type: "running" });
+
+      emitTranscript({
+        role: "assistant",
+        text: "Next reply",
+        isFinal: true,
+      });
+      expect(runtime.messages).toMatchObject([
+        {
+          content: [{ type: "text", text: "Finished reply" }],
+          status: { type: "complete", reason: "stop" },
+        },
+        {
+          content: [{ type: "text", text: "Next reply" }],
+          status: { type: "complete", reason: "stop" },
+        },
+      ]);
+    } finally {
+      runtime.disconnectVoice();
+    }
   });
 });

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -405,7 +405,9 @@ export abstract class BaseThreadRuntimeCore
             steps: [],
             custom: {},
           },
-          status: { type: "running" },
+          status: transcript.isFinal
+            ? { type: "complete", reason: "stop" }
+            : { type: "running" },
           createdAt: new Date(),
         };
         this._voiceMessages.push(this._currentAssistantMsg);

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -393,6 +393,10 @@ export abstract class BaseThreadRuntimeCore
         this._notifySubscribers();
       }
     } else {
+      const status: ThreadAssistantMessage["status"] = transcript.isFinal
+        ? { type: "complete", reason: "stop" }
+        : { type: "running" };
+
       if (!this._currentAssistantMsg) {
         this._currentAssistantMsg = {
           id: generateId(),
@@ -405,9 +409,7 @@ export abstract class BaseThreadRuntimeCore
             steps: [],
             custom: {},
           },
-          status: transcript.isFinal
-            ? { type: "complete", reason: "stop" }
-            : { type: "running" },
+          status,
           createdAt: new Date(),
         };
         this._voiceMessages.push(this._currentAssistantMsg);
@@ -417,9 +419,7 @@ export abstract class BaseThreadRuntimeCore
         const updated: ThreadAssistantMessage = {
           ...this._currentAssistantMsg,
           content: [{ type: "text", text: transcript.text }],
-          ...(transcript.isFinal
-            ? { status: { type: "complete", reason: "stop" } }
-            : {}),
+          status,
         };
         this._voiceMessages[idx] = updated;
         this._currentAssistantMsg = updated;


### PR DESCRIPTION
## Problem

An assistant voice reply that arrives as a single final transcript stays in `running` status. The thread keeps showing the streaming affordances for a reply that has already finished, and when the agent sends two replies in a row the first one never leaves `running` at all, because `_finishVoiceAssistantMessage` only repairs `_voiceMessages.at(-1)` on the next user turn.

`examples/with-elevenlabs-conversational` hits this on every reply: its adapter maps each `onMessage` to `emitTranscript({ ..., isFinal: true })` and never emits a partial. The behavior also contradicts the documented contract in `apps/docs/content/docs/guides/voice.mdx`: "The message stays in a running status until `isFinal: true`".

## Root cause

`_handleVoiceTranscript` expressed the `isFinal` rule in only one of its two branches. The update branch applied `complete/stop`; the create branch hard-coded `running`. A final transcript then cleared `_currentAssistantMsg`, so a first-and-only transcript never reached the branch that would have completed it.

## Change

The `isFinal` rule is derived once, before the branch, and both the created message and the updated message take it. That removes the duplication the gap grew out of, rather than copying the rule into the second branch. A partial transcript still yields `running`, and because a final transcript clears `_currentAssistantMsg`, the update branch only ever sees a message that was already `running`.

## Verification

`pnpm --filter @assistant-ui/core test src/runtime/base/base-thread-runtime-core.test.ts src/adapters/voice.test.ts`: 16 passed.

Both directions on the new test: with the source reverted to the base commit it fails with `status: { type: "running" }` where `{ type: "complete", reason: "stop" }` is expected, and it passes on this branch. The full `@assistant-ui/core` suite reports the same 11 pre-existing failures before and after the change (all under `src/react/**`, from an unbuilt `@assistant-ui/tap`).

The test runs on the `TestRuntime` and `createVoiceAdapter` harness this file already carries, with `emitTranscript` added next to the existing `emitVolume`, so a base-class test does not have to construct a sibling runtime. It covers a final-only reply followed by a separate partial-to-final reply.

Oxlint and oxfmt pass on both touched files.

## Public surface

`@assistant-ui/core` gets a patch changeset. No export, signature, template, or api-reference change. The fix restores the documented `isFinal` behavior.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.aNseM1EflVSNeE_UQnIAnrCjcxVFq0y_HE9l4AHG_qy4SxvI6RjswMBsQXk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
