### PR TITLE
fix(react-generative-ui): bound A2UI array expansion

### DIFF
--- a/.changeset/calm-a2ui-arrays.md
+++ b/.changeset/calm-a2ui-arrays.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: bound A2UI data model array expansion

--- a/packages/react-generative-ui/src/a2ui/reducer.test.ts
+++ b/packages/react-generative-ui/src/a2ui/reducer.test.ts
@@ -82,6 +82,76 @@ describe("applyA2uiOperations", () => {
     });
   });
 
+  it("rejects array pointers that exceed the auto-vivification limit", () => {
+    const dataModel = { items: [] };
+    const state: A2uiState = new Map([
+      ["main", { components: new Map(), dataModel }],
+    ]);
+
+    const result = applyA2uiOperations(state, [
+      {
+        version: "v1.0",
+        updateDataModel: {
+          surfaceId: "main",
+          path: "/items/4294967294",
+          value: "unsafe",
+        },
+      },
+    ]);
+
+    expect(result.warnings).toEqual([
+      "Operation at index 0 has an invalid JSON Pointer path.",
+    ]);
+    expect(result.state.get("main")?.dataModel).toBe(dataModel);
+    expect(dataModel.items).toHaveLength(0);
+  });
+
+  it("allows bounded expansion, existing large indices, and appends", () => {
+    const items = new Array<string | undefined>(10_002);
+    items[10_001] = "existing";
+    const state: A2uiState = new Map([
+      ["main", { components: new Map(), dataModel: { bounded: [], items } }],
+    ]);
+
+    const result = applyA2uiOperations(state, [
+      {
+        version: "v1.0",
+        updateDataModel: {
+          surfaceId: "main",
+          path: "/bounded/10000",
+          value: "limit",
+        },
+      },
+      {
+        version: "v1.0",
+        updateDataModel: {
+          surfaceId: "main",
+          path: "/items/10001",
+          value: "updated",
+        },
+      },
+      {
+        version: "v1.0",
+        updateDataModel: {
+          surfaceId: "main",
+          path: "/items/-",
+          value: "appended",
+        },
+      },
+    ]);
+
+    const resultModel = result.state.get("main")!.dataModel as {
+      bounded: string[];
+      items: string[];
+    };
+    expect(result.warnings).toEqual([]);
+    expect(resultModel.bounded).toHaveLength(10_001);
+    expect(resultModel.bounded[10_000]).toBe("limit");
+    expect(resultModel.items).toHaveLength(10_003);
+    expect(resultModel.items[10_001]).toBe("updated");
+    expect(resultModel.items[10_002]).toBe("appended");
+  });
+
   it("clones the touched surface and component map", () => {
     const components = new Map<string, Record<string, unknown>>([
       ["root", { id: "root", component: "Divider" }],

--- a/packages/react-generative-ui/src/a2ui/reducer.test.ts
+++ b/packages/react-generative-ui/src/a2ui/reducer.test.ts
@@ -82,29 +82,32 @@ describe("applyA2uiOperations", () => {
     });
   });
 
-  it("rejects array pointers that exceed the auto-vivification limit", () => {
-    const dataModel = { items: [] };
-    const state: A2uiState = new Map([
-      ["main", { components: new Map(), dataModel }],
-    ]);
+  it.each(["10001", "4294967294"])(
+    "rejects array pointer index %s beyond the auto-vivification limit",
+    (index) => {
+      const dataModel = { items: [] };
+      const state: A2uiState = new Map([
+        ["main", { components: new Map(), dataModel }],
+      ]);
 
-    const result = applyA2uiOperations(state, [
-      {
-        version: "v1.0",
-        updateDataModel: {
-          surfaceId: "main",
-          path: "/items/4294967294",
-          value: "unsafe",
+      const result = applyA2uiOperations(state, [
+        {
+          version: "v1.0",
+          updateDataModel: {
+            surfaceId: "main",
+            path: `/items/${index}`,
+            value: "unsafe",
+          },
         },
-      },
-    ]);
+      ]);
 
-    expect(result.warnings).toEqual([
-      "Operation at index 0 has an invalid JSON Pointer path.",
-    ]);
-    expect(result.state.get("main")?.dataModel).toBe(dataModel);
-    expect(dataModel.items).toHaveLength(0);
-  });
+      expect(result.warnings).toEqual([
+        "Operation at index 0 has an invalid JSON Pointer path.",
+      ]);
+      expect(result.state.get("main")?.dataModel).toBe(dataModel);
+      expect(dataModel.items).toHaveLength(0);
+    },
+  );
 
   it("allows bounded expansion, existing large indices, and appends", () => {
     const items = new Array<string | undefined>(10_002);

--- a/packages/react-generative-ui/src/a2ui/reducer.ts
+++ b/packages/react-generative-ui/src/a2ui/reducer.ts
@@ -11,6 +11,9 @@ const OPERATION_KEYS = new Set([
   "updateDataModel",
   "deleteSurface",
 ]);
+// Mirrors the A2UI renderer limit to prevent unbounded sparse arrays.
+const MAX_AUTO_VIVIFY_ARRAY_INDEX = 10_000;
+const INVALID_POINTER = Symbol("invalidPointer");
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -115,11 +118,18 @@ const setAtPointer = (
 
     if (Array.isArray(current)) {
       if (segment !== "-" && !isArrayIndex(segment)) return current;
+      const targetIndex = segment === "-" ? current.length : Number(segment);
+      if (
+        segment !== "-" &&
+        targetIndex >= current.length &&
+        targetIndex > MAX_AUTO_VIVIFY_ARRAY_INDEX
+      ) {
+        return INVALID_POINTER;
+      }
+      const next = isLast ? value : update(current[targetIndex], index + 1);
+      if (next === INVALID_POINTER) return INVALID_POINTER;
       const clone = current.slice();
-      const targetIndex = segment === "-" ? clone.length : Number(segment);
-      clone[targetIndex] = isLast
-        ? value
-        : update(clone[targetIndex], index + 1);
+      clone[targetIndex] = next;
       return clone;
     }
 
@@ -127,7 +137,7 @@ const setAtPointer = (
       ? { ...current }
       : {};
     const child = clone[segment];
-    clone[segment] = isLast
+    const next = isLast
       ? value
       : update(
           child ??
@@ -137,10 +147,15 @@ const setAtPointer = (
               : {}),
           index + 1,
         );
+    if (next === INVALID_POINTER) return INVALID_POINTER;
+    clone[segment] = next;
     return clone;
   };
 
-  return { ok: true, value: update(model, 0) };
+  const result = update(model, 0);
+  return result === INVALID_POINTER
+    ? { ok: false, value: model }
+    : { ok: true, value: result };
 };
 
 const dataModelValue = (

--- a/packages/react-generative-ui/src/a2ui/reducer.ts
+++ b/packages/react-generative-ui/src/a2ui/reducer.ts
@@ -11,7 +11,7 @@ const OPERATION_KEYS = new Set([
   "updateDataModel",
   "deleteSurface",
 ]);
-// Mirrors the A2UI renderer limit to prevent unbounded sparse arrays.
+// This defensive ceiling is well above the renderer's displayed-item limit.
 const MAX_AUTO_VIVIFY_ARRAY_INDEX = 10_000;
 const INVALID_POINTER = Symbol("invalidPointer");
 


### PR DESCRIPTION
## Problem

An A2UI `updateDataModel` path can contain an arbitrarily large numeric array segment. On current main, updating `/items/4294967294` against an empty array succeeds and produces an array with `length === 4294967295`. Later cloning, rendering, or serialization can then exhaust resources or throw.

## Root cause

The JSON Pointer walker accepted every canonical decimal segment and assigned it directly as an array index without limiting automatic expansion.

## Change

Reject numeric array paths that would grow an array beyond a defensive auto-vivification limit of 10,000. Invalid status propagates through nested updates so the operation emits the existing invalid-pointer warning and preserves the original model. Updates to existing large indices and the normal `-` append form remain supported.

## Verification

- Confirmed the `/items/4294967294` regression test fails on the pre-fix reducer
- `pnpm --filter @assistant-ui/react-generative-ui test` (626 tests)
- `pnpm --filter @assistant-ui/react-generative-ui build`
- `pnpm exec oxlint packages/react-generative-ui/src/a2ui/reducer.ts packages/react-generative-ui/src/a2ui/reducer.test.ts`
- `pnpm changesets:check`

## Public surface

`@assistant-ui/react-generative-ui` behavior only. No exports or type signatures change. Includes a patch changeset; no documentation or template updates are required.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.pRShNtXJ8xPuHgck6e1El0M1ROicNRzc8VwKXuLObrcaVk62v0UUCSwVRww?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->