### PR TITLE
fix(ai-sdk): show approval request reasons

### DIFF
--- a/.changeset/calm-tools-prompt.md
+++ b/.changeset/calm-tools-prompt.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+fix: show approval request reasons as fallback prompts

--- a/packages/ai-sdk/src/converters/convertMessage.test.ts
+++ b/packages/ai-sdk/src/converters/convertMessage.test.ts
@@ -430,6 +430,7 @@ describe("AISDKMessageConverter", () => {
       reason: "approved by operator",
       prompt: "Deploy to production?",
       descriptor,
+      requestReason: "Production access requires approval",
       signature: "signed-approval",
       futureField: "preserved",
     });
@@ -468,6 +469,7 @@ describe("AISDKMessageConverter", () => {
       id: "approval-1",
       prompt: "kept",
       resolution: "cancelled",
+      requestReason: "kept",
     });
   });
 

--- a/packages/ai-sdk/src/converters/convertMessage.test.ts
+++ b/packages/ai-sdk/src/converters/convertMessage.test.ts
@@ -394,7 +394,7 @@ describe("AISDKMessageConverter", () => {
     });
   });
 
-  it("preserves AI SDK and producer-defined approval fields", () => {
+  it("preserves producer-defined approval fields and gives prompt precedence", () => {
     const descriptor = { scope: "account:deploy" };
     const converted = AISDKMessageConverter.toThreadMessages([
       {
@@ -430,13 +430,12 @@ describe("AISDKMessageConverter", () => {
       reason: "approved by operator",
       prompt: "Deploy to production?",
       descriptor,
-      requestReason: "Production access requires approval",
       signature: "signed-approval",
       futureField: "preserved",
     });
   });
 
-  it("drops the approval fields the AI SDK response cannot answer", () => {
+  it("drops fields the AI SDK cannot answer and uses requestReason as the prompt", () => {
     const converted = AISDKMessageConverter.toThreadMessages([
       {
         id: "a1",
@@ -467,8 +466,8 @@ describe("AISDKMessageConverter", () => {
     );
     expect(toolCall?.approval).toEqual({
       id: "approval-1",
+      prompt: "kept",
       resolution: "cancelled",
-      requestReason: "kept",
     });
   });
 

--- a/packages/ai-sdk/src/converters/convertMessage.ts
+++ b/packages/ai-sdk/src/converters/convertMessage.ts
@@ -168,7 +168,6 @@ function getToolApprovalAndInterrupt(
     const {
       id,
       prompt,
-      requestReason,
       approved,
       reason,
       isAutomatic,
@@ -180,6 +179,7 @@ function getToolApprovalAndInterrupt(
       text,
       ...additionalApprovalFields
     } = part.approval;
+    const requestReason = additionalApprovalFields.requestReason;
     if (typeof id === "string")
       return {
         approval: {

--- a/packages/ai-sdk/src/converters/convertMessage.ts
+++ b/packages/ai-sdk/src/converters/convertMessage.ts
@@ -168,6 +168,7 @@ function getToolApprovalAndInterrupt(
     const {
       id,
       prompt,
+      requestReason,
       approved,
       reason,
       isAutomatic,
@@ -184,7 +185,11 @@ function getToolApprovalAndInterrupt(
         approval: {
           ...additionalApprovalFields,
           id,
-          ...(typeof prompt === "string" && { prompt }),
+          ...(typeof prompt === "string"
+            ? { prompt }
+            : typeof requestReason === "string"
+              ? { prompt: requestReason }
+              : {}),
           ...(typeof approved === "boolean" && { approved }),
           ...(typeof reason === "string" && { reason }),
           ...(isAutomatic === true && { isAutomatic: true }),


### PR DESCRIPTION
## Problem

AI SDK approval requests can include `requestReason`, but the default approval UI only renders `approval.prompt`. The converter preserves `requestReason` as an untyped extra field, so users still see a bare allow or deny decision without the reason supplied by the server.

Closes #7018.

## Root cause

The adapter forwards the provider approval object while filtering fields that its response channel cannot answer, but it does not translate the provider-specific reason field into the core prompt field consumed by renderers.

## Change

Use a string `requestReason` as the approval `prompt` when the producer did not provide a prompt. An explicit prompt keeps precedence. Preserve `requestReason` as well so existing custom renderers remain compatible.

This avoids adding a second public core field for the same displayed question.

## Verification

- `pnpm -C packages/ai-sdk exec vitest run src/converters/convertMessage.test.ts` — 34 tests passed
- `pnpm -C packages/ai-sdk build`
- `pnpm -C packages/ui exec vitest run src/components/react/assistant-ui/elements/tool-fallback.aui.test.tsx`
- `pnpm lint`
- `pnpm changesets:check`
- Converter coverage verifies fallback mapping, explicit-prompt precedence, and preservation of the provider field.

## Public surface

- Changes approval conversion behavior in `@assistant-ui/ai-sdk`.
- Adds a patch changeset for `@assistant-ui/ai-sdk`.
- No new exports, core fields, UI components, docs, or templates.