### PR TITLE
docs(tw-shimmer): align reference with shipped CSS

### DIFF
--- a/.changeset/calm-shimmers-align.md
+++ b/.changeset/calm-shimmers-align.md
@@ -1,0 +1,5 @@
+---
+"tw-shimmer": patch
+---
+
+docs: align the documented utilities and defaults with the shipped CSS

--- a/apps/docs/content/docs/utilities/tw-shimmer.mdx
+++ b/apps/docs/content/docs/utilities/tw-shimmer.mdx
@@ -93,7 +93,7 @@ Background shimmer for skeleton loaders. Applies a gradient animation over the e
 
 #### `shimmer-container`
 
-CSS-only auto-sizing helper using container queries. Sets `container-type: inline-size`, uses the container width as the animation track width, and accounts for the container height when sizing angled gradients.
+CSS-only auto-sizing helper using container queries. It uses the container width as the animation track width. Because it establishes inline-size containment only, the height term for angled gradients uses the nearest block-size query container when one exists and otherwise falls back to the small viewport height; half the container width and `200px` remain its minimums.
 
 ```html
 <div class="shimmer-container">

--- a/apps/docs/content/docs/utilities/tw-shimmer.mdx
+++ b/apps/docs/content/docs/utilities/tw-shimmer.mdx
@@ -8,7 +8,7 @@ platforms: ["react"]
 
 - **CSS-only** — No JavaScript runtime, pure Tailwind utilities
 - **Text + Background** — Shimmer text or skeleton placeholders
-- **Auto-sizing** — CSS container queries for automatic width detection
+- **Auto-sizing** — CSS container queries size the animation track automatically
 - **Customizable** — Speed, spread, angle, color, and timing
 
 See the [interactive demo](/tw-shimmer) for live examples.
@@ -62,11 +62,11 @@ Add to your CSS:
 
 ```html
 <div class="shimmer-container flex gap-3">
-  <div class="shimmer-bg bg-muted size-12 rounded-full" />
+  <div class="shimmer shimmer-bg bg-muted size-12 rounded-full" />
   <div class="flex-1 space-y-2">
-    <div class="shimmer-bg bg-muted h-4 w-1/4 rounded" />
-    <div class="shimmer-bg bg-muted h-4 w-full rounded" />
-    <div class="shimmer-bg bg-muted h-4 w-4/5 rounded" />
+    <div class="shimmer shimmer-bg bg-muted h-4 w-1/4 rounded" />
+    <div class="shimmer shimmer-bg bg-muted h-4 w-full rounded" />
+    <div class="shimmer shimmer-bg bg-muted h-4 w-4/5 rounded" />
   </div>
 </div>
 ```
@@ -93,11 +93,11 @@ Background shimmer for skeleton loaders. Applies a gradient animation over the e
 
 #### `shimmer-container`
 
-CSS-only auto-sizing helper using container queries. Sets `container-type: inline-size` and automatically derives speed and spread from the container width.
+CSS-only auto-sizing helper using container queries. Sets `container-type: inline-size`, uses the container width as the animation track width, and accounts for the container height when sizing angled gradients.
 
 ```html
 <div class="shimmer-container">
-  <div class="shimmer-bg bg-muted h-4 w-full rounded" />
+  <div class="shimmer shimmer-bg bg-muted h-4 w-full rounded" />
 </div>
 ```
 
@@ -109,15 +109,14 @@ CSS-only auto-sizing helper using container queries. Sets `container-type: inlin
 
 | Utility                     | Default (text) | Default (bg) | Description                        |
 | --------------------------- | -------------- | ------------ | ---------------------------------- |
-| `shimmer-speed-{n}`         | `200`          | `1000`       | Animation speed in px/s            |
-| `--shimmer-track-width`     | `200px`        | `200px`      | Track width for timing             |
-| `shimmer-spread-{n}`        | `6ch`          | —            | Text shimmer highlight width       |
-| `shimmer-bg-spread-{n}`     | —              | `480px`      | Background shimmer highlight width |
-| `shimmer-color-{color}`     | auto           | auto         | Highlight color (Tailwind palette) |
-| `shimmer-angle-{deg}`       | `90`           | `90`         | Sweep direction in degrees         |
-| `shimmer-duration-{ms}`     | auto           | auto         | Fixed animation duration           |
-| `shimmer-repeat-delay-{ms}` | `1000`         | `1000`       | Pause between cycles               |
-| `shimmer-invert`            | —              | —            | Use a contrasting highlight color  |
+| `shimmer-speed-{n}`         | `200`                | `1000`  | Animation speed in px/s            |
+| `--shimmer-track-width`     | `200px`              | `200px` | Track width for timing             |
+| `shimmer-spread-{n}`        | `calc(4ch + 80px)`   | `480px` | Shimmer highlight width            |
+| `shimmer-color-{color}`     | auto                 | auto    | Highlight color (Tailwind palette) |
+| `shimmer-angle-{deg}`       | `15`                 | `15`    | Sweep angle in degrees             |
+| `shimmer-duration-{ms}`     | auto                 | auto    | Fixed animation duration           |
+| `shimmer-repeat-delay-{ms}` | `100`                | `20`    | Pause between cycles               |
+| `shimmer-invert`            | —                    | —       | Use a contrasting highlight color  |
 
 All utilities are **inheritable** — set on a parent to affect all shimmer children.
 
@@ -145,11 +144,11 @@ Use any Tailwind color with optional opacity:
 
 ### Angle
 
-Control the sweep direction. Default is `90deg` (vertical sweep).
+Control the sweep angle. The default is `15deg`.
 
 ```html
 <div class="shimmer-container shimmer-angle-15">
-  <div class="shimmer-bg bg-muted h-4 w-full rounded" />
+  <div class="shimmer shimmer-bg bg-muted h-4 w-full rounded" />
 </div>
 ```
 
@@ -159,21 +158,21 @@ Control the sweep direction. Default is `90deg` (vertical sweep).
 
 ### Position Hints (Angled Shimmer)
 
-For angled shimmers, use `shimmer-x-{n}` and `shimmer-y-{n}` to sync elements:
+For angled shimmers, set the unitless `--shimmer-x` and `--shimmer-y` position hints to sync elements:
 
 ```html
 <div class="shimmer-container shimmer-angle-15 flex gap-3">
-  <div class="shimmer-bg shimmer-x-20 shimmer-y-20 bg-muted size-12 rounded-full" />
+  <div class="shimmer shimmer-bg [--shimmer-x:20] [--shimmer-y:20] bg-muted size-12 rounded-full" />
   <div class="flex-1 space-y-2">
-    <div class="shimmer-bg shimmer-x-52 shimmer-y-0 bg-muted h-4 w-24 rounded" />
-    <div class="shimmer-bg shimmer-x-52 shimmer-y-24 bg-muted h-4 w-full rounded" />
+    <div class="shimmer shimmer-bg [--shimmer-x:52] [--shimmer-y:0] bg-muted h-4 w-24 rounded" />
+    <div class="shimmer shimmer-bg [--shimmer-x:52] [--shimmer-y:24] bg-muted h-4 w-full rounded" />
   </div>
 </div>
 ```
 
 ### Repeat Delay
 
-Control the pause between animation cycles:
+Control the pause between animation cycles. The default is derived from speed: `100ms` for text and `20ms` for backgrounds.
 
 ```html
 <!-- Continuous shimmer, no pause -->
@@ -195,6 +194,7 @@ All values can be set via CSS variables for dynamic control:
 | ------------------------ | ------------------------- |
 | `--shimmer-speed`        | Speed in px/s             |
 | `--shimmer-track-width`  | Track width for timing    |
+| `--shimmer-track-height` | Track height for sizing   |
 | `--shimmer-spread`       | Highlight width           |
 | `--shimmer-angle`        | Sweep angle               |
 | `--shimmer-color`        | Highlight color           |

--- a/apps/docs/content/docs/utilities/tw-shimmer.mdx
+++ b/apps/docs/content/docs/utilities/tw-shimmer.mdx
@@ -85,7 +85,8 @@ Both paths hold still under `prefers-reduced-motion: reduce`, leaving the label 
 
 #### `shimmer-bg`
 
-Background shimmer for skeleton loaders. Applies a gradient animation over the element's background. Requires a base `bg-*` class.
+Background shimmer for skeleton loaders. Requires the base `shimmer` class,
+which paints and animates the gradient, and a base `bg-*` class.
 
 ```html
 <div class="shimmer shimmer-bg bg-muted h-4 w-64 rounded" />

--- a/apps/docs/content/docs/utilities/tw-shimmer.mdx
+++ b/apps/docs/content/docs/utilities/tw-shimmer.mdx
@@ -107,16 +107,16 @@ CSS-only auto-sizing helper using container queries. Sets `container-type: inlin
 
 ### Customization Utilities
 
-| Utility                     | Default (text) | Default (bg) | Description                        |
-| --------------------------- | -------------- | ------------ | ---------------------------------- |
-| `shimmer-speed-{n}`         | `200`                | `1000`  | Animation speed in px/s            |
-| `--shimmer-track-width`     | `200px`              | `200px` | Track width for timing             |
-| `shimmer-spread-{n}`        | `calc(4ch + 80px)`   | `480px` | Shimmer highlight width            |
-| `shimmer-color-{color}`     | auto                 | auto    | Highlight color (Tailwind palette) |
-| `shimmer-angle-{deg}`       | `15`                 | `15`    | Sweep angle in degrees             |
-| `shimmer-duration-{ms}`     | auto                 | auto    | Fixed animation duration           |
-| `shimmer-repeat-delay-{ms}` | `100`                | `20`    | Pause between cycles               |
-| `shimmer-invert`            | —                    | —       | Use a contrasting highlight color  |
+| Utility                     | Default (text)     | Default (bg) | Description                        |
+| --------------------------- | ------------------ | ------------ | ---------------------------------- |
+| `shimmer-speed-{n}`         | `200`              | `1000`       | Animation speed in px/s            |
+| `--shimmer-track-width`     | `200px`            | `200px`      | Track width for timing             |
+| `shimmer-spread-{n}`        | `calc(4ch + 80px)` | `480px`      | Shimmer highlight width            |
+| `shimmer-color-{color}`     | auto               | auto         | Highlight color (Tailwind palette) |
+| `shimmer-angle-{deg}`       | `15`               | `15`         | Sweep angle in degrees             |
+| `shimmer-duration-{ms}`     | auto               | auto         | Fixed animation duration           |
+| `shimmer-repeat-delay-{ms}` | `100`              | `20`         | Pause between cycles               |
+| `shimmer-invert`            | —                  | —            | Use a contrasting highlight color  |
 
 All utilities are **inheritable** — set on a parent to affect all shimmer children.
 
@@ -153,7 +153,9 @@ Control the sweep angle. The default is `15deg`.
 ```
 
 <Callout type="warn">
-  Avoid exactly `0deg` and `180deg` — they cause extreme animation delays. Safe range: 15-75° or 105-165°.
+  Avoid `90deg` and `270deg`, where the angle calculation becomes undefined.
+  Prefer angles from `-75deg` to `75deg`; use an arbitrary property such as
+  `[--shimmer-angle:-15deg]` for negative values.
 </Callout>
 
 ### Position Hints (Angled Shimmer)

--- a/apps/docs/content/docs/utilities/tw-shimmer.mdx
+++ b/apps/docs/content/docs/utilities/tw-shimmer.mdx
@@ -156,8 +156,11 @@ Control the sweep angle. The default is `15deg`.
   Avoid `90deg` and `270deg`, where `tan()` diverges and the gradient width
   becomes unbounded. Angles from `0deg` to `75deg` are safe. Negative angles
   are possible with an arbitrary property such as `[--shimmer-angle:-15deg]`,
-  but angles below roughly `-30deg` can make the text shimmer's gradient width
-  negative and stop the effect.
+  but only shallow ones: when `--shimmer-track-height * tan()` exceeds the
+  spread, the gradient width goes negative and the effect stops. At the default
+  `200px` track height that is around `-30deg` for text; inside a
+  `shimmer-container` the track height can be larger, making the limit
+  shallower.
 </Callout>
 
 ### Position Hints (Angled Shimmer)
@@ -194,16 +197,18 @@ Control the pause between animation cycles. The default is derived from speed: `
 
 All values can be set via CSS variables for dynamic control:
 
-| Variable                 | Description               |
-| ------------------------ | ------------------------- |
-| `--shimmer-speed`        | Speed in px/s             |
-| `--shimmer-track-width`  | Track width for timing    |
-| `--shimmer-track-height` | Track height for sizing   |
-| `--shimmer-spread`       | Highlight width           |
-| `--shimmer-angle`        | Sweep angle               |
-| `--shimmer-color`        | Highlight color           |
-| `--shimmer-duration`     | Override duration (ms)    |
-| `--shimmer-repeat-delay` | Pause between cycles (ms) |
+| Variable                 | Description                                  |
+| ------------------------ | -------------------------------------------- |
+| `--shimmer-speed`        | Speed in px/s                                |
+| `--shimmer-track-width`  | Track width for timing                       |
+| `--shimmer-track-height` | Track height for sizing                      |
+| `--shimmer-spread`       | Highlight width                              |
+| `--shimmer-angle`        | Sweep angle                                  |
+| `--shimmer-color`        | Highlight color                              |
+| `--shimmer-duration`     | Override duration (ms)                       |
+| `--shimmer-repeat-delay` | Pause between cycles (ms)                    |
+| `--shimmer-x`            | Horizontal position hint (unitless, px)     |
+| `--shimmer-y`            | Vertical position hint (unitless, px)       |
 
 ```tsx
 <div

--- a/apps/docs/content/docs/utilities/tw-shimmer.mdx
+++ b/apps/docs/content/docs/utilities/tw-shimmer.mdx
@@ -153,9 +153,11 @@ Control the sweep angle. The default is `15deg`.
 ```
 
 <Callout type="warn">
-  Avoid `90deg` and `270deg`, where the angle calculation becomes undefined.
-  Prefer angles from `-75deg` to `75deg`; use an arbitrary property such as
-  `[--shimmer-angle:-15deg]` for negative values.
+  Avoid `90deg` and `270deg`, where `tan()` diverges and the gradient width
+  becomes unbounded. Angles from `0deg` to `75deg` are safe. Negative angles
+  are possible with an arbitrary property such as `[--shimmer-angle:-15deg]`,
+  but angles below roughly `-30deg` can make the text shimmer's gradient width
+  negative and stop the effect.
 </Callout>
 
 ### Position Hints (Angled Shimmer)

--- a/apps/docs/content/docs/utilities/tw-shimmer.mdx
+++ b/apps/docs/content/docs/utilities/tw-shimmer.mdx
@@ -156,9 +156,10 @@ Control the sweep angle. The default is `15deg`.
   Avoid `90deg` and `270deg`, where `tan()` diverges and the gradient width
   becomes unbounded. Angles from `0deg` to `75deg` are safe. Negative angles
   are possible with an arbitrary property such as `[--shimmer-angle:-15deg]`,
-  but only shallow ones: when `--shimmer-track-height * tan()` exceeds the
-  spread, the gradient width goes negative and the effect stops. At the default
-  `200px` track height that is around `-30deg` for text; inside a
+  but only shallow ones: when the magnitude of
+  `--shimmer-track-height * tan()` exceeds the spread, the gradient width goes
+  negative and the effect stops. At the default `200px` track height that is
+  around `-30deg` for text; inside a
   `shimmer-container` the track height can be larger, making the limit
   shallower.
 </Callout>
@@ -207,8 +208,8 @@ All values can be set via CSS variables for dynamic control:
 | `--shimmer-color`        | Highlight color                              |
 | `--shimmer-duration`     | Override duration (ms)                       |
 | `--shimmer-repeat-delay` | Pause between cycles (ms)                    |
-| `--shimmer-x`            | Horizontal position hint (unitless, px)     |
-| `--shimmer-y`            | Vertical position hint (unitless, px)       |
+| `--shimmer-x`            | Horizontal position hint (unitless, px)      |
+| `--shimmer-y`            | Vertical position hint (unitless, px)        |
 
 ```tsx
 <div

--- a/packages/tw-shimmer/README.md
+++ b/packages/tw-shimmer/README.md
@@ -31,7 +31,7 @@ Text shimmer keeps one text node. Where `-webkit-mask-clip: text` is supported, 
 </div>
 ```
 
-Inside a `shimmer-container`, the plugin derives the track width and height from the container automatically. Text shimmer hosts should contain text only: the host mask clips every descendant, including icons. Selection backgrounds are clipped to the glyphs on the compositor path.
+Inside a `shimmer-container`, the plugin derives the track width from the container width. Because the container exposes only its inline size, the height term for angled gradients uses the nearest block-size query container when available and otherwise the small viewport height, with half the container width and `200px` as minimums. Text shimmer hosts should contain text only: the host mask clips every descendant, including icons. Selection backgrounds are clipped to the glyphs on the compositor path.
 
 The compositor highlight is additive. It defaults to white and `--shimmer-color`, including `shimmer-color-*`, overrides the band color. This matches the gradient on white and dark surfaces but can look different on tinted surfaces. `shimmer-invert` selects a black band.
 

--- a/packages/tw-shimmer/README.md
+++ b/packages/tw-shimmer/README.md
@@ -42,13 +42,13 @@ Text shimmer holds still under `prefers-reduced-motion: reduce` on both paths, l
 | Utility                  | Effect                                                                        |
 | ------------------------ | ----------------------------------------------------------------------------- |
 | `shimmer`                | Base text shimmer. Pair with a low-opacity text color.                        |
-| `shimmer-bg`             | Background shimmer (skeleton placeholders).                                   |
+| `shimmer-bg`             | Background shimmer; requires `shimmer` and a base `bg-*` class.                |
 | `shimmer-container`      | Parent container that sizes the animation track for children.                 |
 | `shimmer-speed-{value}`  | Animation speed in px per second (text: 200, background: 1000 by default).    |
 | `--shimmer-track-width`  | Animation track width for timing (200px by default).                          |
 | `shimmer-spread-{value}` | Highlight thickness (text: `calc(4ch + 80px)`, background: 480px by default). |
 | `shimmer-angle-{value}`  | Highlight angle in degrees (15 by default).                                   |
-| `shimmer-repeat-delay-{value}` | Pause between cycles in ms (text: 100, background: 20 by default).     |
+| `shimmer-repeat-delay-*` | Pause between cycles in ms (text: 100, background: 20 by default).            |
 | `shimmer-color-{color}`  | Highlight color from your Tailwind palette.                                   |
 | `shimmer-invert`         | Use a contrasting additive highlight band.                                    |
 

--- a/packages/tw-shimmer/README.md
+++ b/packages/tw-shimmer/README.md
@@ -26,12 +26,12 @@ Text shimmer keeps one text node. Where `-webkit-mask-clip: text` is supported, 
 <span class="shimmer text-foreground/40">Loading...</span>
 
 <div class="shimmer-container space-y-2">
-  <div class="shimmer-bg h-4 w-full rounded"></div>
-  <div class="shimmer-bg h-4 w-3/4 rounded"></div>
+  <div class="shimmer shimmer-bg bg-gray-200 h-4 w-full rounded"></div>
+  <div class="shimmer shimmer-bg bg-gray-200 h-4 w-3/4 rounded"></div>
 </div>
 ```
 
-Inside a `shimmer-container`, the plugin derives the track width from the container size automatically. Text shimmer hosts should contain text only: the host mask clips every descendant, including icons. Selection backgrounds are clipped to the glyphs on the compositor path.
+Inside a `shimmer-container`, the plugin derives the track width and height from the container automatically. Text shimmer hosts should contain text only: the host mask clips every descendant, including icons. Selection backgrounds are clipped to the glyphs on the compositor path.
 
 The compositor highlight is additive. It defaults to white and `--shimmer-color`, including `shimmer-color-*`, overrides the band color. This matches the gradient on white and dark surfaces but can look different on tinted surfaces. `shimmer-invert` selects a black band.
 
@@ -43,11 +43,12 @@ Text shimmer holds still under `prefers-reduced-motion: reduce` on both paths, l
 | ------------------------ | ----------------------------------------------------------------------------- |
 | `shimmer`                | Base text shimmer. Pair with a low-opacity text color.                        |
 | `shimmer-bg`             | Background shimmer (skeleton placeholders).                                   |
-| `shimmer-container`      | Parent container that auto-derives speed and width for children.              |
+| `shimmer-container`      | Parent container that sizes the animation track for children.                 |
 | `shimmer-speed-{value}`  | Animation speed in px per second (text: 200, background: 1000 by default).    |
-| `--shimmer-track-width`  | Animation track width for timing (text: 200px by default).                    |
-| `shimmer-spread-{value}` | Highlight thickness.                                                          |
-| `shimmer-angle-{value}`  | Highlight angle in degrees.                                                   |
+| `--shimmer-track-width`  | Animation track width for timing (200px by default).                          |
+| `shimmer-spread-{value}` | Highlight thickness (text: `calc(4ch + 80px)`, background: 480px by default). |
+| `shimmer-angle-{value}`  | Highlight angle in degrees (15 by default).                                   |
+| `shimmer-repeat-delay-{value}` | Pause between cycles in ms (text: 100, background: 20 by default).     |
 | `shimmer-color-{color}`  | Highlight color from your Tailwind palette.                                   |
 | `shimmer-invert`         | Use a contrasting additive highlight band.                                    |
 

--- a/packages/tw-shimmer/README.md
+++ b/packages/tw-shimmer/README.md
@@ -42,7 +42,7 @@ Text shimmer holds still under `prefers-reduced-motion: reduce` on both paths, l
 | Utility                  | Effect                                                                        |
 | ------------------------ | ----------------------------------------------------------------------------- |
 | `shimmer`                | Base text shimmer. Pair with a low-opacity text color.                        |
-| `shimmer-bg`             | Background shimmer; requires `shimmer` and a base `bg-*` class.                |
+| `shimmer-bg`             | Background shimmer; requires `shimmer` and a base `bg-*` class.               |
 | `shimmer-container`      | Parent container that sizes the animation track for children.                 |
 | `shimmer-speed-{value}`  | Animation speed in px per second (text: 200, background: 1000 by default).    |
 | `--shimmer-track-width`  | Animation track width for timing (200px by default).                          |


### PR DESCRIPTION
## Problem

The current tw-shimmer utility guide and package README describe utility names and defaults that do not exist in the shipped CSS. On `tw-shimmer@0.4.12`, examples using `shimmer-bg` without the base `shimmer` class also remain static. The mismatch is visible by comparing the utility page examples with `packages/tw-shimmer/src/index.css`.

## Root cause

The documentation drifted from the CSS implementation as the spread, position, track sizing, angle, and repeat-delay behavior changed.

## Change

- use the required `shimmer shimmer-bg` class pair in background examples
- document the shipped spread and arbitrary position variables
- correct the angle and derived repeat-delay defaults
- describe `shimmer-container` as sizing the animation track
- keep the package README and site guide aligned

## Verification

- `pnpm -C apps/docs test` — 794 passed, 7 skipped
- `pnpm -C apps/docs build` — passed, including TypeScript and 758 static pages
- `pnpm lint` — passed with existing repository warnings
- `pnpm changesets:check` — passed
- confirmed the documented utility names and defaults against `packages/tw-shimmer/src/index.css`

## Public surface

- `tw-shimmer` package README and patch changeset
- tw-shimmer documentation page
- no export, template, or API-reference changes

Closes #6827

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Po_NrBBlU83qSk_49s18t26zuG10fuPBdIKQUY7XqAmCvLtpF6tuCV_kK3I?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->