### PR TITLE
fix(langgraph): accept tool results with empty names

### DIFF
--- a/.changeset/langgraph-empty-tool-result-name.md
+++ b/.changeset/langgraph-empty-tool-result-name.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: accept tool results with empty names when the tool call IDs match

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -27,6 +27,58 @@ const convertLangChainMessages = (
     ) => ConvertResult
   )(message, metadata);
 
+describe("convertLangChainMessages tool result names", () => {
+  const assistant: LangChainMessage = {
+    id: "ai-1",
+    type: "ai",
+    content: "",
+    tool_calls: [{ id: "call-1", name: "search", args: {} }],
+  };
+  const tool: LangChainMessage = {
+    id: "tool-1",
+    type: "tool",
+    tool_call_id: "call-1",
+    name: "",
+    content: "found",
+    status: "success",
+  };
+
+  it("joins a result with an empty name to its tool call", () => {
+    const messages = convertExternalMessages(
+      [assistant, tool],
+      convertLangChainMessagesImpl,
+      false,
+      {},
+    );
+
+    expect(messages).toMatchObject([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "search",
+            result: "found",
+            isError: false,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("rejects a result with a different nonempty tool name", () => {
+    expect(() =>
+      convertExternalMessages(
+        [assistant, { ...tool, name: "other" }],
+        convertLangChainMessagesImpl,
+        false,
+        {},
+      ),
+    ).toThrow();
+  });
+});
+
 describe("convertLangChainMessages content-less messages", () => {
   it("converts an ai message without content", () => {
     const result = convertLangChainMessages({

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -75,7 +75,7 @@ describe("convertLangChainMessages tool result names", () => {
         false,
         {},
       ),
-    ).toThrow();
+    ).toThrow(/does not match existing tool call/);
   });
 });
 

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -304,7 +304,7 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
     case "tool":
       return {
         role: "tool",
-        toolName: message.name,
+        toolName: message.name || undefined,
         toolCallId: message.tool_call_id,
         result: message.content,
         artifact: message.artifact,


### PR DESCRIPTION
## Problem

A tool result with `name: ""` stops conversation conversion, even when its call ID matches. The result must attach to the existing tool call.

Affected version: `@assistant-ui/react-langgraph` 0.14.26 at base `55c34a62512f901194470c6ad6fc561d69be207b`.

After `pnpm install --frozen-lockfile` and `pnpm --filter '@assistant-ui/react-langgraph...' -r run build`, run this snippet with Bun from `packages/react-langgraph`:

```ts
import assert from "node:assert/strict";
import { convertExternalMessages } from "@assistant-ui/core/react";
import { convertLangChainMessages } from "@assistant-ui/react-langgraph";

const messages = convertExternalMessages(
  [
    {
      id: "ai-1", type: "ai", content: "",
      tool_calls: [{ id: "call-1", name: "search", args: {} }],
    },
    {
      id: "tool-1", type: "tool", tool_call_id: "call-1",
      name: "", content: "found", status: "success",
    },
  ],
  convertLangChainMessages,
  false,
  {},
);
const call = messages[0].content.find((part) => part.type === "tool-call");
assert.equal(call.toolName, "search");
assert.equal(call.result, "found");
```

## Root cause

The graph converter passes the empty name to core. Core compares each non-null result name against the call name and throws on the mismatch.

## Change

Treat an empty result name as unspecified, as the LangChain converter does. The call ID joins the result, and nonempty name mismatches still throw.

## Verification

The API reproduction and regression threw before the correction. The same checks passed afterward. The rebuilt public converter returned `search` and `found`.

`pnpm --filter @assistant-ui/react-langgraph test -- src/convertLangChainMessages.test.ts -t 'tool result names'` passed all 317 package tests. The package build, scoped oxlint, and oxfmt checks passed.

## Public surface

The correction affects `@assistant-ui/react-langgraph`. Public exports and signatures remain unchanged. A patch changeset is included. Documentation, API-reference output, and templates remain unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.1vz-NVhgE1k7SGaUQYcaP10TQWusY5FmKeasJ35YVNx-Rx3TsZetul5BlTg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->