### PR TITLE
fix(react-streamdown): update changed child props

### DIFF
--- a/.changeset/streamdown-child-prop-updates.md
+++ b/.changeset/streamdown-child-prop-updates.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: update memoized children when their text or props change

--- a/packages/react-streamdown/src/__tests__/PreOverride.test.tsx
+++ b/packages/react-streamdown/src/__tests__/PreOverride.test.tsx
@@ -158,13 +158,31 @@ describe("PreOverride component", () => {
     expect(screen.getByText("plain text")).toBeDefined();
   });
 
-  it("is memoized and does not re-render unnecessarily", () => {
+  it("updates child text and props without a node prop", () => {
     const { rerender } = render(
-      <PreOverride className="test">content</PreOverride>,
+      <PreOverride>
+        <code key="same" className="language-js">
+          old
+        </code>
+      </PreOverride>,
     );
 
-    // Same props should not cause issues
-    rerender(<PreOverride className="test">content</PreOverride>);
-    expect(screen.getByText("content")).toBeDefined();
+    rerender(
+      <PreOverride>
+        <code key="same" className="language-js">
+          new
+        </code>
+      </PreOverride>,
+    );
+    expect(screen.getByText("new").className).toBe("language-js");
+
+    rerender(
+      <PreOverride>
+        <code key="same" className="language-ts">
+          new
+        </code>
+      </PreOverride>,
+    );
+    expect(screen.getByText("new").className).toBe("language-ts");
   });
 });

--- a/packages/react-streamdown/src/__tests__/memoization.test.ts
+++ b/packages/react-streamdown/src/__tests__/memoization.test.ts
@@ -44,16 +44,10 @@ describe("memoCompareNodes", () => {
     expect(memoCompareNodes(prev, next)).toBe(true);
   });
 
-  it("returns true for same React element type and key", () => {
+  it("returns true for the same React element", () => {
     const child = createElement("div", { key: "1" }, "content");
     const prev = { children: child };
     const next = { children: child };
-    expect(memoCompareNodes(prev, next)).toBe(true);
-  });
-
-  it("returns true for equivalent React elements (same type and key)", () => {
-    const prev = { children: createElement("div", { key: "1" }) };
-    const next = { children: createElement("div", { key: "1" }) };
     expect(memoCompareNodes(prev, next)).toBe(true);
   });
 

--- a/packages/react-streamdown/src/__tests__/memoization.test.ts
+++ b/packages/react-streamdown/src/__tests__/memoization.test.ts
@@ -51,6 +51,12 @@ describe("memoCompareNodes", () => {
     expect(memoCompareNodes(prev, next)).toBe(true);
   });
 
+  it("returns false when child text changes with the same type and key", () => {
+    const prev = { children: createElement("code", { key: "same" }, "old") };
+    const next = { children: createElement("code", { key: "same" }, "new") };
+    expect(memoCompareNodes(prev, next)).toBe(false);
+  });
+
   it("returns false for different React element types", () => {
     const prev = { children: createElement("div", { key: "1" }) };
     const next = { children: createElement("span", { key: "1" }) };

--- a/packages/react-streamdown/src/memoization.ts
+++ b/packages/react-streamdown/src/memoization.ts
@@ -2,23 +2,6 @@
 
 import type { ReactNode } from "react";
 
-type ReactElement = { type: unknown; key: unknown };
-
-function isReactElement(node: unknown): node is ReactElement {
-  return (
-    typeof node === "object" && node !== null && "type" in node && "key" in node
-  );
-}
-
-/**
- * Compares two ReactNode values for shallow equality.
- */
-function compareNodes(a: ReactNode, b: ReactNode): boolean {
-  if (a === b) return true;
-  if (!isReactElement(a) || !isReactElement(b)) return false;
-  return a.type === b.type && a.key === b.key;
-}
-
 /**
  * Memo comparison function for components with children prop.
  * Inspired by react-markdown's approach.
@@ -34,5 +17,5 @@ export function memoCompareNodes<
     if (prev[key] !== next[key]) return false;
   }
 
-  return compareNodes(prev.children, next.children);
+  return prev.children === next.children;
 }

--- a/packages/react-streamdown/src/memoization.ts
+++ b/packages/react-streamdown/src/memoization.ts
@@ -3,8 +3,7 @@
 import type { ReactNode } from "react";
 
 /**
- * Memo comparison function for components with children prop.
- * Inspired by react-markdown's approach.
+ * Compares props with strict equality, including child element identity.
  */
 export function memoCompareNodes<
   T extends { children?: ReactNode; [key: string]: unknown },


### PR DESCRIPTION
## Problem

Memoized children can keep stale text and props after an update. This correction makes the new child content appear.

Reproduction base: `55c34a62512f901194470c6ad6fc561d69be207b` (`@assistant-ui/react-streamdown` 0.3.13). The button below leaves `old` on screen before the correction:

```jsx
import { memo, useState } from "react";
import { memoCompareNodes } from "@assistant-ui/react-streamdown";

const Content = memo(({ children }) => children, memoCompareNodes);

export default function Repro() {
  const [text, setText] = useState("old");
  return (
    <>
      <button onClick={() => setText("new")}>Update</button>
      <Content><code key="same">{text}</code></Content>
    </>
  );
}
```

## Root cause

The comparator treated different child elements as equal when their type and key matched. It ignored changed child props, including text. `PreOverride` uses this comparator and accepts an omitted `node` prop.

## Change

Children compare by identity instead of type and key. The other prop comparisons stay unchanged. Different child elements can re-render even when their output is equal.

## Verification

The mounted regression retained `old` before the correction and found `new` afterward. It also covers a class-only update.

`pnpm --filter @assistant-ui/react-streamdown test src/__tests__/memoization.test.ts src/__tests__/PreOverride.test.tsx` passed all 23 tests.

The browser check covered text changes, class changes, and reset through the actual `PreOverride` component and a consumer of the public comparator. Scoped Oxlint and formatting checks passed, as did `pnpm changesets:check`.

## Public surface

The `@assistant-ui/react-streamdown` comparator signature and exports stay unchanged. Existing documentation remains accurate. This PR includes a patch changeset. No template or API-reference changes are necessary.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._xNgZKbuYYIlvxywtRKaXt9sIy9_EhNN1_vwt1x5x56aaM4101A3woKS92o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->