### PR TITLE
feat(ai-sdk): let hosts answer tool approvals through their own channel

### DIFF
--- a/.changeset/bright-tools-resume.md
+++ b/.changeset/bright-tools-resume.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+feat: allow hosts to handle tool approval responses

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -20,6 +20,7 @@ type AISDKRuntimeAdapter<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Externa
   cancelPendingToolCallsOnSend?: boolean | undefined;
   onResume?: ExternalStoreAdapter["onResume"];
   onResumeToolCall?: ExternalStoreAdapter["onResumeToolCall"];
+  onRespondToToolApproval?: ExternalStoreAdapter["onRespondToToolApproval"];
   joinStrategy?: JoinStrategy | undefined;
   messageRepository?: MessageFormatRepository<UI_MESSAGE>;
   unstable_onBranchChange?: ExternalStoreAdapter["unstable_onBranchChange"];
@@ -561,6 +562,7 @@ type ChatThreadOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<
   toCreateMessage?: CustomToCreateMessageFunction;
   onResume?: AISDKRuntimeAdapter["onResume"];
   onResumeToolCall?: AISDKRuntimeAdapter["onResumeToolCall"];
+  onRespondToToolApproval?: AISDKRuntimeAdapter["onRespondToToolApproval"];
   onResumeError?: ((error: unknown) => void) | undefined;
   joinStrategy?: AISDKRuntimeAdapter["joinStrategy"];
   messageRepository?: AISDKRuntimeAdapter<UI_MESSAGE>["messageRepository"];

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -20,6 +20,7 @@ type AISDKRuntimeAdapter<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Externa
   cancelPendingToolCallsOnSend?: boolean | undefined;
   onResume?: ExternalStoreAdapter["onResume"];
   onResumeToolCall?: ExternalStoreAdapter["onResumeToolCall"];
+  onRespondToToolApproval?: ExternalStoreAdapter["onRespondToToolApproval"];
   joinStrategy?: JoinStrategy | undefined;
   messageRepository?: MessageFormatRepository<UI_MESSAGE>;
   unstable_onBranchChange?: ExternalStoreAdapter["unstable_onBranchChange"];
@@ -561,6 +562,7 @@ type ChatThreadOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<
   toCreateMessage?: CustomToCreateMessageFunction;
   onResume?: AISDKRuntimeAdapter["onResume"];
   onResumeToolCall?: AISDKRuntimeAdapter["onResumeToolCall"];
+  onRespondToToolApproval?: AISDKRuntimeAdapter["onRespondToToolApproval"];
   onResumeError?: ((error: unknown) => void) | undefined;
   joinStrategy?: AISDKRuntimeAdapter["joinStrategy"];
   messageRepository?: AISDKRuntimeAdapter<UI_MESSAGE>["messageRepository"];

--- a/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
@@ -662,6 +662,20 @@ const runtime = useChatRuntime({
 
 When omitted, `resumeRun` throws `"Runtime does not support resuming runs."`. For streams that should survive a page reload without a custom channel, use the built-in transport-level path instead: see [Resumable streams](/docs/guides/resumable-streams), which reconnects automatically on mount and reports failures via `onResumeError`.
 
+### onRespondToToolApproval
+
+Provide this when your backend owns the paused tool call and needs to resume it through its own endpoint:
+
+```tsx
+const runtime = useChatRuntime({
+  onRespondToToolApproval: async (response) => {
+    await resumeToolApproval(response);
+  },
+});
+```
+
+The callback receives the full normalized response, including `approvalId`, `approved`, and optional `optionId`, `text`, and `reason` fields. When omitted, allow or deny responses use the AI SDK `addToolApprovalResponse` helper. Select and text approval controls are exposed only when a custom handler is present because the built-in channel cannot preserve those answers.
+
 ### messageRepository
 
 Import a branch-aware AI SDK message tree once, and only when `useChat` is empty. After that seed, live updates come only from `useChat`. Clearing the chat or passing a new object identity does not reload the tree. Persisted threads that already go through `adapters.history` do not need this.
@@ -691,7 +705,7 @@ const runtime = useAISDKRuntime(chat);
 
 `useAISDKRuntime` does not provide `cloud` or the higher-level adapter slots; those are part of `useChatRuntime`. If you need both your own `useChat` access AND cloud thread support, you generally want `useChatRuntime` and to read the chat state through assistant-ui hooks instead.
 
-`useAISDKRuntime` accepts `joinStrategy`, `onResume`, `messageRepository`, and `unstable_onBranchChange` (see [Runtime options](#runtime-options)) plus one option of its own, `cancelPendingToolCallsOnSend`:
+`useAISDKRuntime` accepts `joinStrategy`, `onResume`, `onRespondToToolApproval`, `messageRepository`, and `unstable_onBranchChange` (see [Runtime options](#runtime-options)) plus one option of its own, `cancelPendingToolCallsOnSend`:
 
 ```tsx
 const runtime = useAISDKRuntime(chat, {

--- a/packages/ai-sdk/src/converters/convertMessage.test.ts
+++ b/packages/ai-sdk/src/converters/convertMessage.test.ts
@@ -488,7 +488,21 @@ describe("AISDKMessageConverter", () => {
                 id: "approval-1",
                 display: "select",
                 allowFreeform: true,
-                options: [{ id: "once", kind: "allow-once" }],
+                options: [
+                  {
+                    id: "once",
+                    kind: "allow-once",
+                    label: "Only once",
+                    grants: ["repository", 42],
+                    confirm: {
+                      title: "Confirm access",
+                      description: { invalid: true },
+                    },
+                  },
+                  "invalid",
+                  { id: 1, kind: "allow-always" },
+                  { id: "always", kind: 2 },
+                ],
                 optionId: "once",
                 text: "an answer",
               },
@@ -507,7 +521,15 @@ describe("AISDKMessageConverter", () => {
       id: "approval-1",
       display: "select",
       allowFreeform: true,
-      options: [{ id: "once", kind: "allow-once" }],
+      options: [
+        {
+          id: "once",
+          kind: "allow-once",
+          label: "Only once",
+          grants: ["repository"],
+          confirm: { title: "Confirm access" },
+        },
+      ],
       optionId: "once",
       text: "an answer",
     });

--- a/packages/ai-sdk/src/converters/convertMessage.test.ts
+++ b/packages/ai-sdk/src/converters/convertMessage.test.ts
@@ -472,6 +472,47 @@ describe("AISDKMessageConverter", () => {
     });
   });
 
+  it("preserves rich approval fields for a custom response channel", () => {
+    const converted = AISDKMessageConverter.toThreadMessages(
+      [
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-deploy",
+              toolCallId: "tc-1",
+              state: "approval-responded",
+              input: {},
+              approval: {
+                id: "approval-1",
+                display: "select",
+                allowFreeform: true,
+                options: [{ id: "once", kind: "allow-once" }],
+                optionId: "once",
+                text: "an answer",
+              },
+            },
+          ],
+        } as any,
+      ],
+      false,
+      { supportsRichToolApprovalResponses: true },
+    );
+
+    const toolCall = converted[0]?.content.find(
+      (part): part is any => part.type === "tool-call",
+    );
+    expect(toolCall?.approval).toEqual({
+      id: "approval-1",
+      display: "select",
+      allowFreeform: true,
+      options: [{ id: "once", kind: "allow-once" }],
+      optionId: "once",
+      text: "an answer",
+    });
+  });
+
   it("drops a resolution the core contract does not declare", () => {
     const converted = AISDKMessageConverter.toThreadMessages([
       {

--- a/packages/ai-sdk/src/converters/convertMessage.ts
+++ b/packages/ai-sdk/src/converters/convertMessage.ts
@@ -60,6 +60,7 @@ export type AISDKMessageConverterMetadata =
     toolArgsKeyOrderCache?: Map<string, Map<string, string[]>>;
     toolLastInputCache?: Map<string, ReadonlyJSONObject>;
     mcpAppMetadataCache?: Map<string, McpAppMetadata>;
+    supportsRichToolApprovalResponses?: boolean;
     /** Id of the currently-streaming message, flagged optimistic (#4037). */
     optimisticMessageId?: string | undefined;
   };
@@ -157,6 +158,7 @@ function getToolApprovalAndInterrupt(
     approval?: Record<string, unknown> | undefined;
   },
   toolStatus: { type: string; payload?: unknown } | undefined,
+  supportsRichToolApprovalResponses: boolean,
 ): {
   approval?: NonNullable<ToolCallMessagePart["approval"]>;
   interrupt?: NonNullable<ToolCallMessagePart["interrupt"]>;
@@ -188,6 +190,15 @@ function getToolApprovalAndInterrupt(
           ...(typeof approved === "boolean" && { approved }),
           ...(typeof reason === "string" && { reason }),
           ...(isAutomatic === true && { isAutomatic: true }),
+          ...(supportsRichToolApprovalResponses && {
+            ...((display === "decision" ||
+              display === "select" ||
+              display === "text") && { display }),
+            ...(typeof allowFreeform === "boolean" && { allowFreeform }),
+            ...(Array.isArray(options) && { options }),
+            ...(typeof optionId === "string" && { optionId }),
+            ...(typeof text === "string" && { text }),
+          }),
           ...((resolution === "cancelled" || resolution === "expired") && {
             resolution,
           }),
@@ -342,7 +353,11 @@ function convertParts(
                   part.callProviderMetadata as PartProviderMetadata,
               }
             : undefined),
-          ...getToolApprovalAndInterrupt(part, toolStatus),
+          ...getToolApprovalAndInterrupt(
+            part,
+            toolStatus,
+            metadata.supportsRichToolApprovalResponses === true,
+          ),
         } satisfies ToolCallMessagePart;
       }
 

--- a/packages/ai-sdk/src/converters/convertMessage.ts
+++ b/packages/ai-sdk/src/converters/convertMessage.ts
@@ -12,6 +12,7 @@ import {
 import {
   isMcpAppUri,
   type ReasoningMessagePart,
+  type ToolApprovalOption,
   type ToolCallMessagePart,
   type TextMessagePart,
   type DataMessagePart,
@@ -153,6 +154,55 @@ function extractMcpAppMetadata(
   return out;
 }
 
+const normalizeToolApprovalOptions = (
+  options: unknown,
+): readonly ToolApprovalOption[] | undefined => {
+  if (!Array.isArray(options)) return undefined;
+
+  return options.flatMap<ToolApprovalOption>((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+    const option = value as Record<string, unknown>;
+    if (typeof option.id !== "string" || typeof option.kind !== "string")
+      return [];
+
+    const confirm = option.confirm;
+    const confirmDetails =
+      confirm && typeof confirm === "object" && !Array.isArray(confirm)
+        ? (confirm as Record<string, unknown>)
+        : undefined;
+
+    return [
+      {
+        id: option.id,
+        kind: option.kind,
+        ...(typeof option.label === "string" && { label: option.label }),
+        ...(typeof option.description === "string" && {
+          description: option.description,
+        }),
+        ...(Array.isArray(option.grants) && {
+          grants: option.grants.filter(
+            (grant): grant is string => typeof grant === "string",
+          ),
+        }),
+        ...(typeof confirm === "boolean"
+          ? { confirm }
+          : confirmDetails
+            ? {
+                confirm: {
+                  ...(typeof confirmDetails.title === "string" && {
+                    title: confirmDetails.title,
+                  }),
+                  ...(typeof confirmDetails.description === "string" && {
+                    description: confirmDetails.description,
+                  }),
+                },
+              }
+            : {}),
+      },
+    ];
+  });
+};
+
 function getToolApprovalAndInterrupt(
   part: {
     approval?: Record<string, unknown> | undefined;
@@ -164,9 +214,9 @@ function getToolApprovalAndInterrupt(
   interrupt?: NonNullable<ToolCallMessagePart["interrupt"]>;
 } {
   if (part.approval) {
-    // The AI SDK sends only id, approved and reason back to the server, so a
-    // request shape promising any other answer would render controls whose
-    // response cannot travel.
+    // The built-in AI SDK channel sends only id, approved and reason back to
+    // the server, so a request shape promising any other answer would render
+    // controls whose response cannot travel.
     const {
       id,
       prompt,
@@ -181,6 +231,7 @@ function getToolApprovalAndInterrupt(
       text,
       ...additionalApprovalFields
     } = part.approval;
+    const normalizedOptions = normalizeToolApprovalOptions(options);
     if (typeof id === "string")
       return {
         approval: {
@@ -195,7 +246,7 @@ function getToolApprovalAndInterrupt(
               display === "select" ||
               display === "text") && { display }),
             ...(typeof allowFreeform === "boolean" && { allowFreeform }),
-            ...(Array.isArray(options) && { options }),
+            ...(normalizedOptions && { options: normalizedOptions }),
             ...(typeof optionId === "string" && { optionId }),
             ...(typeof text === "string" && { text }),
           }),

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.approval.test.tsx
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.approval.test.tsx
@@ -66,4 +66,96 @@ describe("useAISDKRuntime tool approvals", () => {
       options: { metadata: undefined },
     });
   });
+
+  it("prefers a custom approval handler and forwards the complete response", () => {
+    const approvalPromise = Promise.resolve();
+    const onRespondToToolApproval = vi.fn(() => approvalPromise);
+    const addToolApprovalResponse = vi.fn();
+    const chat = {
+      id: "chat-1",
+      status: "ready",
+      error: undefined,
+      messages: [],
+      setMessages: vi.fn(),
+      sendMessage: vi.fn(),
+      regenerate: vi.fn(),
+      addToolOutput: vi.fn(),
+      addToolApprovalResponse,
+      stop: vi.fn(),
+    };
+
+    renderHook(() =>
+      useAISDKRuntime(chat as never, { onRespondToToolApproval }),
+    );
+
+    const response = {
+      approvalId: "approval-1",
+      approved: true,
+      optionId: "allow-session",
+      text: "Only for this environment",
+      reason: "Approved by operator",
+    };
+    const result = mocks.adapter?.onRespondToToolApproval?.(response);
+
+    expect(result).toBe(approvalPromise);
+    expect(onRespondToToolApproval).toHaveBeenCalledWith(response);
+    expect(addToolApprovalResponse).not.toHaveBeenCalled();
+  });
+
+  it("updates the rendered approval shape with the response channel", () => {
+    const onRespondToToolApproval = vi.fn();
+    const chat = {
+      id: "chat-1",
+      status: "ready",
+      error: undefined,
+      messages: [
+        {
+          id: "message-1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-deploy",
+              toolCallId: "tool-1",
+              state: "approval-requested",
+              input: {},
+              approval: {
+                id: "approval-1",
+                display: "select",
+                options: [{ id: "allow-session", kind: "allow-once" }],
+              },
+            },
+          ],
+        },
+      ],
+      setMessages: vi.fn(),
+      sendMessage: vi.fn(),
+      regenerate: vi.fn(),
+      addToolOutput: vi.fn(),
+      addToolApprovalResponse: vi.fn(),
+      stop: vi.fn(),
+    };
+
+    const { rerender } = renderHook(
+      ({ useCustomHandler }: { useCustomHandler: boolean }) =>
+        useAISDKRuntime(chat as never, {
+          ...(useCustomHandler && { onRespondToToolApproval }),
+        }),
+      { initialProps: { useCustomHandler: false } },
+    );
+
+    const getApproval = () =>
+      mocks.adapter?.messages?.[0]?.content.find(
+        (part) => part.type === "tool-call",
+      )?.approval;
+
+    expect(getApproval()).toEqual({ id: "approval-1" });
+
+    rerender({ useCustomHandler: true });
+
+    expect(getApproval()).toEqual({
+      id: "approval-1",
+      display: "select",
+      options: [{ id: "allow-session", kind: "allow-once" }],
+    });
+  });
 });

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -51,7 +51,10 @@ import { sliceMessagesUntil } from "../utils/sliceMessagesUntil";
 import { toCreateMessage } from "../converters/toCreateMessage";
 import { vercelAttachmentAdapter } from "../adapters/vercelAttachmentAdapter";
 import { getVercelAIMessages } from "../utils/getVercelAIMessages";
-import { AISDKMessageConverter } from "../converters/convertMessage";
+import {
+  AISDKMessageConverter,
+  type AISDKMessageConverterMetadata,
+} from "../converters/convertMessage";
 import { wrapModelContentEnvelope } from "../converters/modelContentEnvelope";
 import {
   type AISDKStorageFormat,
@@ -287,7 +290,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     (sourceMessages: UI_MESSAGE[]) =>
       AISDKMessageConverter.toThreadMessages(sourceMessages, false, {
         supportsRichToolApprovalResponses,
-      }),
+      } as AISDKMessageConverterMetadata),
     [supportsRichToolApprovalResponses],
   );
 
@@ -326,7 +329,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     isRunning,
     messages: chatHelpers.messages,
     joinStrategy,
-    metadata: useMemo(
+    metadata: useMemo<AISDKMessageConverterMetadata>(
       () => ({
         toolStatuses,
         messageTiming,

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -115,6 +115,14 @@ export type AISDKRuntimeAdapter<UI_MESSAGE extends UIMessage = UIMessage> =
      */
     onResumeToolCall?: ExternalStoreAdapter["onResumeToolCall"];
     /**
+     * Called when the user answers a tool approval request.
+     *
+     * When omitted, responses are sent through the AI SDK's
+     * `addToolApprovalResponse`. Custom handlers receive the complete normalized
+     * response, including option and free-form answers.
+     */
+    onRespondToToolApproval?: ExternalStoreAdapter["onRespondToToolApproval"];
+    /**
      * How consecutive assistant messages are rendered.
      *
      * `"concat-content"` (the default) merges them into a single thread message.
@@ -229,6 +237,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     cancelPendingToolCallsOnSend = true,
     onResume,
     onResumeToolCall,
+    onRespondToToolApproval: customOnRespondToToolApproval,
     joinStrategy,
     messageRepository,
     unstable_onBranchChange,
@@ -271,6 +280,16 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     cancelledMessages?.chatId === chatHelpers.id
       ? cancelledMessages.ids
       : NO_CANCELLED_MESSAGE_IDS;
+  const supportsRichToolApprovalResponses =
+    customOnRespondToToolApproval != null;
+
+  const toThreadMessages = useCallback(
+    (sourceMessages: UI_MESSAGE[]) =>
+      AISDKMessageConverter.toThreadMessages(sourceMessages, false, {
+        supportsRichToolApprovalResponses,
+      }),
+    [supportsRichToolApprovalResponses],
+  );
 
   const retractCancellation = useCallback(
     (chatId: string, messageId: string) => {
@@ -314,6 +333,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         toolArgsKeyOrderCache: toolArgsKeyOrderCacheRef.current,
         toolLastInputCache: toolLastInputCacheRef.current,
         mcpAppMetadataCache: mcpAppMetadataCacheRef.current,
+        supportsRichToolApprovalResponses,
         ...(optimisticMessageId && { optimisticMessageId }),
         ...(chatHelpers.error && { error: chatHelpers.error.message }),
         ...(cancelledMessageIds.size > 0 && { cancelledMessageIds }),
@@ -324,6 +344,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         optimisticMessageId,
         chatHelpers.error,
         cancelledMessageIds,
+        supportsRichToolApprovalResponses,
       ],
     ),
   });
@@ -331,13 +352,11 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const exportedMessageRepository = useMemo(() => {
     if (!messageRepository) return undefined;
     const converted = toExportedMessageRepository(
-      AISDKMessageConverter.toThreadMessages as (
-        messages: UI_MESSAGE[],
-      ) => ThreadMessage[],
+      toThreadMessages,
       messageRepository,
     );
     return converted.messages.length > 0 ? converted : undefined;
-  }, [messageRepository]);
+  }, [messageRepository, toThreadMessages]);
 
   const generatedSuggestions = useGeneratedSuggestions(
     suggestionAdapter,
@@ -354,9 +373,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const { isLoading, deleteMessage: deleteHistoryMessage } = useExternalHistory(
     runtimeRef,
     adapters?.history ?? contextAdapters?.history,
-    AISDKMessageConverter.toThreadMessages as (
-      messages: UI_MESSAGE[],
-    ) => ThreadMessage[],
+    toThreadMessages,
     aiSDKV6FormatAdapter as MessageFormatAdapter<
       UI_MESSAGE,
       AISDKStorageFormat
@@ -485,10 +502,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     },
     onLoadExternalState: (repo: MessageFormatRepository<UI_MESSAGE>) => {
       // Convert MessageFormatRepository to ExportedMessageRepository
-      const exportedRepo = toExportedMessageRepository(
-        AISDKMessageConverter.toThreadMessages,
-        repo,
-      );
+      const exportedRepo = toExportedMessageRepository(toThreadMessages, repo);
 
       // Import into the thread's MessageRepository
       runtimeRef.current.thread.import(exportedRepo);
@@ -618,15 +632,17 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         );
       }
     },
-    onRespondToToolApproval: ({ approvalId, approved, reason }) =>
-      Promise.resolve(
-        chatHelpers.addToolApprovalResponse({
-          id: approvalId,
-          approved,
-          ...(reason != null && { reason }),
-          options: { metadata: lastRunConfigRef.current },
-        }),
-      ),
+    onRespondToToolApproval:
+      customOnRespondToToolApproval ??
+      (({ approvalId, approved, reason }) =>
+        Promise.resolve(
+          chatHelpers.addToolApprovalResponse({
+            id: approvalId,
+            approved,
+            ...(reason != null && { reason }),
+            options: { metadata: lastRunConfigRef.current },
+          }),
+        )),
     ...pickExternalStoreSharedOptions(adapter),
     ...(adapter.unstable_messageRepositoryInstance && {
       unstable_messageRepositoryInstance:

--- a/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
@@ -112,6 +112,24 @@ describe("useChatRuntime", () => {
     expect(mocks.useChat.mock.calls[1]?.[0]).not.toHaveProperty("throttle");
   });
 
+  it("forwards a custom approval handler to the runtime only", () => {
+    const onRespondToToolApproval = vi.fn();
+    mocks.useChat.mockReturnValue({
+      resumeStream: vi.fn(),
+      status: "ready",
+    });
+
+    renderHook(() => useChatRuntime({ onRespondToToolApproval }));
+
+    expect(mocks.useAISDKRuntime).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ onRespondToToolApproval }),
+    );
+    expect(mocks.useChat.mock.calls[0]?.[0]).not.toHaveProperty(
+      "onRespondToToolApproval",
+    );
+  });
+
   it("waits for external history to load before resuming a stream", async () => {
     mocks.state.isLoadingHistory = true;
     const resumeStream = vi.fn().mockResolvedValue(undefined);

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -38,6 +38,7 @@ export type ChatThreadOptions<UI_MESSAGE extends UIMessage = UIMessage> =
       toCreateMessage?: CustomToCreateMessageFunction;
       onResume?: AISDKRuntimeAdapter["onResume"];
       onResumeToolCall?: AISDKRuntimeAdapter["onResumeToolCall"];
+      onRespondToToolApproval?: AISDKRuntimeAdapter["onRespondToToolApproval"];
       /**
        * Called when an automatic resumable stream reconnect fails. Use this to
        * surface a toast, report telemetry, or mark the thread as needing a
@@ -140,6 +141,7 @@ export const splitChatThreadOptions = <UI_MESSAGE extends UIMessage>(
     suggestions: _suggestions,
     onResume,
     onResumeToolCall,
+    onRespondToToolApproval,
     onResumeError,
     joinStrategy,
     messageRepository,
@@ -158,6 +160,7 @@ export const splitChatThreadOptions = <UI_MESSAGE extends UIMessage>(
     toCreateMessage,
     onResume,
     onResumeToolCall,
+    onRespondToToolApproval,
     onResumeError,
     joinStrategy,
     messageRepository,
@@ -177,6 +180,7 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     toCreateMessage,
     onResume,
     onResumeToolCall,
+    onRespondToToolApproval,
     onResumeError,
     joinStrategy,
     messageRepository,
@@ -215,6 +219,7 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(toCreateMessage && { toCreateMessage }),
     ...(onResume && { onResume }),
     ...(onResumeToolCall && { onResumeToolCall }),
+    ...(onRespondToToolApproval && { onRespondToToolApproval }),
     ...(joinStrategy && { joinStrategy }),
     ...(messageRepository && { messageRepository }),
     ...(messageRepositoryInstance && {

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -1,8 +1,8 @@
 {
   "@assistant-ui/ai-sdk": {
     ".": {
-      "min": 37044,
-      "gzip": 13336
+      "min": 38320,
+      "gzip": 13720
     }
   },
   "@assistant-ui/cloud-ai-sdk": {


### PR DESCRIPTION
closes #7017

## Problem

`useAISDKRuntime` answers every tool approval through `addToolApprovalResponse`. a host whose backend owns the paused tool call (a Mastra suspend, for example) cannot resume it through its own endpoint, and the AI SDK channel drops `optionId` and `text`.

## Root cause

the runtime installs its built-in `onRespondToToolApproval` unconditionally, and the converter withholds the rich request fields for every approval because that channel cannot carry their answers.

## Change

`AISDKRuntimeAdapter` and `useChatRuntime` accept `onRespondToToolApproval(response, { toolCallId, toolName, respondViaAISDK })`.

- the handler runs for every approval in the thread with the full response. requests the host does not own go to `respondViaAISDK`, the built-in path, so AI SDK `needsApproval` tools keep working beside host-owned pauses. under `useChatRuntime` the host never holds the `Chat`, so this delegate is its only way back.
- the answer applies to the approval as soon as the handler starts, and a second response to the same request is refused while it is held. it lives in the runtime as an overlay keyed by approval id that the converter applies, the same way `cancelledMessageIds` does, and it stays applied across a chat switch on the same runtime, and is never written into the `useChat` messages: an `approval-responded` part there would satisfy `lastAssistantMessageIsCompleteWithApprovalResponses`, so the next `addToolOutput` or run end would post the answer to the chat route and resume the tool a second time.
- a handler that throws removes the answer, so the request reopens, and `respondToApproval` rejects with the handler's error.
- `respondViaAISDK` calls `addToolApprovalResponse` and then drops the overlay, also when that call fails, so the AI SDK records and continues the run exactly as without the option, including leaving a request in an older message unanswered.
- while a handler is set, the converter forwards `display`, `allowFreeform`, `options`, `optionId` and `text`, and the option normalizer only runs then.

this replaces the first version of this PR, where the handler took over the whole thread, received no tool call identity, and left the approval unanswered after the handler resolved, so the controls came back on remount.

the other runtimes with a built-in approval handler keep it without an override: react-ag-ui, react-google-adk, react-opencode, react-pi and eve each answer through the protocol that paused the call (AG-UI resume, ADK confirmation reply, OpenCode permission reply, the pi controller, eve `respond`). the AI SDK runtime is the one whose built-in answer is a generic chat request, which a pause owned by another backend never sees.

### Limits

- an AI SDK stream cannot produce `display` or `options`: `approvalDescriptor` arrives as `approval.descriptor` and is passed through unchanged. tracked in #7644, which depends on #6724.
- the applied answer lasts as long as the runtime: a reload, or a runtime mounted again over the same `Chat` (an in-memory `AISDKThreads` switch away and back, a caller-owned `Chat` behind a conditional render), shows the request open until the chat records its resolution, so the docs tell hosts to bring the resumed run back into the chat and refuse a second resume. keeping the answer with the `Chat` is tracked in #7646.

## Verification

- `packages/ai-sdk`: 305 passed across 27 files; the standalone and React Compiler projects pass; `tsc --noEmit` and `tsc --noEmit -p tsconfig.test.json` report 0 errors
- new integration tests drive a real `useChat` (`ai@7.0.101`, `@ai-sdk/react@4.0.104`) with `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses`: a host answer applies without a chat request, a host answer stays out of the automatic send when another tool call in the step completes, a throwing handler reopens the request, the answer holds across a run the handler continues on the chat, two concurrent answers deliver one decision, a delegated request continues the run, and a delegated request in an older message stays as the AI SDK leaves it
- unit tests: the answer survives the runtime switching chats and back (and still refuses a second response), a failed hand-back that the handler swallows reopens the request, and the handler receives the tool call identity and the AI SDK delegate
- the automatic send test fails on a version that writes the answer into the chat as `approval-responded` (the thread is posted a second time), the approval tests fail 10 of 13 on the first head of this PR, and the converter overlay test fails without the overlay
- `oxfmt --check`, `oxlint`, the api-surface check, the size check, `changesets:check` and the changeset semver check pass

## Public surface

- `@assistant-ui/ai-sdk` patch changeset (`@assistant-ui/react-ai-sdk` by cascade): `onRespondToToolApproval` on `AISDKRuntimeAdapter` and `useChatRuntime` options
- docs: `runtimes/ai-sdk/v7.mdx` `onRespondToToolApproval` section
- api-surface snapshots for both packages, and the ai-sdk size budget

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.KjvQr4bLbzcARhzVJV4ViERBCy-mjTonGUPdzFU7N6KfhGScm44HSgFkvNc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->


