### PR TITLE
fix(core): exclude cleared attachments from pending sends

### DIFF
--- a/.changeset/clear-attachments-during-send.md
+++ b/.changeset/clear-attachments-during-send.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: exclude cleared attachments from a message when its upload finishes

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -203,6 +203,10 @@ export abstract class BaseComposerRuntimeCore
 
   public async clearAttachments() {
     this._cancelAllAttachmentAdds();
+    if (this._isSending) {
+      for (const attachment of this._attachments)
+        this._removedDuringSend.add(attachment.id);
+    }
     const task = this._onClearAttachments();
     this.setAttachments([]);
 

--- a/packages/core/src/tests/base-composer-runtime-core-send.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-send.test.ts
@@ -5,6 +5,7 @@ import type { ThreadRuntimeCore } from "../runtime/interfaces/thread-runtime-cor
 import type { PendingAttachment } from "../types/attachment";
 import { MessageNotSentError } from "../types/error";
 import { BaseComposerRuntimeCore } from "../runtime/base/base-composer-runtime-core";
+import { LocalRuntimeCore } from "../runtimes/local/local-runtime-core";
 
 const makeAdapter = (
   overrides: Partial<AttachmentAdapter> = {},
@@ -377,6 +378,56 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
 
     resolveRemove();
     await removePromise;
+  });
+
+  it("excludes cleared attachments when the upload finishes before adapter removal", async () => {
+    const upload = Promise.withResolvers<void>();
+    const removal = Promise.withResolvers<void>();
+    const adapter = makeAdapter({
+      send: async (attachment) => {
+        await upload.promise;
+        return { ...attachment, status: { type: "complete" }, content: [] };
+      },
+      remove: () => removal.promise,
+    });
+    const core = new LocalRuntimeCore(
+      {
+        adapters: {
+          chatModel: { run: async () => ({ content: [] }) },
+          attachments: adapter,
+        },
+      },
+      undefined,
+    );
+    const thread = core.threads.getMainThreadRuntimeCore();
+    const composer = thread.composer;
+    composer.setText("hello");
+    await composer.addAttachment(textFile());
+    await composer.addAttachment({
+      id: "ready",
+      name: "ready.txt",
+      content: [],
+    });
+
+    const sendPromise = composer.send({ startRun: false });
+    const clearPromise = composer.clearAttachments();
+    expect(composer.attachments).toEqual([]);
+    await composer.addAttachment({
+      id: "later",
+      name: "later.txt",
+      content: [],
+    });
+    upload.resolve();
+    await sendPromise;
+
+    expect(thread.messages).toMatchObject([
+      { content: [{ type: "text", text: "hello" }], attachments: [] },
+    ]);
+    expect(composer.attachments.map((attachment) => attachment.id)).toEqual([
+      "later",
+    ]);
+    removal.resolve();
+    await clearPromise;
   });
 
   it("releases the in-flight lock on reset so a stalled send cannot brick the composer", async () => {


### PR DESCRIPTION
## Problem

Attachments could disappear from the composer after `clearAttachments()` but still appear in the sent message when an upload finished. The sent message now excludes those attachments.

This reproduces on base `55c34a62512f901194470c6ad6fc561d69be207b` (`@assistant-ui/core` 0.3.17). From that checkout, install dependencies with `pnpm install --frozen-lockfile`. Build the runtime dependencies with `pnpm --filter @assistant-ui/tap --filter @assistant-ui/store --filter assistant-stream --filter assistant-cloud run build`.

Save this snippet as `repro.ts` in the repository root, then run `bun run repro.ts`:

```ts
import assert from "node:assert/strict";
import { LocalRuntimeCore } from "./packages/core/src/runtimes/local/local-runtime-core";
import type { AttachmentAdapter } from "./packages/core/src/adapters/attachment";

const upload = Promise.withResolvers<void>();
const attachments: AttachmentAdapter = {
  accept: "*",
  add: async ({ file }) => ({
    id: "att", type: "document", name: file.name, contentType: file.type, file,
    status: { type: "requires-action", reason: "composer-send" },
  }),
  remove: async () => {},
  send: async (attachment) => {
    await upload.promise;
    return { ...attachment, status: { type: "complete" }, content: [] };
  },
};
const core = new LocalRuntimeCore({
  adapters: { chatModel: { run: async () => ({ content: [] }) }, attachments },
}, undefined);
const thread = core.threads.getMainThreadRuntimeCore();
thread.composer.setText("hello");
await thread.composer.addAttachment(new File(["body"], "file.txt", { type: "text/plain" }));
const sending = thread.composer.send({ startRun: false });
await thread.composer.clearAttachments();
upload.resolve();
await sending;
assert.deepEqual(thread.messages.map(({ attachments }) => attachments), [[]]);
```

## Root cause

Send captures attachments before it waits for uploads. Single removal records IDs that the final send filter excludes, but bulk clear did not record them.

## Change

Bulk clear records every current attachment ID before adapter cleanup when a send is active. It uses the same filter as single removal. Attachments added after the clear remain in the composer.

## Verification

The snippet and new regression fail without the correction and pass with it. The regression uses the real local runtime and keeps adapter removal pending until after the send completes.

All 94 tests pass across `base-composer-runtime-core-send`, `base-composer-runtime-core-addAttachment`, `base-composer-runtime-core`, and `default-edit-composer-runtime-core`. Scoped oxlint, `pnpm --filter @assistant-ui/core run build`, and `pnpm changesets:check` pass.

## Public surface

The change affects `@assistant-ui/core` and includes a patch changeset. Public signatures, exports, documentation, API-reference output, and templates remain unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.H4Cj2o-kJ4odTU81b7OHCTtvSuNPOe0mJepDSlNtH8j7kI1tP26UAsZX_H0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->