### PR TITLE
fix: use validated tool input arguments

### DIFF
--- a/.changeset/validated-tool-arguments.md
+++ b/.changeset/validated-tool-arguments.md
@@ -1,5 +1,6 @@
 ---
 "assistant-stream": patch
+"@assistant-ui/react": patch
 ---
 
 fix: Use successful Standard Schema output for tool execution and model output. Keep the original arguments for validation errors and stored tool calls.

--- a/.changeset/validated-tool-arguments.md
+++ b/.changeset/validated-tool-arguments.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: Use successful Standard Schema output for tool execution and model output. Keep the original arguments for validation errors and stored tool calls.

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -238,6 +238,61 @@ describe("unstable_runPendingTools", () => {
     );
   });
 
+  it.each(["sync", "async"] as const)(
+    "uses %s schema output for execution and model content",
+    async (mode) => {
+      const message = createPendingToolMessage("trim");
+      message.parts = [
+        {
+          type: "tool-call",
+          toolCallId: "trim",
+          toolName: "tool",
+          args: { name: " Ada ", extra: true },
+          argsText: '{"name":" Ada ","extra":true}',
+          state: "call",
+          status: { type: "requires-action", reason: "tool-call-result" },
+        },
+      ];
+      const tool: Tool = {
+        parameters: {
+          "~standard": {
+            version: 1,
+            vendor: "test",
+            validate: (input) => {
+              if (
+                typeof input !== "object" ||
+                input === null ||
+                !("name" in input) ||
+                typeof input.name !== "string"
+              ) {
+                return { issues: [{ message: "Expected a name" }] };
+              }
+              const result = { value: { name: input.name.trim() } };
+              return mode === "async" ? Promise.resolve(result) : result;
+            },
+          },
+        },
+        execute: (args) => `Hello, ${args.name}!`,
+        toModelOutput: ({ input, output }) => [
+          { type: "text", text: `${JSON.stringify(input)}: ${output}` },
+        ],
+      };
+
+      const settled = await unstable_runPendingTools(
+        message,
+        { tool },
+        new AbortController().signal,
+        async () => {},
+      );
+
+      expect(settled.parts[0]).toMatchObject({
+        args: { name: " Ada ", extra: true },
+        result: "Hello, Ada!",
+        modelContent: [{ type: "text", text: '{"name":"Ada"}: Hello, Ada!' }],
+      });
+    },
+  );
+
   it.each([
     [
       "thenable",
@@ -259,7 +314,9 @@ describe("unstable_runPendingTools", () => {
     "awaits a %s schema validation result",
     async (kind, createValidationResult) => {
       const execute = vi.fn(async () => "executed");
-      const onSchemaValidationError = vi.fn(async () => "recovered");
+      const onSchemaValidationError = vi.fn(
+        async (_args: unknown) => "recovered",
+      );
       const message = createPendingToolMessage(kind);
       const parameters = {
         "~standard": {
@@ -283,6 +340,7 @@ describe("unstable_runPendingTools", () => {
 
       expect(execute).not.toHaveBeenCalled();
       expect(onSchemaValidationError).toHaveBeenCalledOnce();
+      expect(onSchemaValidationError.mock.calls[0]?.[0]).toEqual({});
       expect(settled.parts[0]).toMatchObject({
         result: "recovered",
         isError: false,
@@ -297,7 +355,7 @@ describe("unstable_runPendingTools", () => {
     const parameters = {
       "~standard": {
         version: 1,
-        validate: () => ({ issues: undefined }),
+        validate: () => ({ value: {} }),
       },
     } as NonNullable<Tool["parameters"]>;
 

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -52,8 +52,8 @@ type InternalToolExecutionOptions = {
 };
 
 const isStandardSchemaV1 = (
-  schema: unknown,
-): schema is StandardSchemaV1<unknown> => {
+  schema: Tool["parameters"],
+): schema is StandardSchemaV1<Record<string, unknown>> => {
   return (
     typeof schema === "object" &&
     schema !== null &&
@@ -81,7 +81,7 @@ function getToolResponse(
   if (!tool?.execute) return undefined;
 
   const getResult = async (
-    toolExecute: ToolExecuteFunction<ReadonlyJSONObject, unknown>,
+    toolExecute: ToolExecuteFunction<Record<string, unknown>, unknown>,
   ): Promise<ToolResponse<ReadonlyJSONValue>> => {
     // Check if already aborted before starting
     if (abortSignal.aborted) {
@@ -92,6 +92,7 @@ function getToolResponse(
     }
 
     let executeFn = toolExecute;
+    let args: Record<string, unknown> = toolCall.args;
 
     if (isStandardSchemaV1(tool.parameters)) {
       const result = tool.parameters["~standard"].validate(toolCall.args);
@@ -105,6 +106,8 @@ function getToolResponse(
               `Function parameter validation failed. ${JSON.stringify(validationResult.issues)}`,
             );
           });
+      } else {
+        args = validationResult.value;
       }
     }
 
@@ -142,7 +145,7 @@ function getToolResponse(
         [TOOL_EXECUTION_ID]: toolCall.executionId,
       } as ToolExecutionContext;
       const result = (await executeFn(
-        toolCall.args,
+        args,
         executionContext,
       )) as unknown as ReadonlyJSONValue;
       const response = ToolResponse.toResponse(result);
@@ -154,7 +157,7 @@ function getToolResponse(
         try {
           const modelContent = await tool.toModelOutput({
             toolCallId: toolCall.toolCallId,
-            input: toolCall.args,
+            input: args,
             output: response.result,
           });
           return new ToolResponse({

--- a/packages/react/src/unstable/webmcp/convertTools.test.ts
+++ b/packages/react/src/unstable/webmcp/convertTools.test.ts
@@ -178,6 +178,25 @@ describe("toWebMcpTool schema validation", () => {
     expect(result).toEqual({ content: [text("ok")] });
   });
 
+  it("uses schema output for execution and model content", async () => {
+    const args = { city: " Paris ", extra: true };
+    const result = await descriptorFor({
+      parameters: z.object({
+        city: z.string().trim(),
+        unit: z.enum(["c", "f"]).default("c"),
+      }),
+      execute: ({ city, unit }) => `Weather in ${city} (${unit})`,
+      toModelOutput: ({ input, output }) => [
+        { type: "text", text: `${JSON.stringify(input)}: ${output}` },
+      ],
+    }).execute(args);
+
+    expect(result).toEqual({
+      content: [text('{"city":"Paris","unit":"c"}: Weather in Paris (c)')],
+    });
+    expect(args).toEqual({ city: " Paris ", extra: true });
+  });
+
   it("returns a validation error when the arguments do not validate", async () => {
     const execute = vi.fn(async () => "ok");
     const result = await zodTool({ execute }).execute({ city: 42 });
@@ -192,10 +211,11 @@ describe("toWebMcpTool schema validation", () => {
     const execute = vi.fn(async () => "ok");
     const result = await zodTool({
       execute,
-      experimental_onSchemaValidationError: async () => "recovered",
+      experimental_onSchemaValidationError: async (args) =>
+        `Invalid: ${JSON.stringify(args)}`,
     }).execute({ city: 42 });
     expect(execute).not.toHaveBeenCalled();
-    expect(result).toEqual({ content: [text("recovered")] });
+    expect(result).toEqual({ content: [text('Invalid: {"city":42}')] });
   });
 
   it("awaits a validator that returns a non-Promise thenable", async () => {

--- a/packages/react/src/unstable/webmcp/convertTools.ts
+++ b/packages/react/src/unstable/webmcp/convertTools.ts
@@ -101,16 +101,10 @@ export const toMcpContent = async (
   return response.isError ? { isError: true, content } : { content };
 };
 
-type StandardSchemaLike = {
-  "~standard": {
-    version: number;
-    validate: (
-      value: unknown,
-    ) =>
-      | { issues?: readonly unknown[] | undefined }
-      | Promise<{ issues?: readonly unknown[] | undefined }>;
-  };
-};
+type StandardSchemaLike = Extract<
+  NonNullable<Tool["parameters"]>,
+  { readonly "~standard": unknown }
+>;
 
 const isStandardSchema = (schema: unknown): schema is StandardSchemaLike =>
   typeof schema === "object" &&
@@ -166,7 +160,7 @@ export const toWebMcpTool = (
       return errorResult(`Tool "${name}" is no longer registered`);
     }
     const tool = getTool();
-    const args = (rawArgs ?? {}) as Record<string, unknown>;
+    let args = (rawArgs ?? {}) as Record<string, unknown>;
     const toolCallId = generateId();
     let cleanup: (() => void) | undefined;
     try {
@@ -192,6 +186,8 @@ export const toWebMcpTool = (
                 `Function parameter validation failed. ${JSON.stringify(issues)}`,
               );
             });
+        } else {
+          args = validation.value;
         }
       }
 


### PR DESCRIPTION
## Problem

Tool execution ignores changes from a successful Standard Schema validation. A schema that trims `" Ada "` still gives the tool `" Ada "`, not `"Ada"`.

This reproduction fails on base `55c34a62512f901194470c6ad6fc561d69be207b` (`assistant-stream` 0.3.41). It runs with Bun from the repository root:

```js
import assert from "node:assert/strict";
import { unstable_runPendingTools } from "./packages/assistant-stream/src/core/tool/toolResultStream.ts";
import { createInitialMessage } from "./packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts";

const part = {
  type: "tool-call", toolCallId: "t", toolName: "trim",
  state: "call", status: { type: "running", isArgsComplete: true },
  argsText: '{"name":" Ada "}', args: { name: " Ada " },
};
const message = { ...createInitialMessage(), parts: [part], content: [part] };
const parameters = {
  "~standard": {
    version: 1, vendor: "local-example",
    validate: (input) => ({ value: { name: input.name.trim() } }),
  },
};
const result = await unstable_runPendingTools(
  message,
  { trim: { parameters, execute: (args) => args.name } },
  new AbortController().signal,
  async () => null,
);
assert.equal(result.parts[0].result, "Ada");
```

## Root cause

The shared executor and WebMCP executor check validation issues but discard the successful schema value. They pass the original arguments to `execute` and `toModelOutput`.

## Change

Successful validation supplies the arguments for execution and model output in pending tools, streamed tools, and WebMCP. Stored tool-call arguments and arguments for the validation-error handler remain unchanged.

## Verification

The reproduction and the synchronous and asynchronous regressions fail before the correction and pass afterward. `pnpm --filter assistant-stream exec vitest run src/core/tool/toolResultStream.test.ts` passes all 29 tests.

`pnpm --filter assistant-stream exec tsc --noEmit`, scoped Oxlint, and `pnpm changesets:check` pass. A direct streamed API check also returns the trimmed name in the tool result and model content.

`pnpm --filter @assistant-ui/react exec vitest run src/unstable/webmcp/convertTools.test.ts` passes all 35 tests. The WebMCP regression and direct API reproduction fail before the correction and pass afterward. Scoped strict production-source types and lint pass. An extra strict check of the test file reports two errors in unchanged test helpers.

## Public surface

`assistant-stream` and `@assistant-ui/react` include patch changesets. Public exports and signatures remain unchanged. No documentation claims, generated API pages, or templates change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.CnF1mJiXQ_PSbvqJ-tcJizMX2E_pdSlpAANwki6NTY5aO5dn-iYBNKiIdyc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->