### PR TITLE
fix: preserve title generation intent during rename

### DIFF
--- a/.changeset/tidy-titles-wait.md
+++ b/.changeset/tidy-titles-wait.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: keep explicit title generations ordered after in-flight renames

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -373,6 +373,50 @@ describe("useThreads", () => {
     expect(mocks.generateThreadTitle).toHaveBeenCalledTimes(2);
   });
 
+  it("holds every explicit generation until a pending rename settles", async () => {
+    const renameUpdate = createDeferred<void>();
+    const applied: string[] = [];
+    const cloud = createCloud("cloud-1");
+    cloud.threads.update.mockImplementation(
+      async (_id: string, patch: { title?: string }) => {
+        if (patch.title === undefined) return;
+        if (patch.title === "Manual title") await renameUpdate.promise;
+        applied.push(patch.title);
+      },
+    );
+    mocks.generateThreadTitle.mockImplementation(
+      async (currentCloud: typeof cloud, tid: string) => {
+        await currentCloud.threads.update(tid, { title: "Second title" });
+        return "Second title";
+      },
+    );
+    const { result } = renderHook(() =>
+      useThreads({ cloud: cloud as never, enabled: false }),
+    );
+
+    let rename!: Promise<boolean>;
+    let first!: Promise<string | null>;
+    let second!: Promise<string | null>;
+    act(() => {
+      rename = result.current.rename("thread-1", "Manual title");
+      first = result.current.generateTitle("thread-1");
+      second = result.current.generateTitle("thread-1");
+    });
+    await Promise.resolve();
+
+    expect(mocks.generateThreadTitle).not.toHaveBeenCalled();
+
+    await act(async () => {
+      renameUpdate.resolve();
+      await Promise.all([rename, first, second]);
+    });
+
+    expect(await first).toBe("Second title");
+    expect(await second).toBe("Second title");
+    expect(mocks.generateThreadTitle).toHaveBeenCalledOnce();
+    expect(applied).toEqual(["Manual title", "Second title"]);
+  });
+
   it("leaves the server on the explicit title when a rename lands late", async () => {
     const applied: string[] = [];
     const renameLanded = createDeferred<void>();

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -417,6 +417,53 @@ describe("useThreads", () => {
     expect(applied).toEqual(["Manual title", "Second title"]);
   });
 
+  it("waits for every overlapping rename before explicit generation", async () => {
+    const firstUpdate = createDeferred<void>();
+    const secondUpdate = createDeferred<void>();
+    const applied: string[] = [];
+    const cloud = createCloud("cloud-1");
+    cloud.threads.update.mockImplementation(
+      async (_id: string, patch: { title?: string }) => {
+        if (patch.title === undefined) return;
+        if (patch.title === "First") await firstUpdate.promise;
+        if (patch.title === "Second") await secondUpdate.promise;
+        applied.push(patch.title);
+      },
+    );
+    mocks.generateThreadTitle.mockImplementation(
+      async (currentCloud: typeof cloud, tid: string) => {
+        await currentCloud.threads.update(tid, { title: "Explicit" });
+        return "Explicit";
+      },
+    );
+    const { result } = renderHook(() =>
+      useThreads({ cloud: cloud as never, enabled: false }),
+    );
+
+    let first!: Promise<boolean>;
+    let second!: Promise<boolean>;
+    let generation!: Promise<string | null>;
+    act(() => {
+      first = result.current.rename("thread-1", "First");
+      second = result.current.rename("thread-1", "Second");
+      generation = result.current.generateTitle("thread-1");
+    });
+
+    await act(async () => {
+      secondUpdate.resolve();
+      await second;
+    });
+    expect(mocks.generateThreadTitle).not.toHaveBeenCalled();
+
+    await act(async () => {
+      firstUpdate.resolve();
+      await Promise.all([first, generation]);
+    });
+
+    expect(await generation).toBe("Explicit");
+    expect(applied).toEqual(["Second", "First", "Explicit"]);
+  });
+
   it("leaves the server on the explicit title when a rename lands late", async () => {
     const applied: string[] = [];
     const renameLanded = createDeferred<void>();

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -55,6 +55,7 @@ type ThreadTitleGeneration = {
 type ThreadTitleState = {
   generations: Set<ThreadTitleGeneration>;
   pendingClaim: ThreadTitleClaim | null;
+  inFlightClaim: ThreadTitleClaim | null;
   manualTitle: string | undefined;
   latestExplicit: ThreadTitleGeneration | null;
   nextOrder: number;
@@ -69,6 +70,7 @@ function getThreadTitleState(
     state = {
       generations: new Set(),
       pendingClaim: null,
+      inFlightClaim: null,
       manualTitle: undefined,
       latestExplicit: null,
       nextOrder: 0,
@@ -125,6 +127,7 @@ function pruneThreadTitleState(
   if (
     state.generations.size === 0 &&
     state.pendingClaim === null &&
+    state.inFlightClaim === null &&
     state.manualTitle === undefined &&
     states.get(threadId) === state
   ) {
@@ -412,6 +415,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
       });
       const claim = { title, order: ++state.nextOrder, settled };
       state.pendingClaim = claim;
+      state.inFlightClaim = claim;
       for (const generation of state.generations) {
         if (generation.order < claim.order) generation.claim = claim;
       }
@@ -430,6 +434,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
         isCurrentCloud,
       );
       settleClaim(renamed);
+      if (state.inFlightClaim === claim) state.inFlightClaim = null;
       if (state.pendingClaim === claim) {
         state.pendingClaim = null;
         if (renamed) state.manualTitle = title;
@@ -531,7 +536,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
         automatic,
         order: ++state.nextOrder,
         claim: automatic ? state.pendingClaim : null,
-        beforeGenerationClaim: automatic ? null : state.pendingClaim,
+        beforeGenerationClaim: automatic ? null : state.inFlightClaim,
         superseded: false,
         persisted,
         settlePersisted,

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -46,7 +46,7 @@ type ThreadTitleGeneration = {
   readonly automatic: boolean;
   readonly order: number;
   claim: ThreadTitleClaim | null;
-  readonly beforeGenerationClaim: ThreadTitleClaim | null;
+  readonly beforeGenerationClaims: readonly ThreadTitleClaim[];
   superseded: boolean;
   readonly persisted: Promise<string | undefined>;
   readonly settlePersisted: (title: string | undefined) => void;
@@ -55,7 +55,7 @@ type ThreadTitleGeneration = {
 type ThreadTitleState = {
   generations: Set<ThreadTitleGeneration>;
   pendingClaim: ThreadTitleClaim | null;
-  inFlightClaim: ThreadTitleClaim | null;
+  inFlightClaims: Set<ThreadTitleClaim>;
   manualTitle: string | undefined;
   latestExplicit: ThreadTitleGeneration | null;
   nextOrder: number;
@@ -70,7 +70,7 @@ function getThreadTitleState(
     state = {
       generations: new Set(),
       pendingClaim: null,
-      inFlightClaim: null,
+      inFlightClaims: new Set(),
       manualTitle: undefined,
       latestExplicit: null,
       nextOrder: 0,
@@ -127,7 +127,7 @@ function pruneThreadTitleState(
   if (
     state.generations.size === 0 &&
     state.pendingClaim === null &&
-    state.inFlightClaim === null &&
+    state.inFlightClaims.size === 0 &&
     state.manualTitle === undefined &&
     states.get(threadId) === state
   ) {
@@ -415,7 +415,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
       });
       const claim = { title, order: ++state.nextOrder, settled };
       state.pendingClaim = claim;
-      state.inFlightClaim = claim;
+      state.inFlightClaims.add(claim);
       for (const generation of state.generations) {
         if (generation.order < claim.order) generation.claim = claim;
       }
@@ -434,7 +434,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
         isCurrentCloud,
       );
       settleClaim(renamed);
-      if (state.inFlightClaim === claim) state.inFlightClaim = null;
+      state.inFlightClaims.delete(claim);
       if (state.pendingClaim === claim) {
         state.pendingClaim = null;
         if (renamed) state.manualTitle = title;
@@ -536,7 +536,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
         automatic,
         order: ++state.nextOrder,
         claim: automatic ? state.pendingClaim : null,
-        beforeGenerationClaim: automatic ? null : state.inFlightClaim,
+        beforeGenerationClaims: automatic ? [] : [...state.inFlightClaims],
         superseded: false,
         persisted,
         settlePersisted,
@@ -601,11 +601,14 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
             let generated = false;
 
             const runGeneration = async () => {
-              // `rename` resolves only once its own server write lands, so an
-              // explicit generation that started mid-rename waits rather than
-              // racing that write with its own.
-              if (generation.beforeGenerationClaim !== null) {
-                await generation.beforeGenerationClaim.settled;
+              // An explicit generation waits for every earlier rename because
+              // any of those server writes may settle last.
+              if (generation.beforeGenerationClaims.length > 0) {
+                await Promise.all(
+                  generation.beforeGenerationClaims.map(
+                    (claim) => claim.settled,
+                  ),
+                );
               }
               while (true) {
                 if (generation.claim) {

--- a/packages/core/src/runtimes/remote-thread-list/title-generation.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/title-generation.test.ts
@@ -288,6 +288,52 @@ describe("runThreadTitleGeneration", () => {
     expect(server).toBe("Second");
   });
 
+  it("waits for every overlapping rename before explicit generation", async () => {
+    const states = new Map<string, ThreadTitleState>();
+    const firstOpen = deferred<void>();
+    const secondOpen = deferred<void>();
+    const generated: string[] = [];
+    let server: string | undefined;
+
+    const firstClaim = startThreadTitleRename(states, "t1", "First");
+    const firstRename = (async () => {
+      await firstOpen.promise;
+      server = firstClaim.title;
+      finishThreadTitleRename(states, "t1", firstClaim, true);
+    })();
+    const secondClaim = startThreadTitleRename(states, "t1", "Second");
+    const secondRename = (async () => {
+      await secondOpen.promise;
+      server = secondClaim.title;
+      finishThreadTitleRename(states, "t1", secondClaim, true);
+    })();
+    const generation = runThreadTitleGeneration({
+      states,
+      threadId: "t1",
+      automatic: false,
+      generate: async (onTitle) => {
+        generated.push("Explicit");
+        server = "Explicit";
+        await onTitle("Explicit");
+      },
+      rename: async (title) => {
+        server = title;
+      },
+      applyTitle: noop,
+    });
+
+    secondOpen.resolve();
+    await secondRename;
+    await flushMicrotasks();
+    expect(generated).toEqual([]);
+
+    firstOpen.resolve();
+    await Promise.all([firstRename, generation]);
+
+    expect(generated).toEqual(["Explicit"]);
+    expect(server).toBe("Explicit");
+  });
+
   it("reasserts the explicit title when the superseded run persists last", async () => {
     const states = new Map<string, ThreadTitleState>();
     const streamOpen = deferred<void>();

--- a/packages/core/src/runtimes/remote-thread-list/title-generation.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/title-generation.test.ts
@@ -247,6 +247,47 @@ describe("runThreadTitleGeneration", () => {
     expect(applied).toEqual(["Explicit"]);
   });
 
+  it("holds every explicit generation until a pending rename settles", async () => {
+    const states = new Map<string, ThreadTitleState>();
+    const renameOpen = deferred<void>();
+    const generated: string[] = [];
+    let server: string | undefined;
+
+    const claim = startThreadTitleRename(states, "t1", "Manual");
+    const rename = (async () => {
+      await renameOpen.promise;
+      server = claim.title;
+      finishThreadTitleRename(states, "t1", claim, true);
+    })();
+    const runOf = (title: string) =>
+      runThreadTitleGeneration({
+        states,
+        threadId: "t1",
+        automatic: false,
+        generate: async (onTitle) => {
+          generated.push(title);
+          server = title;
+          await onTitle(title);
+        },
+        rename: async (next) => {
+          server = next;
+        },
+        applyTitle: noop,
+      });
+
+    const first = runOf("First");
+    const second = runOf("Second");
+    await flushMicrotasks();
+
+    expect(generated).toEqual([]);
+
+    renameOpen.resolve();
+    await Promise.all([rename, first, second]);
+
+    expect(generated).toEqual(["Second"]);
+    expect(server).toBe("Second");
+  });
+
   it("reasserts the explicit title when the superseded run persists last", async () => {
     const states = new Map<string, ThreadTitleState>();
     const streamOpen = deferred<void>();

--- a/packages/core/src/runtimes/remote-thread-list/title-generation.ts
+++ b/packages/core/src/runtimes/remote-thread-list/title-generation.ts
@@ -259,6 +259,8 @@ export async function runThreadTitleGeneration({
   };
 
   const runGeneration = async () => {
+    // An explicit generation waits for every earlier rename because any of
+    // those server writes may settle last.
     if (generation.beforeGenerationClaims.length > 0) {
       await Promise.all(
         generation.beforeGenerationClaims.map((claim) => claim.settled),

--- a/packages/core/src/runtimes/remote-thread-list/title-generation.ts
+++ b/packages/core/src/runtimes/remote-thread-list/title-generation.ts
@@ -18,6 +18,7 @@ type ThreadTitleGeneration = {
 export type ThreadTitleState = {
   generations: Set<ThreadTitleGeneration>;
   pendingClaim: ThreadTitleClaim | null;
+  inFlightClaim: ThreadTitleClaim | null;
   manualTitle: string | undefined;
   latestExplicit: ThreadTitleGeneration | null;
   nextOrder: number;
@@ -43,6 +44,7 @@ function getThreadTitleState(
     state = {
       generations: new Set(),
       pendingClaim: null,
+      inFlightClaim: null,
       manualTitle: undefined,
       latestExplicit: null,
       nextOrder: 0,
@@ -60,6 +62,7 @@ function pruneThreadTitleState(
   if (
     state.generations.size === 0 &&
     state.pendingClaim === null &&
+    state.inFlightClaim === null &&
     state.manualTitle === undefined &&
     states.get(threadId) === state
   ) {
@@ -101,6 +104,7 @@ export function startThreadTitleRename(
     settle,
   };
   state.pendingClaim = claim;
+  state.inFlightClaim = claim;
   for (const generation of state.generations) {
     if (generation.order < claim.order) generation.claim = claim;
   }
@@ -116,6 +120,7 @@ export function finishThreadTitleRename(
   claim.settle(renamed);
   const state = states.get(threadId);
   if (state === undefined) return;
+  if (state.inFlightClaim === claim) state.inFlightClaim = null;
   if (state.pendingClaim === claim) {
     state.pendingClaim = null;
     if (renamed) {
@@ -166,7 +171,7 @@ function startThreadTitleGeneration(
     automatic,
     order: ++state.nextOrder,
     claim: automatic ? state.pendingClaim : null,
-    beforeGenerationClaim: automatic ? null : state.pendingClaim,
+    beforeGenerationClaim: automatic ? null : state.inFlightClaim,
     superseded: false,
     persisted,
     settlePersisted,

--- a/packages/core/src/runtimes/remote-thread-list/title-generation.ts
+++ b/packages/core/src/runtimes/remote-thread-list/title-generation.ts
@@ -9,7 +9,7 @@ type ThreadTitleGeneration = {
   readonly automatic: boolean;
   readonly order: number;
   claim: ThreadTitleClaim | null;
-  beforeGenerationClaim: ThreadTitleClaim | null;
+  beforeGenerationClaims: readonly ThreadTitleClaim[];
   superseded: boolean;
   readonly persisted: Promise<string | undefined>;
   readonly settlePersisted: (title: string | undefined) => void;
@@ -18,7 +18,7 @@ type ThreadTitleGeneration = {
 export type ThreadTitleState = {
   generations: Set<ThreadTitleGeneration>;
   pendingClaim: ThreadTitleClaim | null;
-  inFlightClaim: ThreadTitleClaim | null;
+  inFlightClaims: Set<ThreadTitleClaim>;
   manualTitle: string | undefined;
   latestExplicit: ThreadTitleGeneration | null;
   nextOrder: number;
@@ -44,7 +44,7 @@ function getThreadTitleState(
     state = {
       generations: new Set(),
       pendingClaim: null,
-      inFlightClaim: null,
+      inFlightClaims: new Set(),
       manualTitle: undefined,
       latestExplicit: null,
       nextOrder: 0,
@@ -62,7 +62,7 @@ function pruneThreadTitleState(
   if (
     state.generations.size === 0 &&
     state.pendingClaim === null &&
-    state.inFlightClaim === null &&
+    state.inFlightClaims.size === 0 &&
     state.manualTitle === undefined &&
     states.get(threadId) === state
   ) {
@@ -104,7 +104,7 @@ export function startThreadTitleRename(
     settle,
   };
   state.pendingClaim = claim;
-  state.inFlightClaim = claim;
+  state.inFlightClaims.add(claim);
   for (const generation of state.generations) {
     if (generation.order < claim.order) generation.claim = claim;
   }
@@ -120,7 +120,7 @@ export function finishThreadTitleRename(
   claim.settle(renamed);
   const state = states.get(threadId);
   if (state === undefined) return;
-  if (state.inFlightClaim === claim) state.inFlightClaim = null;
+  state.inFlightClaims.delete(claim);
   if (state.pendingClaim === claim) {
     state.pendingClaim = null;
     if (renamed) {
@@ -171,7 +171,7 @@ function startThreadTitleGeneration(
     automatic,
     order: ++state.nextOrder,
     claim: automatic ? state.pendingClaim : null,
-    beforeGenerationClaim: automatic ? null : state.inFlightClaim,
+    beforeGenerationClaims: automatic ? [] : [...state.inFlightClaims],
     superseded: false,
     persisted,
     settlePersisted,
@@ -259,8 +259,10 @@ export async function runThreadTitleGeneration({
   };
 
   const runGeneration = async () => {
-    if (generation.beforeGenerationClaim !== null) {
-      await generation.beforeGenerationClaim.settled;
+    if (generation.beforeGenerationClaims.length > 0) {
+      await Promise.all(
+        generation.beforeGenerationClaims.map((claim) => claim.settled),
+      );
     }
     if (generation.claim !== null) {
       const renamed = await settleClaim(generation.claim);


### PR DESCRIPTION
## Problem

When a rename is still being written, the first explicit `generateTitle()` waits for it, but a second explicit generation starts immediately. If that generation writes first and the older rename lands afterward, the newer regenerate intent is lost. This reproduces on the current core and cloud title-generation paths.

## Root cause

`pendingClaim` was doing two jobs: transferring claim ownership and representing the rename still on the wire. The first explicit generation correctly cleared ownership, but that also removed the dependency needed by every later explicit generation.

## Change

Keep the in-flight rename claim separately from `pendingClaim` in both title state machines. Every explicit generation now waits for the same active rename, while the existing automatic-generation, manual-title, supersession, and repair behavior remains unchanged. The claim is cleared only when that exact rename settles.

Paired regression tests hold a rename write, start two explicit generations, prove neither begins early, and verify the newer generated title remains on the server after the rename lands. The regression fails in both packages without the state change and passes with it.

## Verification

- `pnpm test` in `packages/core` — 1,788 passed
- `pnpm test` in `packages/cloud-ai-sdk` — 120 passed on each supported peer matrix; peer-v6 type check passed
- `pnpm build` in both affected packages — passed
- `pnpm exec tsc --noEmit` in `packages/cloud-ai-sdk` — passed
- `pnpm lint` — passed with existing repository warnings
- `pnpm changesets:check` — passed
- affected core and cloud entries remain within `pnpm size:check` budgets; the overall command reports an unrelated over-budget `@assistant-ui/ai-sdk` entry
- monorepo `pnpm test:types` still reports existing test-fixture errors outside this change; neither changed implementation file produces an error, and both package builds pass declaration generation

## Public surface

- behavior fix in `@assistant-ui/core` and `@assistant-ui/cloud-ai-sdk`
- patch changeset for both packages
- no new exports, documentation, templates, or API-reference output

Closes #7045

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.JmZ3mYtc9BAOC0lNYP--yvdCq69rAGsRc42iAGpmm10fWPVGkhE2zJjJo5M?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->