### PR TITLE
fix(langgraph): accept late tool names

### DIFF
--- a/.changeset/langgraph-late-tool-name.md
+++ b/.changeset/langgraph-late-tool-name.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: accept a tool name that arrives after the first tool-call chunk.

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { appendLangChainChunk } from "./appendLangChainChunk";
 import { convertLangChainMessages } from "./convertLangChainMessages";
+import { normalizeLangGraphTupleMessage } from "./normalizeLangGraphTupleMessage";
 import type { LangChainMessage, LangChainMessageChunk } from "./types";
 
 type AiMessage = Extract<LangChainMessage, { type: "ai" }>;
@@ -672,6 +673,52 @@ describe("appendLangChainChunk continuation content", () => {
       { type: "text", text: "Answer." },
       { type: "reasoning", text: "Two steps." },
     ]);
+  });
+});
+
+describe("appendLangChainChunk tool_call name merging", () => {
+  it("accepts a late tool name and keeps it through unnamed chunks", () => {
+    const first = normalizeLangGraphTupleMessage({
+      id: "ai-1",
+      type: "ai",
+      content: "",
+      tool_call_chunks: [{ index: 0 }],
+    });
+    const next = normalizeLangGraphTupleMessage({
+      id: "ai-1",
+      type: "ai",
+      content: "",
+      tool_call_chunks: [
+        { index: 0, id: "call-1", name: "search", args: "{}" },
+      ],
+    });
+    if (!first || !next) throw new Error("Expected normalized chunks");
+
+    const merged = appendLangChainChunk(
+      appendLangChainChunk(undefined, first.message),
+      next.message,
+    );
+    const expected = expect.arrayContaining([
+      expect.objectContaining({
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "search",
+        argsText: "{}",
+      }),
+    ]);
+    expect(convertLangChainMessages(merged, {})).toHaveProperty(
+      "content",
+      expected,
+    );
+
+    const continued = appendLangChainChunk(
+      merged,
+      aiChunk([{ index: 0, id: "call-1", name: "", args: "" }]),
+    );
+    expect(convertLangChainMessages(continued, {})).toHaveProperty(
+      "content",
+      expected,
+    );
   });
 });
 

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -260,6 +260,7 @@ export const appendLangChainChunk = (
         ...chunk,
         ...existing,
         id: existing.id || chunk.id,
+        name: existing.name || chunk.name,
         partial_json: partialJson,
         args:
           parsePartialJsonObject(partialJson) ??


### PR DESCRIPTION
## Problem

A streamed tool call stays unnamed when its name arrives after the first chunk. The converted tool call then has an empty `toolName`.

This reproduction affects `@assistant-ui/react-langgraph` 0.14.26 at base `55c34a62512f901194470c6ad6fc561d69be207b`. After dependency installation and package builds, Bun can run this snippet from the repository root:

```ts
import assert from "node:assert/strict";
import { appendLangChainChunk } from "./packages/react-langgraph/src/appendLangChainChunk.ts";
import { normalizeLangGraphTupleMessage } from "./packages/react-langgraph/src/normalizeLangGraphTupleMessage.ts";

const first = normalizeLangGraphTupleMessage({
  id: "ai-1", type: "ai", content: "",
  tool_call_chunks: [{ index: 0 }],
});
const next = normalizeLangGraphTupleMessage({
  id: "ai-1", type: "ai", content: "",
  tool_call_chunks: [{ index: 0, id: "call-1", name: "search", args: "{}" }],
});
assert.ok(first && next);
const result = appendLangChainChunk(
  appendLangChainChunk(undefined, first.message), next.message,
);
assert.equal(result.tool_calls[0].name, "search");
```

## Root cause

The chunk merge keeps every accumulated field except `id`, so a tool call that started without a name never picks one up. Two wire shapes reach that state: tuple normalization coerces a missing name to an empty string, and a provider that opens the call with `name: null` (Bedrock) keeps the null. `_mergeDicts` in `@langchain/core` treats `id` and `name` alike, replacing either one when the incoming value is truthy, so the accumulator now follows that rule for both.

## Change

The merger accepts the later name when the accumulated name is empty, as it already does for IDs. Later unnamed chunks retain that name.

## Verification

The API reproduction and the focused regressions failed before the correction and passed afterward. Three regressions cover the empty name, the `null` name, and the tuple path through conversion, and all three fail on the base commit.

`pnpm --filter @assistant-ui/react-langgraph test` passed all 318 tests. The scoped Oxlint and format checks passed, and the package typecheck reports no error in the touched file.

## Public surface

The patch changeset covers `@assistant-ui/react-langgraph`. Public exports and signatures remain unchanged. Documentation, generated API references, and templates remain unchanged because their contracts do not change.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4lJ2e2bF1aWbBtBqlrIKIfsZnNCTzVgJmMDb1G_RyMlbzA9Nm12MfgOi_58?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


