### PR TITLE
fix(react-generative-ui): preserve prototype-named data paths

### DIFF
--- a/.changeset/calm-pointers-own.md
+++ b/.changeset/calm-pointers-own.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: preserve prototype-named A2UI data model paths

--- a/packages/react-generative-ui/src/a2ui/reducer.test.ts
+++ b/packages/react-generative-ui/src/a2ui/reducer.test.ts
@@ -155,6 +155,33 @@ describe("applyA2uiOperations", () => {
     expect(resultModel.items[10_002]).toBe("appended");
   });
 
+  it("stores prototype-named JSON Pointer segments as own properties", () => {
+    const state: A2uiState = new Map([
+      ["main", { components: new Map(), dataModel: {} }],
+    ]);
+
+    const result = applyA2uiOperations(state, [
+      {
+        version: "v1.0",
+        updateDataModel: {
+          surfaceId: "main",
+          path: "/__proto__/admin",
+          value: true,
+        },
+      },
+    ]);
+
+    const resultModel = result.state.get("main")?.dataModel as Record<
+      string,
+      unknown
+    >;
+    expect(result.warnings).toEqual([]);
+    expect(Object.getPrototypeOf(resultModel)).toBe(Object.prototype);
+    expect(Object.hasOwn(resultModel, "__proto__")).toBe(true);
+    expect(resultModel["__proto__"]).toEqual({ admin: true });
+    expect(JSON.stringify(resultModel)).toBe('{"__proto__":{"admin":true}}');
+  });
+
   it("deletes object properties updated to null", () => {
     const dataModel = {
       profile: { name: "Ada", role: "admin" },

--- a/packages/react-generative-ui/src/a2ui/reducer.ts
+++ b/packages/react-generative-ui/src/a2ui/reducer.ts
@@ -180,10 +180,8 @@ const setAtPointer = (
       return clone;
     }
 
-    const clone: Record<string, unknown> = isRecord(current)
-      ? { ...current }
-      : {};
-    const child = clone[segment];
+    const record: Record<string, unknown> = isRecord(current) ? current : {};
+    const child = Object.hasOwn(record, segment) ? record[segment] : undefined;
     const next = isLast
       ? value
       : update(
@@ -195,8 +193,7 @@ const setAtPointer = (
           index + 1,
         );
     if (next === INVALID_POINTER) return INVALID_POINTER;
-    clone[segment] = next;
-    return clone;
+    return { ...record, [segment]: next };
   };
 
   const result = update(model, 0);


### PR DESCRIPTION
## Problem

A valid A2UI `updateDataModel` operation targeting `/__proto__/admin` changes the data model object's prototype instead of creating an own `__proto__` property. The operation reports no warning, inherited reads return the injected value, and serializing the model produces `{}`.

Minimal reproduction on current main:

```ts
applyA2uiOperations(state, [{
  version: "v1.0",
  updateDataModel: {
    surfaceId: "main",
    path: "/__proto__/admin",
    value: true,
  },
}]);
```

## Root cause

The JSON Pointer updater read path segments through the prototype chain and assigned them with `clone[segment] = next`. For `__proto__`, that assignment invokes the legacy prototype setter rather than defining model data.

## Change

Read only own properties while traversing object paths and rebuild the updated object with a computed property. This stores prototype-named segments as ordinary own data properties without changing JSON Pointer syntax or the object prototype.

## Verification

- Confirmed the reproduction on unmodified current main: the result inherited `admin: true`, had no own `__proto__`, and serialized to `{}`.
- `pnpm --filter @assistant-ui/react-generative-ui exec vitest run src/a2ui/reducer.test.ts`
- `pnpm exec oxlint packages/react-generative-ui/src/a2ui/reducer.ts packages/react-generative-ui/src/a2ui/reducer.test.ts`
- `pnpm exec oxfmt --check packages/react-generative-ui/src/a2ui/reducer.ts packages/react-generative-ui/src/a2ui/reducer.test.ts`
- `pnpm changesets:check`

## Public surface

Affected package: `@assistant-ui/react-generative-ui` (patch changeset). No export, documentation, template, or API-reference changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._D2twxfQ4SvaKoeXMfPGAuwHbGwX5UDyNtBR0_T1mIyYZp9AmLXvf2QbGXI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->