### PR TITLE
fix(assistant-stream): keep tool response messages

### DIFF
--- a/.changeset/preserve-tool-response-messages.md
+++ b/.changeset/preserve-tool-response-messages.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: keep provider messages in backend tool responses and completed pending tool calls

--- a/packages/assistant-stream/src/core/modules/tool-call.test.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.test.ts
@@ -64,13 +64,19 @@ describe("ToolCallStreamController", () => {
     const reader = await toolReaderPromise;
     expect(await reader.args.get("query")).toBe("London");
 
-    toolCall.setResponse(new ToolResponse({ result: { source: "backend" } }));
+    toolCall.setResponse(
+      new ToolResponse({
+        result: { source: "backend" },
+        messages: [{ role: "assistant", content: [] }],
+      }),
+    );
     toolCall.close();
     controller.close();
 
     const response = await reader.response.get();
     expect(response.result).toEqual({ source: "backend" });
     expect(response.isError).toBe(false);
+    expect(response.messages).toEqual([{ role: "assistant", content: [] }]);
     expect(execute).not.toHaveBeenCalled();
     await drain;
     const results = chunks.filter((chunk) => chunk.type === "result");
@@ -78,6 +84,7 @@ describe("ToolCallStreamController", () => {
     expect(results[0]).toMatchObject({
       result: { source: "backend" },
       isError: false,
+      messages: [{ role: "assistant", content: [] }],
     });
   });
 

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -191,6 +191,7 @@ export class ToolExecutionStream extends PipeableTransformStream<
                   artifact: chunk.artifact,
                   isError: chunk.isError,
                   modelContent: chunk.modelContent,
+                  messages: chunk.messages,
                 }),
               );
               toolCallIdsWithBackendResult.add(executionId!);

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -59,6 +59,31 @@ afterEach(() => {
 });
 
 describe("unstable_runPendingTools", () => {
+  it("keeps provider messages when a pending tool settles", async () => {
+    const settled = await unstable_runPendingTools(
+      createPendingToolMessage("messages"),
+      {
+        tool: {
+          parameters: { type: "object", properties: {} },
+          execute: () =>
+            new ToolResponse({
+              result: "done",
+              messages: [{ role: "assistant", content: [] }],
+            }),
+        },
+      },
+      new AbortController().signal,
+      async () => {},
+    );
+
+    expect(settled.parts[0]).toMatchObject({
+      state: "result",
+      result: "done",
+      messages: [{ role: "assistant", content: [] }],
+    });
+    expect(settled.content).toEqual(settled.parts);
+  });
+
   it("settles a tool that returns no value with a concrete result", async () => {
     const message: AssistantMessage = {
       role: "assistant",

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -271,6 +271,9 @@ export async function unstable_runPendingTools(
           ...(toolResponse.modelContent !== undefined
             ? { modelContent: toolResponse.modelContent }
             : {}),
+          ...(toolResponse.messages !== undefined
+            ? { messages: toolResponse.messages }
+            : {}),
           result: toolResponse.result as ReadonlyJSONValue,
           isError: toolResponse.isError,
         };


### PR DESCRIPTION
## Problem

Provider messages disappear from backend tool readers and completed pending tool calls. Callers receive `undefined` instead of the original `messages` payload.

This occurs in `assistant-stream` 0.3.41 at base commit `55c34a62512f901194470c6ad6fc561d69be207b`. The following snippet reproduces the pending-tool path from that checkout after `pnpm install --frozen-lockfile`. It runs with Bun.

```js
import assert from "node:assert/strict";
import { unstable_runPendingTools } from "./packages/assistant-stream/src/core/tool/toolResultStream.ts";
import { ToolResponse } from "./packages/assistant-stream/src/core/tool/ToolResponse.ts";
import { createInitialMessage } from "./packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts";

const messages = [{ role: "assistant", content: [] }];
const part = {
  type: "tool-call",
  toolCallId: "p",
  toolName: "front",
  state: "call",
  status: { type: "running", isArgsComplete: true },
  argsText: "{}",
  args: {},
};
const settled = await unstable_runPendingTools(
  { ...createInitialMessage(), parts: [part], content: [part] },
  {
    front: {
      parameters: { type: "object" },
      execute: () => new ToolResponse({ result: "ok", messages }),
    },
  },
  new AbortController().signal,
  async () => null,
);
assert.deepEqual(settled.parts[0].messages, messages);
```

## Root cause

The backend result conversion omits `messages` from `ToolResponse`. The pending-tool conversion omits the same field from the completed part.

## Change

The two conversions keep `messages` through the existing response-field handling. Responses without messages keep their current behavior.

## Verification

The original API reproduction returned `undefined` on each path before the correction and passed afterward. The two regression checks also failed before the correction.

`pnpm --filter assistant-stream exec vitest run src/core/tool/toolResultStream.test.ts src/core/modules/tool-call.test.ts` passed all 32 tests afterward.

`pnpm --filter assistant-stream exec tsc --noEmit` passed. Scoped `oxlint` and `oxfmt --check` checks passed for the four changed TypeScript files.

## Public surface

The change affects `assistant-stream` and includes a patch changeset. Public exports, signatures, documentation, API-reference output, and templates are unchanged.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._wBzm1WzLV1S-b8oOpWSQKvO7oXPiRlYKzQO2L8Je1xxdHQtCYSK0GgpzJw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

