### PR TITLE
fix(ui): prevent file icon static-components lint failure

### DIFF
--- a/packages/ui/src/components/react/assistant-ui/elements/file.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/file.tsx
@@ -130,6 +130,7 @@ function FileIconDisplay({
       className={cn("text-muted-foreground shrink-0", className)}
       {...props}
     >
+      {/* eslint-disable-next-line react-hooks/static-components -- The helper only selects module-level icon components. */}
       {children ?? <IconComponent className="size-5" />}
     </span>
   );


### PR DESCRIPTION
## Problem

The registry-copied `file.tsx` fails `eslint-plugin-react-hooks@7.1.1` with `react-hooks/static-components`. This is the remaining half of #6362 after #6925 fixed the `ReasoningRoot` finding.

The direction follows the [maintainer closing note on #6363](https://github.com/assistant-ui/assistant-ui/pull/6363#issuecomment-5558587296): the MIME helper selects stable module-level icons, so restructuring the component would only work around a false positive.

## Root cause

The rule cannot prove that `getMimeTypeIcon()` returns an imported module-level component, so it reports `<IconComponent />` as a component created during render even though its identity is stable.

## Change

Add a narrow, documented suppression directly at the flagged JSX expression. MIME selection, rendering behavior, and the exported helper remain unchanged.

## Verification

- Confirmed the official plugin reports one `react-hooks/static-components` error before the change and none afterward.
- `pnpm --filter @assistant-ui/ui... build`
- `pnpm --filter @assistant-ui/ui test` (20 files; 728 passed, 16 skipped)
- `pnpm sync-templates`
- `pnpm exec oxfmt --check packages/ui/src/components/react/assistant-ui/elements/file.tsx`
- `pnpm exec oxlint packages/ui/src/components/react/assistant-ui/elements/file.tsx`

## Public surface

The canonical registry source in private `@assistant-ui/ui` is affected. No exports or runtime behavior change, and no changeset is required.

Fixes #6362

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.SU5b5ZVG6k1_KtmNtMHoB4JCfdpFc_ZSsa6T2z3DbfDuyC3A4lEc8BLA6bc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->