### PR TITLE
fix(react-streamdown): type PluginConfig slots with the streamdown plugin interfaces

### DIFF
--- a/.changeset/streamdown-plugin-config-types.md
+++ b/.changeset/streamdown-plugin-config-types.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: type every `PluginConfig` slot with its streamdown plugin interface instead of `unknown`

--- a/api-surface/assistant-ui__react-streamdown.ts
+++ b/api-surface/assistant-ui__react-streamdown.ts
@@ -235,7 +235,10 @@ type ParentOf<K extends ClientNames> = ClientMeta<K> extends {
 } ? S extends ClientNames ? S : never : never;
 
 type PluginConfig = {
-  [K in "cjk" | "code" | "math" | "mermaid"]?: ResolvedPluginConfig[K] | false | undefined;
+  code?: ResolvedPluginConfig["code"] | false;
+  math?: ResolvedPluginConfig["math"] | false;
+  cjk?: ResolvedPluginConfig["cjk"] | false;
+  mermaid?: ResolvedPluginConfig["mermaid"] | false;
 };
 
 interface Point {

--- a/api-surface/assistant-ui__react-streamdown.ts
+++ b/api-surface/assistant-ui__react-streamdown.ts
@@ -12,7 +12,7 @@ import { Options as RemarkRehypeOptions } from "remark-rehype";
 
 import { RemendOptions } from "remend";
 
-import { BundledLanguage, BundledTheme, BundledTheme as BundledTheme$1, CjkPlugin, CodeHighlighterPlugin, DiagramPlugin, HighlightOptions, MathPlugin, MermaidErrorComponentProps, MermaidOptions, StreamdownContext, StreamdownProps, StreamdownProps as StreamdownProps$1, StreamdownProps as StreamdownProps$2, parseMarkdownIntoBlocks } from "streamdown";
+import { BundledLanguage, BundledTheme, BundledTheme as BundledTheme$1, CjkPlugin, CjkPlugin as CjkPlugin$1, CodeHighlighterPlugin, CodeHighlighterPlugin as CodeHighlighterPlugin$1, DiagramPlugin, DiagramPlugin as DiagramPlugin$1, HighlightOptions, MathPlugin, MathPlugin as MathPlugin$1, MermaidErrorComponentProps, MermaidOptions, StreamdownContext, StreamdownProps, StreamdownProps as StreamdownProps$1, StreamdownProps as StreamdownProps$2, parseMarkdownIntoBlocks } from "streamdown";
 
 import "zustand";
 
@@ -235,10 +235,10 @@ type ParentOf<K extends ClientNames> = ClientMeta<K> extends {
 } ? S extends ClientNames ? S : never : never;
 
 type PluginConfig = {
-  code?: unknown | false | undefined;
-  math?: unknown | false | undefined;
-  cjk?: unknown | false | undefined;
-  mermaid?: unknown | false | undefined;
+  code?: CodeHighlighterPlugin | false | undefined;
+  math?: MathPlugin | false | undefined;
+  cjk?: CjkPlugin | false | undefined;
+  mermaid?: DiagramPlugin | false | undefined;
 };
 
 interface Point {
@@ -1092,7 +1092,7 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { AllowedTags, BlockProps, BundledLanguage, BundledTheme$1 as BundledTheme, CaretStyle, CjkPlugin, CodeHeaderProps, CodeHighlighterPlugin, ComponentsByLanguage, ControlsConfig, DEFAULT_SHIKI_THEME, DiagramPlugin, HighlightOptions, LinkSafetyConfig, LinkSafetyModalProps, MathPlugin, MermaidErrorComponentProps, MermaidOptions, PluginConfig, RemarkRehypeOptions, RemendConfig, RemendHandler, ResolvedPluginConfig, SecurityConfig, StreamdownContext, StreamdownProps$1 as StreamdownProps, StreamdownTextComponents, StreamdownTextPrimitive, StreamdownTextPrimitiveProps, SyntaxHighlighterProps, escapeCurrencyDollars, findRemendWindowStart, memoCompareNodes, normalizeMathDelimiters, parseMarkdownIntoBlocks, rewriteCustomMathTags, rewriteLatexBracketDelimiters, tailBoundedRemend, useIsStreamdownCodeBlock, useStreamdownPreProps };
+  export { AllowedTags, BlockProps, BundledLanguage, BundledTheme$1 as BundledTheme, CaretStyle, CjkPlugin$1 as CjkPlugin, CodeHeaderProps, CodeHighlighterPlugin$1 as CodeHighlighterPlugin, ComponentsByLanguage, ControlsConfig, DEFAULT_SHIKI_THEME, DiagramPlugin$1 as DiagramPlugin, HighlightOptions, LinkSafetyConfig, LinkSafetyModalProps, MathPlugin$1 as MathPlugin, MermaidErrorComponentProps, MermaidOptions, PluginConfig, RemarkRehypeOptions, RemendConfig, RemendHandler, ResolvedPluginConfig, SecurityConfig, StreamdownContext, StreamdownProps$1 as StreamdownProps, StreamdownTextComponents, StreamdownTextPrimitive, StreamdownTextPrimitiveProps, SyntaxHighlighterProps, escapeCurrencyDollars, findRemendWindowStart, memoCompareNodes, normalizeMathDelimiters, parseMarkdownIntoBlocks, rewriteCustomMathTags, rewriteLatexBracketDelimiters, tailBoundedRemend, useIsStreamdownCodeBlock, useStreamdownPreProps };
 }
 
 declare function memoCompareNodes<T extends {

--- a/api-surface/assistant-ui__react-streamdown.ts
+++ b/api-surface/assistant-ui__react-streamdown.ts
@@ -12,7 +12,7 @@ import { Options as RemarkRehypeOptions } from "remark-rehype";
 
 import { RemendOptions } from "remend";
 
-import { BundledLanguage, BundledTheme, BundledTheme as BundledTheme$1, CjkPlugin, CjkPlugin as CjkPlugin$1, CodeHighlighterPlugin, CodeHighlighterPlugin as CodeHighlighterPlugin$1, DiagramPlugin, DiagramPlugin as DiagramPlugin$1, HighlightOptions, MathPlugin, MathPlugin as MathPlugin$1, MermaidErrorComponentProps, MermaidOptions, StreamdownContext, StreamdownProps, StreamdownProps as StreamdownProps$1, StreamdownProps as StreamdownProps$2, parseMarkdownIntoBlocks } from "streamdown";
+import { BundledLanguage, BundledTheme, BundledTheme as BundledTheme$1, CjkPlugin, CodeHighlighterPlugin, DiagramPlugin, HighlightOptions, MathPlugin, MermaidErrorComponentProps, MermaidOptions, StreamdownContext, StreamdownProps, StreamdownProps as StreamdownProps$1, StreamdownProps as StreamdownProps$2, parseMarkdownIntoBlocks } from "streamdown";
 
 import "zustand";
 
@@ -235,10 +235,7 @@ type ParentOf<K extends ClientNames> = ClientMeta<K> extends {
 } ? S extends ClientNames ? S : never : never;
 
 type PluginConfig = {
-  code?: CodeHighlighterPlugin | false | undefined;
-  math?: MathPlugin | false | undefined;
-  cjk?: CjkPlugin | false | undefined;
-  mermaid?: DiagramPlugin | false | undefined;
+  [K in "cjk" | "code" | "math" | "mermaid"]?: ResolvedPluginConfig[K] | false | undefined;
 };
 
 interface Point {
@@ -1092,7 +1089,7 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { AllowedTags, BlockProps, BundledLanguage, BundledTheme$1 as BundledTheme, CaretStyle, CjkPlugin$1 as CjkPlugin, CodeHeaderProps, CodeHighlighterPlugin$1 as CodeHighlighterPlugin, ComponentsByLanguage, ControlsConfig, DEFAULT_SHIKI_THEME, DiagramPlugin$1 as DiagramPlugin, HighlightOptions, LinkSafetyConfig, LinkSafetyModalProps, MathPlugin$1 as MathPlugin, MermaidErrorComponentProps, MermaidOptions, PluginConfig, RemarkRehypeOptions, RemendConfig, RemendHandler, ResolvedPluginConfig, SecurityConfig, StreamdownContext, StreamdownProps$1 as StreamdownProps, StreamdownTextComponents, StreamdownTextPrimitive, StreamdownTextPrimitiveProps, SyntaxHighlighterProps, escapeCurrencyDollars, findRemendWindowStart, memoCompareNodes, normalizeMathDelimiters, parseMarkdownIntoBlocks, rewriteCustomMathTags, rewriteLatexBracketDelimiters, tailBoundedRemend, useIsStreamdownCodeBlock, useStreamdownPreProps };
+  export { AllowedTags, BlockProps, BundledLanguage, BundledTheme$1 as BundledTheme, CaretStyle, CjkPlugin, CodeHeaderProps, CodeHighlighterPlugin, ComponentsByLanguage, ControlsConfig, DEFAULT_SHIKI_THEME, DiagramPlugin, HighlightOptions, LinkSafetyConfig, LinkSafetyModalProps, MathPlugin, MermaidErrorComponentProps, MermaidOptions, PluginConfig, RemarkRehypeOptions, RemendConfig, RemendHandler, ResolvedPluginConfig, SecurityConfig, StreamdownContext, StreamdownProps$1 as StreamdownProps, StreamdownTextComponents, StreamdownTextPrimitive, StreamdownTextPrimitiveProps, SyntaxHighlighterProps, escapeCurrencyDollars, findRemendWindowStart, memoCompareNodes, normalizeMathDelimiters, parseMarkdownIntoBlocks, rewriteCustomMathTags, rewriteLatexBracketDelimiters, tailBoundedRemend, useIsStreamdownCodeBlock, useStreamdownPreProps };
 }
 
 declare function memoCompareNodes<T extends {

--- a/packages/react-streamdown/package.json
+++ b/packages/react-streamdown/package.json
@@ -72,7 +72,10 @@
   "devDependencies": {
     "@assistant-ui/react": "workspace:*",
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@streamdown/cjk": "^1.0.3",
     "@streamdown/code": "^1.1.1",
+    "@streamdown/math": "^1.0.2",
+    "@streamdown/mermaid": "^1.0.2",
     "@testing-library/react": "^16.3.3",
     "@types/react": "^19.2.18",
     "react": "^19.2.8",

--- a/packages/react-streamdown/src/__tests__/defaults.test.ts
+++ b/packages/react-streamdown/src/__tests__/defaults.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { code } from "@streamdown/code";
 import { mergePlugins, DEFAULT_SHIKI_THEME } from "../defaults";
 import type { PluginConfig, ResolvedPluginConfig } from "../types";
 import type {
@@ -15,16 +16,29 @@ describe("DEFAULT_SHIKI_THEME", () => {
 });
 
 describe("PluginConfig", () => {
-  it("accepts plugin instances and the false opt-out only", () => {
+  it("accepts a real plugin instance, a cast instance, and the false opt-out", () => {
     const config: PluginConfig = {
-      code: false,
-      math: { name: "math" } as unknown as MathPlugin,
+      code,
+      math: false,
+      cjk: { name: "cjk" } as unknown as CjkPlugin,
+      mermaid: { name: "mermaid" } as unknown as DiagramPlugin,
+    };
+    expect(config.code).toBe(code);
+    expect(config.math).toBe(false);
+  });
+
+  it("rejects values that are neither a plugin instance nor false", () => {
+    const config: PluginConfig = {
+      // @ts-expect-error a bare object is not a plugin instance
+      code: { type: "code" },
+      // @ts-expect-error true is not an opt-in
+      math: true,
       // @ts-expect-error a bare object is not a plugin instance
       cjk: { type: "cjk" },
       // @ts-expect-error true is not an opt-in
       mermaid: true,
     };
-    expect(config.code).toBe(false);
+    expect(Object.keys(config)).toHaveLength(4);
   });
 });
 

--- a/packages/react-streamdown/src/__tests__/defaults.test.ts
+++ b/packages/react-streamdown/src/__tests__/defaults.test.ts
@@ -1,11 +1,30 @@
 import { describe, it, expect } from "vitest";
 import { mergePlugins, DEFAULT_SHIKI_THEME } from "../defaults";
 import type { PluginConfig, ResolvedPluginConfig } from "../types";
-import type { CodeHighlighterPlugin, MathPlugin, CjkPlugin } from "streamdown";
+import type {
+  CjkPlugin,
+  CodeHighlighterPlugin,
+  DiagramPlugin,
+  MathPlugin,
+} from "streamdown";
 
 describe("DEFAULT_SHIKI_THEME", () => {
   it("has light and dark theme", () => {
     expect(DEFAULT_SHIKI_THEME).toEqual(["github-light", "github-dark"]);
+  });
+});
+
+describe("PluginConfig", () => {
+  it("accepts plugin instances and the false opt-out only", () => {
+    const config: PluginConfig = {
+      code: false,
+      math: { name: "math" } as unknown as MathPlugin,
+      // @ts-expect-error a bare object is not a plugin instance
+      cjk: { type: "cjk" },
+      // @ts-expect-error true is not an opt-in
+      mermaid: true,
+    };
+    expect(config.code).toBe(false);
   });
 });
 
@@ -15,7 +34,9 @@ describe("mergePlugins", () => {
   } as unknown as CodeHighlighterPlugin;
   const mockMathPlugin = { type: "math" } as unknown as MathPlugin;
   const mockCjkPlugin = { type: "cjk" } as unknown as CjkPlugin;
-  const mockMermaidPlugin = { type: "mermaid" };
+  const mockMermaidPlugin = {
+    type: "mermaid",
+  } as unknown as DiagramPlugin;
 
   it("returns empty object when no plugins provided or detected", () => {
     const result = mergePlugins(undefined, {});
@@ -35,7 +56,7 @@ describe("mergePlugins", () => {
   });
 
   it("uses user plugins over defaults", () => {
-    const userCode = { type: "user-code" };
+    const userCode = { type: "user-code" } as unknown as CodeHighlighterPlugin;
     const userPlugins: PluginConfig = { code: userCode };
     const defaults: ResolvedPluginConfig = { code: mockCodePlugin };
 
@@ -52,7 +73,7 @@ describe("mergePlugins", () => {
   });
 
   it("allows mixing user plugins with defaults", () => {
-    const userMath = { type: "user-math" };
+    const userMath = { type: "user-math" } as unknown as MathPlugin;
     const userPlugins: PluginConfig = {
       code: false,
       math: userMath,

--- a/packages/react-streamdown/src/__tests__/defaults.test.ts
+++ b/packages/react-streamdown/src/__tests__/defaults.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { cjk } from "@streamdown/cjk";
-import { code } from "@streamdown/code";
-import { math } from "@streamdown/math";
-import { mermaid } from "@streamdown/mermaid";
+import { describe, it, expect, expectTypeOf } from "vitest";
+import type { cjk } from "@streamdown/cjk";
+import type { code } from "@streamdown/code";
+import type { math } from "@streamdown/math";
+import type { mermaid } from "@streamdown/mermaid";
 import { mergePlugins, DEFAULT_SHIKI_THEME } from "../defaults";
 import type { PluginConfig, ResolvedPluginConfig } from "../types";
 import type {
@@ -19,31 +19,30 @@ describe("DEFAULT_SHIKI_THEME", () => {
 });
 
 describe("PluginConfig", () => {
-  it("accepts the real plugin instances and the false opt-out", () => {
-    const config: PluginConfig = { code, math, cjk, mermaid };
-    expect(config).toEqual({ code, math, cjk, mermaid });
-
-    const disabled: PluginConfig = {
-      code: false,
-      math: false,
-      cjk: false,
-      mermaid: false,
-    };
-    expect(Object.values(disabled)).toEqual([false, false, false, false]);
+  it("accepts the real plugin exports and the false opt-out", () => {
+    expectTypeOf<{
+      code: typeof code;
+      math: typeof math;
+      cjk: typeof cjk;
+      mermaid: typeof mermaid;
+    }>().toMatchTypeOf<PluginConfig>();
+    expectTypeOf<{
+      code: false;
+      math: false;
+      cjk: false;
+      mermaid: false;
+    }>().toMatchTypeOf<PluginConfig>();
   });
 
   it("rejects values that are neither a plugin instance nor false", () => {
-    const config: PluginConfig = {
-      // @ts-expect-error a bare object is not a plugin instance
-      code: { type: "code" },
-      // @ts-expect-error true is not an opt-in
-      math: true,
-      // @ts-expect-error a bare object is not a plugin instance
-      cjk: { type: "cjk" },
-      // @ts-expect-error true is not an opt-in
-      mermaid: true,
-    };
-    expect(Object.keys(config)).toHaveLength(4);
+    // @ts-expect-error a bare object is not a plugin instance
+    expectTypeOf<{ code: { type: "code" } }>().toMatchTypeOf<PluginConfig>();
+    // @ts-expect-error true is not an opt-in
+    expectTypeOf<{ math: true }>().toMatchTypeOf<PluginConfig>();
+    // @ts-expect-error a bare object is not a plugin instance
+    expectTypeOf<{ cjk: { type: "cjk" } }>().toMatchTypeOf<PluginConfig>();
+    // @ts-expect-error true is not an opt-in
+    expectTypeOf<{ mermaid: true }>().toMatchTypeOf<PluginConfig>();
   });
 });
 

--- a/packages/react-streamdown/src/__tests__/defaults.test.ts
+++ b/packages/react-streamdown/src/__tests__/defaults.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
+import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
+import { math } from "@streamdown/math";
+import { mermaid } from "@streamdown/mermaid";
 import { mergePlugins, DEFAULT_SHIKI_THEME } from "../defaults";
 import type { PluginConfig, ResolvedPluginConfig } from "../types";
 import type {
@@ -16,15 +19,17 @@ describe("DEFAULT_SHIKI_THEME", () => {
 });
 
 describe("PluginConfig", () => {
-  it("accepts a real plugin instance, a cast instance, and the false opt-out", () => {
-    const config: PluginConfig = {
-      code,
+  it("accepts the real plugin instances and the false opt-out", () => {
+    const config: PluginConfig = { code, math, cjk, mermaid };
+    expect(config).toEqual({ code, math, cjk, mermaid });
+
+    const disabled: PluginConfig = {
+      code: false,
       math: false,
-      cjk: { name: "cjk" } as unknown as CjkPlugin,
-      mermaid: { name: "mermaid" } as unknown as DiagramPlugin,
+      cjk: false,
+      mermaid: false,
     };
-    expect(config.code).toBe(code);
-    expect(config.math).toBe(false);
+    expect(Object.values(disabled)).toEqual([false, false, false, false]);
   });
 
   it("rejects values that are neither a plugin instance nor false", () => {

--- a/packages/react-streamdown/src/__tests__/defaults.test.ts
+++ b/packages/react-streamdown/src/__tests__/defaults.test.ts
@@ -25,24 +25,24 @@ describe("PluginConfig", () => {
       math: typeof math;
       cjk: typeof cjk;
       mermaid: typeof mermaid;
-    }>().toMatchTypeOf<PluginConfig>();
+    }>().toExtend<PluginConfig>();
     expectTypeOf<{
       code: false;
       math: false;
       cjk: false;
       mermaid: false;
-    }>().toMatchTypeOf<PluginConfig>();
+    }>().toExtend<PluginConfig>();
   });
 
   it("rejects values that are neither a plugin instance nor false", () => {
     // @ts-expect-error a bare object is not a plugin instance
-    expectTypeOf<{ code: { type: "code" } }>().toMatchTypeOf<PluginConfig>();
+    expectTypeOf<{ code: { type: "code" } }>().toExtend<PluginConfig>();
     // @ts-expect-error true is not an opt-in
-    expectTypeOf<{ math: true }>().toMatchTypeOf<PluginConfig>();
+    expectTypeOf<{ math: true }>().toExtend<PluginConfig>();
     // @ts-expect-error a bare object is not a plugin instance
-    expectTypeOf<{ cjk: { type: "cjk" } }>().toMatchTypeOf<PluginConfig>();
+    expectTypeOf<{ cjk: { type: "cjk" } }>().toExtend<PluginConfig>();
     // @ts-expect-error true is not an opt-in
-    expectTypeOf<{ mermaid: true }>().toMatchTypeOf<PluginConfig>();
+    expectTypeOf<{ mermaid: true }>().toExtend<PluginConfig>();
   });
 });
 

--- a/packages/react-streamdown/src/defaults.ts
+++ b/packages/react-streamdown/src/defaults.ts
@@ -38,9 +38,7 @@ export function mergePlugins(
 
   // Mermaid requires explicit enabling (not auto-detected)
   const mermaid = userPlugins?.mermaid;
-  if (mermaid && mermaid !== false) {
-    result.mermaid = mermaid;
-  }
+  if (mermaid) result.mermaid = mermaid;
 
   return result as ResolvedPluginConfig;
 }

--- a/packages/react-streamdown/src/types.ts
+++ b/packages/react-streamdown/src/types.ts
@@ -127,10 +127,14 @@ export type StreamdownTextComponents = NonNullable<
  * <StreamdownTextPrimitive plugins={{ code, math }} />
  */
 export type PluginConfig = {
-  [K in "code" | "math" | "cjk" | "mermaid"]?:
-    | ResolvedPluginConfig[K]
-    | false
-    | undefined;
+  /** Code syntax highlighting plugin. Must be explicitly provided. */
+  code?: ResolvedPluginConfig["code"] | false;
+  /** Math/LaTeX rendering plugin. Must be explicitly provided. */
+  math?: ResolvedPluginConfig["math"] | false;
+  /** CJK text optimization plugin. Must be explicitly provided. */
+  cjk?: ResolvedPluginConfig["cjk"] | false;
+  /** Mermaid diagram plugin. Must be explicitly provided. */
+  mermaid?: ResolvedPluginConfig["mermaid"] | false;
 };
 
 /**

--- a/packages/react-streamdown/src/types.ts
+++ b/packages/react-streamdown/src/types.ts
@@ -7,10 +7,6 @@ import type {
 import type { ComponentPropsWithoutRef, ComponentType, ReactNode } from "react";
 import type { Options as RemarkRehypeOptions } from "remark-rehype";
 import type {
-  CjkPlugin,
-  CodeHighlighterPlugin,
-  DiagramPlugin,
-  MathPlugin,
   MermaidErrorComponentProps,
   MermaidOptions,
   StreamdownProps,
@@ -118,9 +114,9 @@ export type StreamdownTextComponents = NonNullable<
 };
 
 /**
- * Plugin configuration type.
- * Set to `false` to explicitly disable a plugin.
- * Set to a plugin instance to use that plugin.
+ * Plugin configuration type. Each slot takes the matching streamdown plugin
+ * instance, or `false` to disable that plugin explicitly; the slot types come
+ * from streamdown's own `plugins` prop so the two cannot drift.
  *
  * NOTE: Plugins are NOT auto-detected for tree-shaking optimization.
  * You must explicitly import and provide them.
@@ -131,14 +127,10 @@ export type StreamdownTextComponents = NonNullable<
  * <StreamdownTextPrimitive plugins={{ code, math }} />
  */
 export type PluginConfig = {
-  /** Code syntax highlighting plugin. Must be explicitly provided. */
-  code?: CodeHighlighterPlugin | false | undefined;
-  /** Math/LaTeX rendering plugin. Must be explicitly provided. */
-  math?: MathPlugin | false | undefined;
-  /** CJK text optimization plugin. Must be explicitly provided. */
-  cjk?: CjkPlugin | false | undefined;
-  /** Mermaid diagram plugin. Must be explicitly provided. */
-  mermaid?: DiagramPlugin | false | undefined;
+  [K in "code" | "math" | "cjk" | "mermaid"]?:
+    | ResolvedPluginConfig[K]
+    | false
+    | undefined;
 };
 
 /**

--- a/packages/react-streamdown/src/types.ts
+++ b/packages/react-streamdown/src/types.ts
@@ -7,9 +7,13 @@ import type {
 import type { ComponentPropsWithoutRef, ComponentType, ReactNode } from "react";
 import type { Options as RemarkRehypeOptions } from "remark-rehype";
 import type {
-  StreamdownProps,
-  MermaidOptions,
+  CjkPlugin,
+  CodeHighlighterPlugin,
+  DiagramPlugin,
+  MathPlugin,
   MermaidErrorComponentProps,
+  MermaidOptions,
+  StreamdownProps,
 } from "streamdown";
 
 /**
@@ -128,13 +132,13 @@ export type StreamdownTextComponents = NonNullable<
  */
 export type PluginConfig = {
   /** Code syntax highlighting plugin. Must be explicitly provided. */
-  code?: unknown | false | undefined;
+  code?: CodeHighlighterPlugin | false | undefined;
   /** Math/LaTeX rendering plugin. Must be explicitly provided. */
-  math?: unknown | false | undefined;
+  math?: MathPlugin | false | undefined;
   /** CJK text optimization plugin. Must be explicitly provided. */
-  cjk?: unknown | false | undefined;
+  cjk?: CjkPlugin | false | undefined;
   /** Mermaid diagram plugin. Must be explicitly provided. */
-  mermaid?: unknown | false | undefined;
+  mermaid?: DiagramPlugin | false | undefined;
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4932,15 +4932,6 @@ importers:
       '@assistant-ui/react-markdown':
         specifier: ^0.14.14
         version: link:../react-markdown
-      '@streamdown/cjk':
-        specifier: ^1.0.0
-        version: 1.0.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@10.2.2))(react@19.2.8)(supports-color@10.2.2)(unified@11.0.5)
-      '@streamdown/math':
-        specifier: ^1.0.0
-        version: 1.0.2(react@19.2.8)(supports-color@10.2.2)
-      '@streamdown/mermaid':
-        specifier: ^1.0.0
-        version: 1.0.2(react@19.2.8)
       '@types/hast':
         specifier: ^3.0.5
         version: 3.0.5
@@ -4966,9 +4957,18 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
+      '@streamdown/cjk':
+        specifier: ^1.0.3
+        version: 1.0.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@10.2.2))(react@19.2.8)(supports-color@10.2.2)(unified@11.0.5)
       '@streamdown/code':
         specifier: ^1.1.1
         version: 1.1.1(react@19.2.8)
+      '@streamdown/math':
+        specifier: ^1.0.2
+        version: 1.0.2(react@19.2.8)(supports-color@10.2.2)
+      '@streamdown/mermaid':
+        specifier: ^1.0.2
+        version: 1.0.2(react@19.2.8)
       '@testing-library/react':
         specifier: ^16.3.3
         version: 16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@19.2.7(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)


### PR DESCRIPTION
## Problem

`PluginConfig` in `@assistant-ui/react-streamdown` types every slot as `unknown | false | undefined`, which collapses to `unknown`. Any value type-checks as a plugin (`plugins={{ code: { type: "x" } }}` compiles), a wrong import surfaces only at runtime inside streamdown, and the `false` opt-out is invisible in IntelliSense because the union has already widened.

## Root cause

`unknown` absorbs every other member of a union, so `unknown | false` carries no information. streamdown exports the plugin interfaces (`CodeHighlighterPlugin`, `MathPlugin`, `CjkPlugin`, `DiagramPlugin`) and this package already re-exports them, but `PluginConfig` never referenced them.

## Change

Each `PluginConfig` slot is typed as the matching slot of streamdown's own `plugins` prop (`ResolvedPluginConfig["code"]` and so on) plus `| false`, with the per-slot JSDoc kept. The slot types therefore cannot drift from what streamdown accepts, and the api-surface file changes by exactly those four lines. `mergePlugins` keeps the same runtime behavior; its `mermaid !== false` comparison became unreachable after narrowing and is folded into the truthiness check.

`@streamdown/cjk`, `@streamdown/math`, and `@streamdown/mermaid` join `@streamdown/code` as devDependencies at the versions the lockfile already resolved for the optional peers, so the test can name the real plugin exports the docs tell users to pass. They are imported as types only, so the suite loads none of them at runtime. The lockfile change is the three importer specifiers only.

- Narrowing an input from `unknown` is compile-time only, and only for values that were never valid plugins. Each satellite declares its own local plugin interface, so assignability to streamdown's is structural; the type test turns that into a checked fact for all four documented slots.
- streamdown's `PluginConfig` also carries `renderers?: CustomRenderer[]`; this package's config does not expose it, and adding it is new surface for a separate change.

## Verification

- `packages/react-streamdown`: `pnpm exec tsc --noEmit -p tsconfig.json` exits 0. `defaults.test.ts` gains two type-level tests built on vitest's `expectTypeOf`: the real `code`, `math`, `cjk`, and `mermaid` exports and the all-`false` opt-out match `PluginConfig`, and a bare object or `true` on each slot is rejected under `@ts-expect-error`. `expectTypeOf` is a runtime no-op, so these are evaluated by `tsc` (`pnpm test:types`), not by `turbo test`; against main's `types.ts` all four directives become unused-directive errors.
- `packages/react-streamdown`: `pnpm exec vitest run` exits 0 (10 files, 225 tests).
- `pnpm exec oxlint` and `pnpm exec oxfmt --check` on the package source exit 0.
- `node scripts/generate-api-surface.mjs --filter @assistant-ui/react-streamdown` regenerates one file; the diff is the four slot lines replaced by the mapped type.
- `pnpm changesets:check` exits 0. `pnpm size:check` shows no change attributable to this PR (types only).

## Public surface

`@assistant-ui/react-streamdown`, patch changeset. `PluginConfig` slot types narrow from `unknown` to streamdown's own slot types; no export added or removed. api-surface file regenerated. Three devDependencies added to the package. No docs or template changes.
