### PR TITLE
fix(react-generative-ui): apply null data model deletions

### DIFF
--- a/.changeset/quiet-a2ui-deletions.md
+++ b/.changeset/quiet-a2ui-deletions.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: apply A2UI null updates as data model deletions

--- a/packages/react-generative-ui/src/a2ui/reducer.test.ts
+++ b/packages/react-generative-ui/src/a2ui/reducer.test.ts
@@ -122,7 +122,7 @@ describe("applyA2uiOperations", () => {
   });
 
   it("does not create missing paths for null updates", () => {
-    const dataModel = { profile: { name: "Ada" } };
+    const dataModel = { profile: { name: "Ada" }, tags: ["first", "second"] };
     const state: A2uiState = new Map([
       ["main", { components: new Map(), dataModel }],
     ]);
@@ -133,6 +133,22 @@ describe("applyA2uiOperations", () => {
         updateDataModel: {
           surfaceId: "main",
           path: "/missing/value",
+          value: null,
+        },
+      },
+      {
+        version: "v1.0",
+        updateDataModel: {
+          surfaceId: "main",
+          path: "/tags/-",
+          value: null,
+        },
+      },
+      {
+        version: "v1.0",
+        updateDataModel: {
+          surfaceId: "main",
+          path: "/tags/7",
           value: null,
         },
       },

--- a/packages/react-generative-ui/src/a2ui/reducer.test.ts
+++ b/packages/react-generative-ui/src/a2ui/reducer.test.ts
@@ -82,6 +82,85 @@ describe("applyA2uiOperations", () => {
     });
   });
 
+  it("deletes object properties updated to null", () => {
+    const dataModel = {
+      profile: { name: "Ada", role: "admin" },
+      tags: ["first", "second"],
+    };
+    const state: A2uiState = new Map([
+      ["main", { components: new Map(), dataModel }],
+    ]);
+
+    const result = applyA2uiOperations(state, [
+      {
+        version: "v1.0",
+        updateDataModel: {
+          surfaceId: "main",
+          path: "/profile/name",
+          value: null,
+        },
+      },
+      {
+        version: "v1.0",
+        updateDataModel: {
+          surfaceId: "main",
+          path: "/tags/1",
+          value: null,
+        },
+      },
+    ]);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.state.get("main")?.dataModel).toEqual({
+      profile: { role: "admin" },
+      tags: ["first", null],
+    });
+    expect(dataModel).toEqual({
+      profile: { name: "Ada", role: "admin" },
+      tags: ["first", "second"],
+    });
+  });
+
+  it("does not create missing paths for null updates", () => {
+    const dataModel = { profile: { name: "Ada" } };
+    const state: A2uiState = new Map([
+      ["main", { components: new Map(), dataModel }],
+    ]);
+
+    const result = applyA2uiOperations(state, [
+      {
+        version: "v1.0",
+        updateDataModel: {
+          surfaceId: "main",
+          path: "/missing/value",
+          value: null,
+        },
+      },
+    ]);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.state.get("main")?.dataModel).toBe(dataModel);
+  });
+
+  it("allows null to replace the data model root", () => {
+    const state: A2uiState = new Map([
+      [
+        "main",
+        { components: new Map(), dataModel: { profile: { name: "Ada" } } },
+      ],
+    ]);
+
+    const result = applyA2uiOperations(state, [
+      {
+        version: "v1.0",
+        updateDataModel: { surfaceId: "main", value: null },
+      },
+    ]);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.state.get("main")?.dataModel).toBeNull();
+  });
+
   it("clones the touched surface and component map", () => {
     const components = new Map<string, Record<string, unknown>>([
       ["root", { id: "root", component: "Divider" }],

--- a/packages/react-generative-ui/src/a2ui/reducer.test.ts
+++ b/packages/react-generative-ui/src/a2ui/reducer.test.ts
@@ -111,13 +111,41 @@ describe("applyA2uiOperations", () => {
     ]);
 
     expect(result.warnings).toEqual([]);
-    expect(result.state.get("main")?.dataModel).toEqual({
-      profile: { role: "admin" },
-      tags: ["first", null],
-    });
+    const resultModel = result.state.get("main")?.dataModel as typeof dataModel;
+    expect(resultModel.profile).toEqual({ role: "admin" });
+    expect(resultModel.tags).toHaveLength(2);
+    expect(resultModel.tags[0]).toBe("first");
+    expect(Object.prototype.hasOwnProperty.call(resultModel.tags, 1)).toBe(
+      false,
+    );
     expect(dataModel).toEqual({
       profile: { name: "Ada", role: "admin" },
       tags: ["first", "second"],
+    });
+  });
+
+  it("preserves null values in v0.9 data model updates", () => {
+    const state: A2uiState = new Map([
+      [
+        "main",
+        { components: new Map(), dataModel: { profile: { name: "Ada" } } },
+      ],
+    ]);
+
+    const result = applyA2uiOperations(state, [
+      {
+        version: "v0.9",
+        updateDataModel: {
+          surfaceId: "main",
+          path: "/profile/name",
+          value: null,
+        },
+      },
+    ]);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.state.get("main")?.dataModel).toEqual({
+      profile: { name: null },
     });
   });
 

--- a/packages/react-generative-ui/src/a2ui/reducer.ts
+++ b/packages/react-generative-ui/src/a2ui/reducer.ts
@@ -109,6 +109,43 @@ const setAtPointer = (
   if (!segments) return { ok: false, value: model };
   if (segments.length === 0) return { ok: true, value };
 
+  const remove = (current: unknown, index: number): unknown => {
+    const segment = segments[index]!;
+    const isLast = index === segments.length - 1;
+
+    if (Array.isArray(current)) {
+      if (segment !== "-" && !isArrayIndex(segment)) return current;
+      const targetIndex = segment === "-" ? current.length : Number(segment);
+      if (isLast) {
+        const clone = current.slice();
+        clone[targetIndex] = null;
+        return clone;
+      }
+      const child = current[targetIndex];
+      if (!Array.isArray(child) && !isRecord(child)) return current;
+      const next = remove(child, index + 1);
+      if (next === child) return current;
+      const clone = current.slice();
+      clone[targetIndex] = next;
+      return clone;
+    }
+
+    if (!isRecord(current)) return current;
+    if (!Object.prototype.hasOwnProperty.call(current, segment)) return current;
+    if (isLast) {
+      const clone = { ...current };
+      delete clone[segment];
+      return clone;
+    }
+    const child = current[segment];
+    if (!Array.isArray(child) && !isRecord(child)) return current;
+    const next = remove(child, index + 1);
+    if (next === child) return current;
+    return { ...current, [segment]: next };
+  };
+
+  if (value === null) return { ok: true, value: remove(model, 0) };
+
   const update = (current: unknown, index: number): unknown => {
     const segment = segments[index]!;
     const isLast = index === segments.length - 1;

--- a/packages/react-generative-ui/src/a2ui/reducer.ts
+++ b/packages/react-generative-ui/src/a2ui/reducer.ts
@@ -117,6 +117,12 @@ const setAtPointer = (
       if (segment !== "-" && !isArrayIndex(segment)) return current;
       const targetIndex = segment === "-" ? current.length : Number(segment);
       if (isLast) {
+        if (
+          segment === "-" ||
+          !Object.prototype.hasOwnProperty.call(current, targetIndex)
+        ) {
+          return current;
+        }
         const clone = current.slice();
         clone[targetIndex] = null;
         return clone;

--- a/packages/react-generative-ui/src/a2ui/reducer.ts
+++ b/packages/react-generative-ui/src/a2ui/reducer.ts
@@ -104,6 +104,7 @@ const setAtPointer = (
   model: unknown,
   path: string,
   value: unknown,
+  nullDeletes: boolean,
 ): { readonly ok: boolean; readonly value: unknown } => {
   const segments = decodePointer(path);
   if (!segments) return { ok: false, value: model };
@@ -124,7 +125,8 @@ const setAtPointer = (
           return current;
         }
         const clone = current.slice();
-        clone[targetIndex] = null;
+        // Preserve indices referenced by other JSON Pointers.
+        delete clone[targetIndex];
         return clone;
       }
       const child = current[targetIndex];
@@ -150,7 +152,9 @@ const setAtPointer = (
     return { ...current, [segment]: next };
   };
 
-  if (value === null) return { ok: true, value: remove(model, 0) };
+  if (nullDeletes && value === null) {
+    return { ok: true, value: remove(model, 0) };
+  }
 
   const update = (current: unknown, index: number): unknown => {
     const segment = segments[index]!;
@@ -307,7 +311,12 @@ export function applyA2uiOperations(
         );
         continue;
       }
-      const result = setAtPointer(surface.dataModel, path, update.value);
+      const result = setAtPointer(
+        surface.dataModel,
+        path,
+        update.value,
+        version === "v1.0",
+      );
       if (!result.ok) {
         warnings.push(
           `Operation at index ${index} has an invalid JSON Pointer path.`,


### PR DESCRIPTION
## Problem

A2UI v1.0 defines an `updateDataModel` value of `null` as deletion of the key at the supplied path. The reducer instead stored `null`, leaving stale object properties in the rendered model. A null update to a missing nested path could also create a new branch containing `null`.

Reproduced on current main with `/profile/name`: the result retained `{ name: null }` instead of removing `name`.

## Root cause

`setAtPointer()` used the same upsert path for every value and protocol version, so it could not distinguish v1.0 deletion from ordinary assignment.

## Change

Apply v1.0 non-root null updates through an immutable removal path. Existing object keys and array slots are deleted, missing paths remain unchanged, and array indices remain stable. A root null update still replaces the entire data model. A2UI v0.9 continues treating explicit `null` as a stored value.

## Verification

- Confirmed the regression tests fail on the pre-fix reducer
- `pnpm --filter @assistant-ui/react-generative-ui test` (628 tests)
- `pnpm --filter @assistant-ui/react-generative-ui build`
- `pnpm exec oxlint packages/react-generative-ui/src/a2ui/reducer.ts packages/react-generative-ui/src/a2ui/reducer.test.ts`
- `pnpm changesets:check`

## Public surface

`@assistant-ui/react-generative-ui` behavior only. No exports or type signatures change. Includes a patch changeset; no documentation or template updates are required.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.SLr1XmgU_8rxVw2shLviwOO8nO8M5JMP-bfa52ibhK3ykNsGNxceA78VgRk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->