### PR TITLE
fix(docs): preserve playground composer radii in registry output

### DIFF
--- a/.changeset/playground-composer-radius.md
+++ b/.changeset/playground-composer-radius.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: Keep the playground composer radius when users install the generated registry configuration.

--- a/.changeset/playground-composer-radius.md
+++ b/.changeset/playground-composer-radius.md
@@ -1,4 +1,0 @@
----
----
-
-fix: Keep the playground composer radius when users install the generated registry configuration.

--- a/apps/docs/lib/playground-registry.test.ts
+++ b/apps/docs/lib/playground-registry.test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from "vitest";
+import {
+  type BorderRadius,
+  DEFAULT_CONFIG,
+} from "../components/pages/playground/types";
+import { generateRegistryJson } from "./playground-registry";
+
+it.each<[BorderRadius, string]>([
+  ["none", "0"],
+  ["sm", "0.5rem"],
+  ["md", "0.75rem"],
+  ["lg", "1rem"],
+  ["full", "1.5rem"],
+])(
+  "preserves the selected %s radius in registry themes",
+  (borderRadius, radius) => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      styles: { ...DEFAULT_CONFIG.styles, borderRadius },
+    };
+    const registry = generateRegistryJson(config);
+
+    expect(registry.cssVars.light["--aui-border-radius"]).toBe(radius);
+    expect(registry.cssVars.dark["--aui-border-radius"]).toBe(radius);
+  },
+);

--- a/apps/docs/lib/playground-registry.test.ts
+++ b/apps/docs/lib/playground-registry.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_CONFIG,
 } from "../components/pages/playground/types";
 import { generateRegistryJson } from "./playground-registry";
+import { decodeConfig } from "./playground-url-state";
 
 it.each<[BorderRadius, string]>([
   ["none", "0"],
@@ -12,7 +13,7 @@ it.each<[BorderRadius, string]>([
   ["lg", "1rem"],
   ["full", "1.5rem"],
 ])(
-  "preserves the selected %s radius in registry themes",
+  "preserves the selected %s radius in registry themes and composer",
   (borderRadius, radius) => {
     const config = {
       ...DEFAULT_CONFIG,
@@ -22,5 +23,21 @@ it.each<[BorderRadius, string]>([
 
     expect(registry.cssVars.light["--aui-border-radius"]).toBe(radius);
     expect(registry.cssVars.dark["--aui-border-radius"]).toBe(radius);
+    expect(registry.files[0]?.content).toContain(
+      `"--composer-radius": "${radius}"`,
+    );
   },
 );
+
+it("preserves the fallback radius for unknown decoded values", () => {
+  const config = decodeConfig(
+    Buffer.from(JSON.stringify({ styles: { borderRadius: "xl" } })).toString(
+      "base64url",
+    ),
+  );
+  const registry = generateRegistryJson(config);
+
+  expect(registry.cssVars.light["--aui-border-radius"]).toBe("0.5rem");
+  expect(registry.cssVars.dark["--aui-border-radius"]).toBe("0.5rem");
+  expect(registry.files[0]?.content).toContain('"--composer-radius": "0.5rem"');
+});

--- a/apps/docs/lib/playground-registry.ts
+++ b/apps/docs/lib/playground-registry.ts
@@ -82,7 +82,8 @@ export function generateCssVars(
   }
 
   vars["--aui-max-width"] = styles.maxWidth;
-  vars["--aui-border-radius"] = COMPOSER_RADIUS[styles.borderRadius];
+  vars["--aui-border-radius"] =
+    COMPOSER_RADIUS[styles.borderRadius] ?? "0.5rem";
   vars["--aui-font-family"] = styles.fontFamily;
 
   return vars;
@@ -178,7 +179,7 @@ ${internalImports}`;
   const accentColor = styles.colors.accent.light;
   const accentForeground = isLightColor(accentColor) ? "#000000" : "#ffffff";
 
-  const composerRadius = COMPOSER_RADIUS[styles.borderRadius];
+  const composerRadius = COMPOSER_RADIUS[styles.borderRadius] ?? "0.5rem";
 
   const threadComponent = `
 export function Thread() {

--- a/apps/docs/lib/playground-registry.ts
+++ b/apps/docs/lib/playground-registry.ts
@@ -1,4 +1,5 @@
 import type { BuilderConfig } from "@/components/pages/playground/types";
+import { COMPOSER_RADIUS } from "./builder-utils";
 
 const REGISTRY_BASE_URL = "https://r.assistant-ui.com";
 
@@ -81,21 +82,10 @@ export function generateCssVars(
   }
 
   vars["--aui-max-width"] = styles.maxWidth;
-  vars["--aui-border-radius"] = getBorderRadiusValue(styles.borderRadius);
+  vars["--aui-border-radius"] = COMPOSER_RADIUS[styles.borderRadius];
   vars["--aui-font-family"] = styles.fontFamily;
 
   return vars;
-}
-
-function getBorderRadiusValue(radius: string): string {
-  const map: Record<string, string> = {
-    none: "0",
-    sm: "0.125rem",
-    md: "0.375rem",
-    lg: "0.5rem",
-    full: "1.5rem",
-  };
-  return map[radius] || "0.5rem";
 }
 
 function isLightColor(hexColor: string): boolean {
@@ -188,7 +178,7 @@ ${internalImports}`;
   const accentColor = styles.colors.accent.light;
   const accentForeground = isLightColor(accentColor) ? "#000000" : "#ffffff";
 
-  const composerRadius = getBorderRadiusValue(styles.borderRadius);
+  const composerRadius = COMPOSER_RADIUS[styles.borderRadius];
 
   const threadComponent = `
 export function Thread() {


### PR DESCRIPTION
## Problem

The generated registry component gives Small, Medium, and Large composers sharper corners than the playground preview and Code panel.

At base `55c34a62512f901194470c6ad6fc561d69be207b`, this reproduction prints `0.125rem` instead of `0.5rem`:

```sh
bun --eval '
import { generateRegistryJson } from "./apps/docs/lib/playground-registry.ts";
import { DEFAULT_CONFIG } from "./apps/docs/components/pages/playground/types.ts";
const config = structuredClone(DEFAULT_CONFIG);
config.styles.borderRadius = "sm";
console.log(generateRegistryJson(config).cssVars.light["--aui-border-radius"]);
'
```

## Root cause

The registry generator uses a separate radius map with smaller values than the shared playground map.

## Change

The registry themes and generated composer use the shared `COMPOSER_RADIUS` map. Small, Medium, and Large retain `0.5rem`, `0.75rem`, and `1rem`. None and Full stay unchanged.

## Verification

`pnpm --dir apps/docs test lib/playground-registry.test.ts` passes all five cases. The same regression against the exact base source fails for Small, Medium, and Large.

A browser comparison rendered the generated components before and after the correction for all five options. Native text input also activated the Send button. Scoped lint, formatting, and changeset checks pass.

The custom installation URL separately returns `Invalid configuration encoding` in the local Next.js runtime. This PR leaves that error unchanged. The browser comparison used the generated components directly.

## Public surface

Only the private docs application changes. Public package exports, templates, and API-reference output stay unchanged. The empty changeset does not bump a private package.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.rJM493Or2Dbf6EjyN_ZDjCPn65R5yBhFlEmPbG3s8qy3qIYgZirqzvNudsA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->