### PR TITLE
fix(ai-sdk): release superseded chats on resource replacement

### DIFF
--- a/.changeset/tidy-resource-lifetimes.md
+++ b/.changeset/tidy-resource-lifetimes.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/ai-sdk": patch
+"@assistant-ui/tap": patch
+---
+
+fix: release permanently disposed resource state without treating soft unmounts as deletion

--- a/api-surface/assistant-ui__tap.ts
+++ b/api-surface/assistant-ui__tap.ts
@@ -20,7 +20,7 @@ declare const createTapRoot: <R>(render: () => R, options?: {
 declare const flushTapSync: <T>(callback: () => T) => T;
 
 declare namespace entry_root_exports {
-  export { Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useMemoCache, useResource, useResources, useTapHost, useTapRoot, withKey };
+  export { Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useMemoCache, useResource, useResourceDispose, useResources, useTapHost, useTapRoot, withKey };
 }
 
 declare function resource<R, A extends readonly unknown[]>(hook: (...args: A) => R): Resource<R, A>;
@@ -30,6 +30,8 @@ declare const useContextProvider: <T, TResult>(context: Context<T>, value: T, fn
 declare const useMemoCache: (size: number) => unknown[];
 
 declare function useResource<E extends ResourceElement<any>>(element: E): ExtractResourceReturnType<E>;
+
+declare const useResourceDispose: (dispose: () => void) => void;
 
 declare function useResources<E extends ResourceElement<any>>(elements: readonly E[]): ExtractResourceReturnType<E>[];
 

--- a/apps/docs/content/tap-docs/tap/api-reference.mdx
+++ b/apps/docs/content/tap-docs/tap/api-reference.mdx
@@ -128,6 +128,25 @@ const values = useResources(
 );
 ```
 
+## useResourceDispose
+
+Registers a callback that runs once when the current resource or React host is
+permanently disposed. Soft unmounts, including a hidden React `Activity` or a
+`mountOnSubscribe` root with no subscribers, preserve the callback for a later
+remount.
+
+```ts
+function useResourceDispose(dispose: () => void): void;
+```
+
+```ts
+useResourceDispose(() => connection.close());
+```
+
+Use an effect cleanup for work that should run on every soft unmount. Use
+`useResourceDispose` to release state that must survive a soft unmount but must
+not outlive its owner.
+
 ## useTapRoot
 
 Hosts a render callback behind a subscribable boundary. It returns a stable root

--- a/apps/docs/content/tap-docs/tap/lifecycle.mdx
+++ b/apps/docs/content/tap-docs/tap/lifecycle.mdx
@@ -70,14 +70,23 @@ This is intentional, it lets you run setup logic both before and after children,
 
 Cleanup on unmount runs in the same order as mount (FIFO), matching the order effects were originally registered.
 
-## Mount and unmount
+## Mount, soft unmount, and disposal
 
 A resource is **mounted** after its first commit. At this point, effects have run and the resource is live.
 
-A resource is **unmounted** when its owner removes it, all effect cleanups run and the resource is disposed. This happens automatically when:
+A resource is **soft-unmounted** when its effects disconnect but its state and
+identity are preserved for a later remount. A hidden React `Activity` and a
+`createTapRoot` root with `mountOnSubscribe: true` and no subscribers use this
+lifecycle.
 
-- A parent resource stops rendering the child via `useResource`
-- A React component using `useResource` unmounts
+A resource is **disposed** when it permanently leaves its owner. All effect
+cleanups run, its state is released, and callbacks registered with
+[`useResourceDispose`](/tap/docs/tap/api-reference#useresourcedispose) run once.
+This happens automatically when:
+
+- A parent resource removes or replaces a child through `useResource` or
+  `useResources`
+- A React component using `useResource` is deleted
 - `root.unmount()` is called on a `createTapRoot` root
 
 ## Concurrent mode

--- a/packages/ai-sdk/src/runtime/AISDKChat.test.ts
+++ b/packages/ai-sdk/src/runtime/AISDKChat.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { flushTapSync } from "@assistant-ui/tap";
-import { AuiConfig, createAssistantClient } from "@assistant-ui/store/client";
+import { flushTapSync, resource, useResource } from "@assistant-ui/tap";
+import { runtimeAdapterTransformScopes } from "@assistant-ui/core/store";
+import {
+  attachTransformScopes,
+  AuiConfig,
+  createAssistantClient,
+} from "@assistant-ui/store/client";
 import { AISDKChat } from "./AISDKChat";
 import {
   createCancellableTransport,
@@ -110,6 +115,57 @@ describe("AISDKChat as a standalone client config entry", () => {
     await vi.waitFor(() => {
       expect(getCancelCount()).toBe(1);
     });
+  });
+
+  it("releases a superseded chat when its resource hook is replaced", async () => {
+    const first = createCancellableTransport();
+    const second = createCancellableTransport();
+    function useFirst() {
+      return useResource(AISDKChat({ transport: first.transport }));
+    }
+    function useSecond() {
+      return useResource(AISDKChat({ transport: second.transport }));
+    }
+    attachTransformScopes(useFirst, runtimeAdapterTransformScopes);
+    attachTransformScopes(useSecond, runtimeAdapterTransformScopes);
+    const First = resource(useFirst);
+    const Second = resource(useSecond);
+    let config = AuiConfig({ threads: First() });
+    const listeners = new Set<() => void>();
+    const handle = createAssistantClient({
+      getConfig: () => config,
+      subscribe: (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    });
+    handle.subscribe(() => {});
+
+    let aui = handle.getClient();
+    flushTapSync(() => aui.composer.setText("first"));
+    flushTapSync(() => aui.composer.send());
+    await vi.waitFor(() => {
+      expect(aui.thread.getState().isRunning).toBe(true);
+    });
+
+    config = AuiConfig({ threads: Second() });
+    flushTapSync(() => listeners.forEach((listener) => listener()));
+    await vi.waitFor(() => {
+      expect(first.getCancelCount()).toBe(1);
+    });
+
+    aui = handle.getClient();
+    flushTapSync(() => aui.composer.setText("second"));
+    flushTapSync(() => aui.composer.send());
+    await vi.waitFor(() => {
+      expect(aui.thread.getState().isRunning).toBe(true);
+    });
+
+    handle.destroy();
+    await vi.waitFor(() => {
+      expect(second.getCancelCount()).toBe(1);
+    });
+    expect(first.getCancelCount()).toBe(1);
   });
 
   it("installs the RuntimeAdapter scope defaults", () => {

--- a/packages/ai-sdk/src/runtime/AISDKChat.test.ts
+++ b/packages/ai-sdk/src/runtime/AISDKChat.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { flushTapSync, resource, useResource } from "@assistant-ui/tap";
 import { runtimeAdapterTransformScopes } from "@assistant-ui/core/store";
+import { useAssistantClientDestroySignal } from "@assistant-ui/store/internal";
 import {
   attachTransformScopes,
   AuiConfig,
@@ -14,6 +15,7 @@ import {
 
 describe("AISDKChat as a standalone client config entry", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -120,10 +122,40 @@ describe("AISDKChat as a standalone client config entry", () => {
   it("releases a superseded chat when its resource hook is replaced", async () => {
     const first = createCancellableTransport();
     const second = createCancellableTransport();
+    const abortListeners = new Map<
+      AbortSignal,
+      Set<EventListenerOrEventListenerObject>
+    >();
+    const addEventListener = AbortSignal.prototype.addEventListener;
+    const removeEventListener = AbortSignal.prototype.removeEventListener;
+    vi.spyOn(AbortSignal.prototype, "addEventListener").mockImplementation(
+      function (this: AbortSignal, type, listener, options) {
+        if (type === "abort" && listener !== null) {
+          let listeners = abortListeners.get(this);
+          if (listeners === undefined) {
+            listeners = new Set();
+            abortListeners.set(this, listeners);
+          }
+          listeners.add(listener);
+        }
+        return addEventListener.call(this, type, listener, options);
+      },
+    );
+    vi.spyOn(AbortSignal.prototype, "removeEventListener").mockImplementation(
+      function (this: AbortSignal, type, listener, options) {
+        if (type === "abort" && listener !== null) {
+          abortListeners.get(this)?.delete(listener);
+        }
+        return removeEventListener.call(this, type, listener, options);
+      },
+    );
+    let destroySignal!: AbortSignal;
     function useFirst() {
+      destroySignal = useAssistantClientDestroySignal()!;
       return useResource(AISDKChat({ transport: first.transport }));
     }
     function useSecond() {
+      destroySignal = useAssistantClientDestroySignal()!;
       return useResource(AISDKChat({ transport: second.transport }));
     }
     attachTransformScopes(useFirst, runtimeAdapterTransformScopes);
@@ -141,27 +173,31 @@ describe("AISDKChat as a standalone client config entry", () => {
     });
     handle.subscribe(() => {});
 
-    let aui = handle.getClient();
-    flushTapSync(() => aui.composer.setText("first"));
-    flushTapSync(() => aui.composer.send());
-    await vi.waitFor(() => {
-      expect(aui.thread.getState().isRunning).toBe(true);
-    });
+    try {
+      let aui = handle.getClient();
+      flushTapSync(() => aui.composer.setText("first"));
+      flushTapSync(() => aui.composer.send());
+      await vi.waitFor(() => {
+        expect(aui.thread.getState().isRunning).toBe(true);
+      });
+      expect(abortListeners.get(destroySignal)?.size).toBe(1);
 
-    config = AuiConfig({ threads: Second() });
-    flushTapSync(() => listeners.forEach((listener) => listener()));
-    await vi.waitFor(() => {
-      expect(first.getCancelCount()).toBe(1);
-    });
+      config = AuiConfig({ threads: Second() });
+      flushTapSync(() => listeners.forEach((listener) => listener()));
+      await vi.waitFor(() => {
+        expect(first.getCancelCount()).toBe(1);
+      });
+      expect(abortListeners.get(destroySignal)?.size).toBe(1);
 
-    aui = handle.getClient();
-    flushTapSync(() => aui.composer.setText("second"));
-    flushTapSync(() => aui.composer.send());
-    await vi.waitFor(() => {
-      expect(aui.thread.getState().isRunning).toBe(true);
-    });
-
-    handle.destroy();
+      aui = handle.getClient();
+      flushTapSync(() => aui.composer.setText("second"));
+      flushTapSync(() => aui.composer.send());
+      await vi.waitFor(() => {
+        expect(aui.thread.getState().isRunning).toBe(true);
+      });
+    } finally {
+      handle.destroy();
+    }
     await vi.waitFor(() => {
       expect(second.getCancelCount()).toBe(1);
     });

--- a/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
@@ -183,6 +183,56 @@ describe("useChatRuntime integration", () => {
     view.unmount();
     await waitFor(() => expect(getCancelCount()).toBe(1));
   });
+
+  it("aborts a nested runtime when only its own panel unmounts", async () => {
+    const outer = createCancellableTransport();
+    const { transport, getCancelCount } = createCancellableTransport();
+    let nested: AssistantRuntime | undefined;
+    let setVisible: ((visible: boolean) => void) | undefined;
+
+    const NestedChat = () => {
+      nested = useChatRuntime({ transport });
+      return null;
+    };
+    const Shell = () => {
+      const [visible, set] = useState(true);
+      setVisible = set;
+      return (
+        <AuiProvider
+          config={AuiConfig({
+            threads: AISDKChat({ transport: outer.transport }),
+          })}
+        >
+          {visible && <NestedChat />}
+        </AuiProvider>
+      );
+    };
+
+    const view = render(<Shell />);
+    await waitFor(() => expect(nested).toBeDefined());
+    await act(async () => {
+      await nested!.thread.append("first stream");
+    });
+    await waitFor(() => expect(nested!.thread.getState().isRunning).toBe(true));
+
+    await act(async () => setVisible?.(false));
+    await waitFor(() => expect(getCancelCount()).toBe(1));
+
+    nested = undefined;
+    await act(async () => setVisible?.(true));
+    await waitFor(() => expect(nested).toBeDefined());
+    await act(async () => {
+      await nested!.thread.append("second stream");
+    });
+    await waitFor(() => expect(nested!.thread.getState().isRunning).toBe(true));
+
+    await act(async () => setVisible?.(false));
+    await waitFor(() => expect(getCancelCount()).toBe(2));
+
+    view.unmount();
+    await act(nextTask);
+    expect(getCancelCount()).toBe(2);
+  });
 });
 
 const StreamingApp = ({

--- a/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
@@ -52,7 +52,11 @@ const mocks = vi.hoisted(() => {
 });
 
 vi.mock("@ai-sdk/react", () => ({
-  useChat: mocks.useChat,
+  useChat: (...args: unknown[]) => {
+    const chat = mocks.useChat(...args);
+    chat.stop ??= vi.fn().mockResolvedValue(undefined);
+    return chat;
+  },
 }));
 
 vi.mock("@assistant-ui/core/react", async (importOriginal) => ({

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -54,6 +54,10 @@ export type ChatThreadEnvironment<UI_MESSAGE extends UIMessage = UIMessage> = {
   id: string;
   isMainThread: boolean;
   getThreadListItem: () => InitializableThreadListItem | undefined;
+  /**
+   * Stops the chat when the owning assistant client is destroyed. Permanent
+   * disposal of the hosting resource always stops the chat.
+   */
   stopOnClientDestroy?: boolean;
   /**
    * An externally owned chat instance. State lives on the instance, so it

--- a/packages/ai-sdk/src/runtime/useResourceCleanup.test.tsx
+++ b/packages/ai-sdk/src/runtime/useResourceCleanup.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resource, useResource } from "@assistant-ui/tap";
+import { useResourceCleanup } from "./useResourceCleanup";
+
+describe("useResourceCleanup", () => {
+  afterEach(cleanup);
+
+  it("cleans up permanent disposal when client-destroy cleanup is disabled", () => {
+    const dispose = vi.fn();
+    const First = resource(function useFirst() {
+      useResourceCleanup(false, dispose);
+      return null;
+    });
+    const Second = resource(function useSecond() {
+      return null;
+    });
+    function App({ first }: { first: boolean }) {
+      useResource(first ? First() : Second());
+      return null;
+    }
+
+    const { rerender } = render(<App first={true} />);
+    expect(dispose).not.toHaveBeenCalled();
+
+    rerender(<App first={false} />);
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ai-sdk/src/runtime/useResourceCleanup.ts
+++ b/packages/ai-sdk/src/runtime/useResourceCleanup.ts
@@ -1,32 +1,59 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { useResourceDispose } from "@assistant-ui/tap";
 import { useAssistantClientDestroySignal } from "@assistant-ui/store/internal";
 
 export const useResourceCleanup = (enabled: boolean, cleanup: () => void) => {
   const destroySignal = useAssistantClientDestroySignal();
-  const cleanupRef = useRef(cleanup);
-  const enabledRef = useRef(enabled);
-  const registeredSignalRef = useRef<AbortSignal | undefined>(undefined);
+  const stateRef = useRef<{
+    cleanup: () => void;
+    enabled: boolean;
+    cleaned: boolean;
+    registration: {
+      signal: AbortSignal;
+      listener: () => void;
+    } | null;
+  }>({ cleanup, enabled, cleaned: false, registration: null });
 
   useEffect(() => {
-    cleanupRef.current = cleanup;
-    enabledRef.current = enabled;
+    stateRef.current.cleanup = cleanup;
+    stateRef.current.enabled = enabled;
   });
 
+  const removeRegistration = useCallback(() => {
+    const state = stateRef.current;
+    const registration = state.registration;
+    if (registration === null) return;
+    state.registration = null;
+    registration.signal.removeEventListener("abort", registration.listener);
+  }, []);
+
+  const dispose = useCallback(() => {
+    const state = stateRef.current;
+    removeRegistration();
+    if (state.cleaned) return;
+    state.cleaned = true;
+    if (state.enabled) state.cleanup();
+  }, [removeRegistration]);
+
+  useResourceDispose(dispose);
+
   useEffect(() => {
-    if (!enabled || !destroySignal) return undefined;
-    if (registeredSignalRef.current === destroySignal) return undefined;
+    const current = stateRef.current.registration;
+    if (current !== null && (current.signal !== destroySignal || !enabled)) {
+      removeRegistration();
+    }
+    if (!enabled || !destroySignal || stateRef.current.cleaned) {
+      return undefined;
+    }
+    if (stateRef.current.registration?.signal === destroySignal) {
+      return undefined;
+    }
 
-    registeredSignalRef.current = destroySignal;
-    destroySignal.addEventListener(
-      "abort",
-      () => {
-        if (enabledRef.current) cleanupRef.current();
-      },
-      { once: true },
-    );
+    const listener = () => dispose();
+    stateRef.current.registration = { signal: destroySignal, listener };
+    if (destroySignal.aborted) dispose();
+    else destroySignal.addEventListener("abort", listener, { once: true });
 
-    // The listener must survive standalone soft unmounts so a later permanent
-    // client destroy still cleans up the retained resource state.
     return undefined;
-  }, [destroySignal, enabled]);
+  }, [destroySignal, dispose, enabled, removeRegistration]);
 };

--- a/packages/ai-sdk/src/runtime/useResourceCleanup.ts
+++ b/packages/ai-sdk/src/runtime/useResourceCleanup.ts
@@ -6,17 +6,15 @@ export const useResourceCleanup = (enabled: boolean, cleanup: () => void) => {
   const destroySignal = useAssistantClientDestroySignal();
   const stateRef = useRef<{
     cleanup: () => void;
-    enabled: boolean;
     cleaned: boolean;
     registration: {
       signal: AbortSignal;
       listener: () => void;
     } | null;
-  }>({ cleanup, enabled, cleaned: false, registration: null });
+  }>({ cleanup, cleaned: false, registration: null });
 
   useEffect(() => {
     stateRef.current.cleanup = cleanup;
-    stateRef.current.enabled = enabled;
   });
 
   const removeRegistration = useCallback(() => {
@@ -32,7 +30,7 @@ export const useResourceCleanup = (enabled: boolean, cleanup: () => void) => {
     removeRegistration();
     if (state.cleaned) return;
     state.cleaned = true;
-    if (state.enabled) state.cleanup();
+    state.cleanup();
   }, [removeRegistration]);
 
   useResourceDispose(dispose);

--- a/packages/tap/src/__tests__/basic/resource-dispose.basic.test.ts
+++ b/packages/tap/src/__tests__/basic/resource-dispose.basic.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resource } from "../../core/resource";
+import { createTapRoot } from "../../core/createTapRoot";
+import { withKey } from "../../core/withKey";
+import { useResource } from "../../hooks/useResource";
+import { useResourceDispose } from "../../hooks/useResourceDispose";
+import { useResources } from "../../hooks/useResources";
+import {
+  cleanupAllResources,
+  createTestResource,
+  renderTest,
+  waitForNextTick,
+} from "../test-utils";
+
+describe("resource disposal", () => {
+  afterEach(cleanupAllResources);
+
+  it("disposes the previous hook when useResource replaces it", () => {
+    const disposeFirst = vi.fn();
+    const disposeSecond = vi.fn();
+    const First = resource(function useFirst() {
+      useResourceDispose(disposeFirst);
+    });
+    const Second = resource(function useSecond() {
+      useResourceDispose(disposeSecond);
+    });
+    const parent = createTestResource((second: boolean) =>
+      useResource(second ? Second() : First()),
+    );
+
+    renderTest(parent, false);
+    renderTest(parent, true);
+
+    expect(disposeFirst).toHaveBeenCalledOnce();
+    expect(disposeSecond).not.toHaveBeenCalled();
+  });
+
+  it("disposes nested resources with their owner", () => {
+    const disposeInner = vi.fn();
+    const Inner = resource(function useInner() {
+      useResourceDispose(disposeInner);
+    });
+    const First = resource(function useFirst() {
+      return useResource(Inner());
+    });
+    const Second = resource(function useSecond() {});
+    const parent = createTestResource((second: boolean) =>
+      useResource(second ? Second() : First()),
+    );
+
+    renderTest(parent, false);
+    renderTest(parent, true);
+
+    expect(disposeInner).toHaveBeenCalledOnce();
+  });
+
+  it("disposes keyed resources when they are replaced or removed", () => {
+    const disposeFirst = vi.fn();
+    const disposeSecond = vi.fn();
+    const First = resource(function useFirst() {
+      useResourceDispose(disposeFirst);
+    });
+    const Second = resource(function useSecond() {
+      useResourceDispose(disposeSecond);
+    });
+    const parent = createTestResource((state: "first" | "second" | "removed") =>
+      useResources(
+        state === "removed"
+          ? []
+          : [withKey("item", state === "first" ? First() : Second())],
+      ),
+    );
+
+    renderTest(parent, "first");
+    renderTest(parent, "second");
+    expect(disposeFirst).toHaveBeenCalledOnce();
+    expect(disposeSecond).not.toHaveBeenCalled();
+
+    renderTest(parent, "removed");
+    expect(disposeSecond).toHaveBeenCalledOnce();
+  });
+
+  it("disposes an explicitly unmounted root", () => {
+    const dispose = vi.fn();
+    const root = createTapRoot(function Root() {
+      useResourceDispose(dispose);
+    });
+
+    root.unmount();
+
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("preserves disposal callbacks across mount-on-subscribe soft unmounts", async () => {
+    const dispose = vi.fn();
+    const root = createTapRoot(
+      function Root() {
+        useResourceDispose(dispose);
+      },
+      { mountOnSubscribe: true },
+    );
+
+    const unsubscribe = root.subscribe(() => {});
+    unsubscribe();
+    await waitForNextTick();
+    expect(dispose).not.toHaveBeenCalled();
+
+    const unsubscribeAgain = root.subscribe(() => {});
+    expect(dispose).not.toHaveBeenCalled();
+    unsubscribeAgain();
+    await waitForNextTick();
+  });
+});

--- a/packages/tap/src/__tests__/basic/resource-dispose.basic.test.ts
+++ b/packages/tap/src/__tests__/basic/resource-dispose.basic.test.ts
@@ -1,10 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resource } from "../../core/resource";
+import {
+  disposeResourceFiber,
+  unmountResourceFiber,
+} from "../../core/ResourceFiber";
 import { createTapRoot } from "../../core/createTapRoot";
+import { flushTapSync } from "../../core/scheduler";
 import { withKey } from "../../core/withKey";
 import { useResource } from "../../hooks/useResource";
 import { useResourceDispose } from "../../hooks/useResourceDispose";
 import { useResources } from "../../hooks/useResources";
+import { useTapHost } from "../../hooks/useTapHost";
+import { useTapRoot } from "../../hooks/useTapRoot";
+import { useEffect } from "../../react-hooks/useEffect";
+import { useState } from "../../react-hooks/useState";
 import {
   cleanupAllResources,
   createTestResource,
@@ -54,6 +63,40 @@ describe("resource disposal", () => {
     expect(disposeInner).toHaveBeenCalledOnce();
   });
 
+  it.each(["useResource", "useResources", "useTapRoot", "useTapHost"] as const)(
+    "disposes %s children after their owner was soft-unmounted",
+    (hostKind) => {
+      const dispose = vi.fn();
+      const Child = resource(function useChild() {
+        useResourceDispose(dispose);
+      });
+      const useResourceHost = () => useResource(Child());
+      const useResourcesHost = () => useResources([withKey("child", Child())]);
+      const useTapRootHost = () =>
+        useTapRoot(function ChildRoot() {
+          useResourceDispose(dispose);
+        });
+      const useTapHostHost = () =>
+        useTapHost(function ChildHost() {
+          useResourceDispose(dispose);
+        });
+      const hosts = {
+        useResource: useResourceHost,
+        useResources: useResourcesHost,
+        useTapRoot: useTapRootHost,
+        useTapHost: useTapHostHost,
+      };
+      const owner = createTestResource(hosts[hostKind]);
+
+      renderTest(owner);
+      unmountResourceFiber(owner);
+      expect(dispose).not.toHaveBeenCalled();
+
+      disposeResourceFiber(owner);
+      expect(dispose).toHaveBeenCalledOnce();
+    },
+  );
+
   it("disposes keyed resources when they are replaced or removed", () => {
     const disposeFirst = vi.fn();
     const disposeSecond = vi.fn();
@@ -91,6 +134,28 @@ describe("resource disposal", () => {
     expect(dispose).toHaveBeenCalledOnce();
   });
 
+  it("does not re-run cleanup or setup after cleanup disposes its root", () => {
+    const setup = vi.fn();
+    let root: { unmount: () => void } | undefined;
+    const effectCleanup = vi.fn(() => root?.unmount());
+    let setVersion!: (version: number) => void;
+    root = createTapRoot(function Root() {
+      const [version, set] = useState(0);
+      setVersion = set;
+      useEffect(() => {
+        setup();
+        return effectCleanup;
+      }, [version]);
+    });
+    setup.mockClear();
+    effectCleanup.mockClear();
+
+    flushTapSync(() => setVersion(1));
+
+    expect(effectCleanup).toHaveBeenCalledOnce();
+    expect(setup).not.toHaveBeenCalled();
+  });
+
   it("preserves disposal callbacks across mount-on-subscribe soft unmounts", async () => {
     const dispose = vi.fn();
     const root = createTapRoot(
@@ -109,5 +174,6 @@ describe("resource disposal", () => {
     expect(dispose).not.toHaveBeenCalled();
     unsubscribeAgain();
     await waitForNextTick();
+    expect(dispose).not.toHaveBeenCalled();
   });
 });

--- a/packages/tap/src/__tests__/react/resource-dispose.test.tsx
+++ b/packages/tap/src/__tests__/react/resource-dispose.test.tsx
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { Activity, StrictMode } from "react";
+import {
+  resource,
+  useResource,
+  useResourceDispose,
+  useResources,
+  useTapHost,
+  useTapRoot,
+  withKey,
+} from "../../index";
+import { useState as useTapState } from "../../react-hooks/useState";
+
+type Counter = {
+  count: number;
+  setCount: (count: number) => void;
+};
+
+const hostKinds = [
+  "useResource",
+  "useResources",
+  "useTapRoot",
+  "useTapHost",
+] as const;
+
+type HostKind = (typeof hostKinds)[number];
+
+const createHosts = (
+  dispose: () => void,
+  setRead: (read: () => Counter) => void,
+): Record<HostKind, () => null> => {
+  const useTracked = () => {
+    const [count, setCount] = useTapState(0);
+    useResourceDispose(dispose);
+    return { count, setCount };
+  };
+  const Tracked = resource(useTracked);
+
+  function ResourceHost() {
+    const value = useResource(Tracked());
+    setRead(() => value);
+    return null;
+  }
+
+  function ResourcesHost() {
+    const [value] = useResources([withKey("tracked", Tracked())]);
+    setRead(() => value!);
+    return null;
+  }
+
+  function TapRootHost() {
+    const root = useTapRoot(function TrackedRoot() {
+      return useTracked();
+    });
+    setRead(root.getValue);
+    return null;
+  }
+
+  function TapHostHost() {
+    const { value } = useTapHost(function TrackedHost() {
+      return useTracked();
+    });
+    setRead(() => value);
+    return null;
+  }
+
+  return {
+    useResource: ResourceHost,
+    useResources: ResourcesHost,
+    useTapRoot: TapRootHost,
+    useTapHost: TapHostHost,
+  };
+};
+
+describe("useResourceDispose in React hosts", () => {
+  afterEach(cleanup);
+
+  it.each(hostKinds)(
+    "%s preserves resources while Activity is hidden and disposes on deletion",
+    (hostKind) => {
+      const dispose = vi.fn();
+      let read!: () => Counter;
+      const Host = createHosts(dispose, (nextRead) => {
+        read = nextRead;
+      })[hostKind];
+      function App({ hidden }: { hidden: boolean }) {
+        return (
+          <Activity mode={hidden ? "hidden" : "visible"}>
+            <Host />
+          </Activity>
+        );
+      }
+
+      const { rerender, unmount } = render(<App hidden={false} />);
+      expect(read().count).toBe(0);
+
+      rerender(<App hidden={true} />);
+      expect(dispose).not.toHaveBeenCalled();
+      act(() => read().setCount(1));
+
+      rerender(<App hidden={false} />);
+      expect(read().count).toBe(1);
+      expect(dispose).not.toHaveBeenCalled();
+
+      unmount();
+      expect(dispose).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(hostKinds)(
+    "%s does not dispose during a StrictMode mount replay",
+    (hostKind) => {
+      const dispose = vi.fn();
+      const Host = createHosts(dispose, () => {})[hostKind];
+
+      const { unmount } = render(
+        <StrictMode>
+          <Host />
+        </StrictMode>,
+      );
+
+      expect(dispose).not.toHaveBeenCalled();
+      unmount();
+      expect(dispose).toHaveBeenCalledOnce();
+    },
+  );
+});

--- a/packages/tap/src/__tests__/react/resource-dispose.test.tsx
+++ b/packages/tap/src/__tests__/react/resource-dispose.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, render } from "@testing-library/react";
-import { Activity, StrictMode } from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { Activity, Component, StrictMode, type ReactNode } from "react";
 import {
   resource,
   useResource,
@@ -25,6 +25,25 @@ const hostKinds = [
 ] as const;
 
 type HostKind = (typeof hostKinds)[number];
+
+class ErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    return this.state.error ? (
+      <div role="alert">{this.state.error.message}</div>
+    ) : (
+      this.props.children
+    );
+  }
+}
 
 const createHosts = (
   dispose: () => void,
@@ -74,7 +93,10 @@ const createHosts = (
 };
 
 describe("useResourceDispose in React hosts", () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
 
   it.each(hostKinds)(
     "%s preserves resources while Activity is hidden and disposes on deletion",
@@ -125,4 +147,22 @@ describe("useResourceDispose in React hosts", () => {
       expect(dispose).toHaveBeenCalledOnce();
     },
   );
+
+  it("routes direct React-host disposal errors through React", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    function Host() {
+      useResourceDispose(() => {
+        throw new Error("dispose failed");
+      });
+      return null;
+    }
+    function App({ show }: { show: boolean }) {
+      return <ErrorBoundary>{show ? <Host /> : null}</ErrorBoundary>;
+    }
+
+    const { rerender } = render(<App show={true} />);
+    rerender(<App show={false} />);
+
+    expect(screen.getByRole("alert").textContent).toBe("dispose failed");
+  });
 });

--- a/packages/tap/src/__tests__/react/resource-dispose.test.tsx
+++ b/packages/tap/src/__tests__/react/resource-dispose.test.tsx
@@ -216,4 +216,31 @@ describe("useResourceDispose in React hosts", () => {
 
     expect(screen.getByRole("alert").textContent).toBe("dispose failed");
   });
+
+  it("routes hidden React-host disposal errors through React", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    function Host() {
+      useResourceDispose(() => {
+        throw new Error("hidden dispose failed");
+      });
+      return null;
+    }
+    function App({ hidden, show }: { hidden: boolean; show: boolean }) {
+      return (
+        <ErrorBoundary>
+          {show ? (
+            <Activity mode={hidden ? "hidden" : "visible"}>
+              <Host />
+            </Activity>
+          ) : null}
+        </ErrorBoundary>
+      );
+    }
+
+    const { rerender } = render(<App hidden={false} show={true} />);
+    rerender(<App hidden={true} show={true} />);
+    rerender(<App hidden={true} show={false} />);
+
+    expect(screen.getByRole("alert").textContent).toBe("hidden dispose failed");
+  });
 });

--- a/packages/tap/src/__tests__/react/resource-dispose.test.tsx
+++ b/packages/tap/src/__tests__/react/resource-dispose.test.tsx
@@ -3,6 +3,7 @@ import { act, cleanup, render, screen } from "@testing-library/react";
 import { Activity, Component, StrictMode, type ReactNode } from "react";
 import {
   resource,
+  flushTapSync,
   useResource,
   useResourceDispose,
   useResources,
@@ -119,7 +120,13 @@ describe("useResourceDispose in React hosts", () => {
 
       rerender(<App hidden={true} />);
       expect(dispose).not.toHaveBeenCalled();
-      act(() => read().setCount(1));
+      act(() => {
+        if (hostKind === "useTapRoot") {
+          flushTapSync(() => read().setCount(1));
+        } else {
+          read().setCount(1);
+        }
+      });
 
       rerender(<App hidden={false} />);
       expect(read().count).toBe(1);
@@ -129,6 +136,50 @@ describe("useResourceDispose in React hosts", () => {
       expect(dispose).toHaveBeenCalledOnce();
     },
   );
+
+  it.each(hostKinds)(
+    "%s disposes when deleted while Activity remains hidden",
+    async (hostKind) => {
+      const dispose = vi.fn();
+      const Host = createHosts(dispose, () => {})[hostKind];
+      function App({ hidden }: { hidden: boolean }) {
+        return (
+          <Activity mode={hidden ? "hidden" : "visible"}>
+            <Host />
+          </Activity>
+        );
+      }
+
+      const { rerender, unmount } = render(<App hidden={false} />);
+      rerender(<App hidden={true} />);
+      expect(dispose).not.toHaveBeenCalled();
+
+      unmount();
+      await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce());
+    },
+  );
+
+  it("disposes a direct React host deleted while Activity remains hidden", async () => {
+    const dispose = vi.fn();
+    function Host() {
+      useResourceDispose(dispose);
+      return null;
+    }
+    function App({ hidden }: { hidden: boolean }) {
+      return (
+        <Activity mode={hidden ? "hidden" : "visible"}>
+          <Host />
+        </Activity>
+      );
+    }
+
+    const { rerender, unmount } = render(<App hidden={false} />);
+    rerender(<App hidden={true} />);
+    expect(dispose).not.toHaveBeenCalled();
+
+    unmount();
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce());
+  });
 
   it.each(hostKinds)(
     "%s does not dispose during a StrictMode mount replay",

--- a/packages/tap/src/__tests__/react/resource-dispose.test.tsx
+++ b/packages/tap/src/__tests__/react/resource-dispose.test.tsx
@@ -243,4 +243,36 @@ describe("useResourceDispose in React hosts", () => {
 
     expect(screen.getByRole("alert").textContent).toBe("hidden dispose failed");
   });
+
+  it.each(hostKinds)(
+    "%s routes hidden resource disposal errors through React",
+    (hostKind) => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      const Host = createHosts(
+        () => {
+          throw new Error("hidden resource dispose failed");
+        },
+        () => {},
+      )[hostKind];
+      function App({ hidden, show }: { hidden: boolean; show: boolean }) {
+        return (
+          <ErrorBoundary>
+            {show ? (
+              <Activity mode={hidden ? "hidden" : "visible"}>
+                <Host />
+              </Activity>
+            ) : null}
+          </ErrorBoundary>
+        );
+      }
+
+      const { rerender } = render(<App hidden={false} show={true} />);
+      rerender(<App hidden={true} show={true} />);
+      rerender(<App hidden={true} show={false} />);
+
+      expect(screen.getByRole("alert").textContent).toBe(
+        "hidden resource dispose failed",
+      );
+    },
+  );
 });

--- a/packages/tap/src/__tests__/react/resource-dispose.test.tsx
+++ b/packages/tap/src/__tests__/react/resource-dispose.test.tsx
@@ -31,13 +31,13 @@ class ErrorBoundary extends Component<
   { children: ReactNode },
   { error: Error | null }
 > {
-  state = { error: null };
+  override state: { error: Error | null } = { error: null };
 
   static getDerivedStateFromError(error: Error) {
     return { error };
   }
 
-  render() {
+  override render() {
     return this.state.error ? (
       <div role="alert">{this.state.error.message}</div>
     ) : (

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -9,6 +9,7 @@ import { withResourceFiber } from "./helpers/execution-context";
 import { withReactDispatcher } from "./react-dispatcher";
 import { isDevelopment } from "./helpers/env";
 import { commitRoot } from "./helpers/root";
+import { throwAggregated } from "./helpers/throwAggregated";
 
 export function createResourceFiber<R>(
   hook: (...args: any[]) => R,
@@ -23,6 +24,7 @@ export function createResourceFiber<R>(
     devStrictMode: strictMode,
     cells: [],
     effectCells: [],
+    disposeCallbacks: new Set(),
     contextDeps: null,
     wipContextDeps: null,
     wipCommitCallbacks: null,
@@ -35,6 +37,8 @@ export function createResourceFiber<R>(
     currentIndex: 0,
     isFirstRender: true,
     isMounted: false,
+    isDisposePending: false,
+    isDisposing: false,
     isNeverMounted: true,
   };
 }
@@ -52,6 +56,35 @@ export function unmountResourceFiber<R>(fiber: ResourceFiber<R>): void {
 
   fiber.isMounted = false;
   cleanupAllEffects(fiber);
+}
+
+export function disposeResourceFiber<R>(fiber: ResourceFiber<R>): void {
+  if (fiber.isDisposing) return;
+  fiber.isDisposePending = false;
+  fiber.isDisposing = true;
+
+  const errors: unknown[] = [];
+  try {
+    unmountResourceFiber(fiber);
+  } catch (error) {
+    errors.push(error);
+  }
+
+  const callbacks = [...fiber.disposeCallbacks];
+  fiber.disposeCallbacks.clear();
+  for (const callback of callbacks) {
+    try {
+      callback();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  throwAggregated(errors, "Errors during resource disposal");
+}
+
+export function markResourceFiberForDisposal<R>(fiber: ResourceFiber<R>): void {
+  if (!fiber.isDisposing) fiber.isDisposePending = true;
 }
 
 export function renderResourceFiber<R>(

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -96,6 +96,16 @@ export function markResourceFiberForDisposal<R>(fiber: ResourceFiber<R>): void {
   if (!fiber.isDisposing) fiber.isDisposePending = true;
 }
 
+export function scheduleResourceFiberDisposal<R>(
+  fiber: ResourceFiber<R>,
+): void {
+  markResourceFiberForDisposal(fiber);
+  if (!fiber.isMounted) {
+    // A hidden React subtree has already consumed its passive cleanup.
+    queueMicrotask(() => disposeResourceFiber(fiber));
+  }
+}
+
 export function attachResourceFiberToParent<R>(
   fiber: ResourceFiber<R>,
   parent: ResourceFiber<unknown>,

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -102,7 +102,7 @@ export function scheduleResourceFiberDisposal<R>(
   markResourceFiberForDisposal(fiber);
   if (!fiber.isMounted) {
     // A hidden React subtree has already consumed its passive cleanup.
-    queueMicrotask(() => disposeResourceFiber(fiber));
+    disposeResourceFiber(fiber);
   }
 }
 

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -11,6 +11,15 @@ import { isDevelopment } from "./helpers/env";
 import { commitRoot } from "./helpers/root";
 import { throwAggregated } from "./helpers/throwAggregated";
 
+const parentDisposalLinks = new WeakMap<
+  ResourceFiber<unknown>,
+  {
+    parent: ResourceFiber<unknown>;
+    dispose: () => void;
+    unlink: () => void;
+  }
+>();
+
 export function createResourceFiber<R>(
   hook: (...args: any[]) => R,
   root: TapRoot,
@@ -87,6 +96,27 @@ export function markResourceFiberForDisposal<R>(fiber: ResourceFiber<R>): void {
   if (!fiber.isDisposing) fiber.isDisposePending = true;
 }
 
+export function attachResourceFiberToParent<R>(
+  fiber: ResourceFiber<R>,
+  parent: ResourceFiber<unknown>,
+): void {
+  const existing = parentDisposalLinks.get(fiber);
+  if (existing?.parent === parent) return;
+  if (existing !== undefined) {
+    existing.parent.disposeCallbacks.delete(existing.dispose);
+    fiber.disposeCallbacks.delete(existing.unlink);
+  }
+
+  const dispose = () => disposeResourceFiber(fiber);
+  const unlink = () => {
+    parent.disposeCallbacks.delete(dispose);
+    parentDisposalLinks.delete(fiber);
+  };
+  parent.disposeCallbacks.add(dispose);
+  fiber.disposeCallbacks.add(unlink);
+  parentDisposalLinks.set(fiber, { parent, dispose, unlink });
+}
+
 export function renderResourceFiber<R>(
   fiber: ResourceFiber<R>,
   args: readonly unknown[],
@@ -124,6 +154,7 @@ export function renderResourceFiber<R>(
 }
 
 export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
+  if (fiber.isDisposing) return;
   const commitCallbacks = fiber.wipCommitCallbacks;
   fiber.wipCommitCallbacks = null;
   const strictReplay =

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -1,5 +1,6 @@
 import {
   createResourceFiber,
+  disposeResourceFiber,
   unmountResourceFiber,
   renderResourceFiber,
   commitResourceFiber,
@@ -62,7 +63,7 @@ export const createTapRoot = <R>(
 
     return {
       ...root,
-      unmount: () => unmountResourceFiber(fiber),
+      unmount: () => disposeResourceFiber(fiber),
     };
   }
 

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -16,7 +16,7 @@ export function commitAllCallbacks(callbacks: CommitCallbacks): void {
   throwAggregated(errors, "Errors during commit");
 }
 
-function setupEffect(cell: EffectCell): void {
+function setupEffect(fiber: ResourceFiber<unknown>, cell: EffectCell): void {
   const setup = cell.setup!;
   const deps = cell.setupDeps;
   const generation = cell.generation;
@@ -31,7 +31,7 @@ function setupEffect(cell: EffectCell): void {
     }
     cleanup = result;
   } finally {
-    if (cell.generation === generation) {
+    if (cell.generation === generation && !fiber.isDisposing) {
       cell.cleanup = cleanup;
       cell.deps = deps;
     } else {
@@ -58,19 +58,23 @@ export function reconcileEffects<R>(fiber: ResourceFiber<R>): void {
   for (const cell of pending) {
     cell.deps = null;
     if (cell.cleanup === undefined) continue;
+    const cleanup = cell.cleanup;
+    cell.cleanup = undefined;
     try {
-      cell.cleanup();
+      cleanup();
     } catch (e) {
       errors.push(e);
-    } finally {
-      cell.cleanup = undefined;
     }
+    if (fiber.isDisposing) break;
   }
-  for (const cell of pending) {
-    try {
-      setupEffect(cell);
-    } catch (e) {
-      errors.push(e);
+  if (!fiber.isDisposing) {
+    for (const cell of pending) {
+      try {
+        setupEffect(fiber, cell);
+      } catch (e) {
+        errors.push(e);
+      }
+      if (fiber.isDisposing) break;
     }
   }
 

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -95,6 +95,7 @@ export interface ResourceFiber<R> {
 
   cells: Cell[];
   effectCells: EffectCell[];
+  disposeCallbacks: Set<() => void>;
 
   wipContextDeps: ResourceContextDeps | null;
   contextDeps: ResourceContextDeps | null;
@@ -113,6 +114,8 @@ export interface ResourceFiber<R> {
   renderPendingCells: Set<ReducerCell> | null;
 
   isMounted: boolean;
+  isDisposePending: boolean;
+  isDisposing: boolean;
   isFirstRender: boolean;
   isNeverMounted: boolean;
 }

--- a/packages/tap/src/hooks/useResource.ts
+++ b/packages/tap/src/hooks/useResource.ts
@@ -1,17 +1,22 @@
 import type { ExtractResourceReturnType, ResourceElement } from "../core/types";
 import {
+  disposeResourceFiber,
+  markResourceFiberForDisposal,
   unmountResourceFiber,
   renderResourceFiber,
   commitResourceFiber,
 } from "../core/ResourceFiber";
 import { hasContextDepsChanged } from "../core/context";
 import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
-import { useEffect, useMemo } from "react";
+import { useEffect, useInsertionEffect, useMemo, useRef } from "react";
 import { useRenderMemo } from "./utils/useRenderMemo";
+import { peekResourceFiber } from "../core/helpers/execution-context";
+import { addCommit } from "../core/helpers/root";
 
 export function useResource<E extends ResourceElement<any>>(
   element: E,
 ): ExtractResourceReturnType<E> {
+  const parentFiber = peekResourceFiber();
   const { version, createFiber } = useResourceFiberHost();
   const fiber = useMemo(() => {
     return createFiber(element.hook, element.key);
@@ -23,7 +28,41 @@ export function useResource<E extends ResourceElement<any>>(
     hasContextDepsChanged(fiber),
   );
 
-  useEffect(() => () => unmountResourceFiber(fiber), [fiber]);
+  useInsertionEffect(() => {
+    if (parentFiber !== null) return undefined;
+    return () => disposeResourceFiber(fiber);
+  }, [fiber, parentFiber]);
+
+  const committedFiberRef = useRef<typeof fiber | null>(null);
+  const committedFiber = committedFiberRef.current;
+  if (
+    parentFiber !== null &&
+    committedFiber !== null &&
+    committedFiber !== fiber
+  ) {
+    addCommit(parentFiber, () => markResourceFiberForDisposal(committedFiber));
+  }
+
+  useEffect(() => {
+    const previous = committedFiberRef.current;
+    committedFiberRef.current = fiber;
+    if (
+      previous !== null &&
+      previous !== fiber &&
+      (parentFiber === null || previous.isDisposePending)
+    ) {
+      disposeResourceFiber(previous);
+    }
+  }, [fiber, parentFiber]);
+
+  useEffect(
+    () => () => {
+      if (fiber.isDisposePending || parentFiber?.isDisposing) {
+        disposeResourceFiber(fiber);
+      } else unmountResourceFiber(fiber);
+    },
+    [fiber, parentFiber],
+  );
   useEffect(() => {
     void result;
     commitResourceFiber(fiber);

--- a/packages/tap/src/hooks/useResource.ts
+++ b/packages/tap/src/hooks/useResource.ts
@@ -30,7 +30,7 @@ export function useResource<E extends ResourceElement<any>>(
 
   useInsertionEffect(() => {
     if (parentFiber !== null) return undefined;
-    return () => disposeResourceFiber(fiber);
+    return () => markResourceFiberForDisposal(fiber);
   }, [fiber, parentFiber]);
 
   const committedFiberRef = useRef<typeof fiber | null>(null);
@@ -44,16 +44,8 @@ export function useResource<E extends ResourceElement<any>>(
   }
 
   useEffect(() => {
-    const previous = committedFiberRef.current;
     committedFiberRef.current = fiber;
-    if (
-      previous !== null &&
-      previous !== fiber &&
-      (parentFiber === null || previous.isDisposePending)
-    ) {
-      disposeResourceFiber(previous);
-    }
-  }, [fiber, parentFiber]);
+  }, [fiber]);
 
   useEffect(
     () => () => {

--- a/packages/tap/src/hooks/useResource.ts
+++ b/packages/tap/src/hooks/useResource.ts
@@ -1,5 +1,6 @@
 import type { ExtractResourceReturnType, ResourceElement } from "../core/types";
 import {
+  attachResourceFiberToParent,
   disposeResourceFiber,
   markResourceFiberForDisposal,
   unmountResourceFiber,
@@ -47,14 +48,14 @@ export function useResource<E extends ResourceElement<any>>(
     committedFiberRef.current = fiber;
   }, [fiber]);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    if (parentFiber !== null) attachResourceFiberToParent(fiber, parentFiber);
+    return () => {
       if (fiber.isDisposePending || parentFiber?.isDisposing) {
         disposeResourceFiber(fiber);
       } else unmountResourceFiber(fiber);
-    },
-    [fiber, parentFiber],
-  );
+    };
+  }, [fiber, parentFiber]);
   useEffect(() => {
     void result;
     commitResourceFiber(fiber);

--- a/packages/tap/src/hooks/useResource.ts
+++ b/packages/tap/src/hooks/useResource.ts
@@ -29,14 +29,10 @@ export function useResource<E extends ResourceElement<any>>(
     hasContextDepsChanged(fiber),
   );
 
-  if (parentFiber === null) {
-    // The React-hosted or Tap-hosted execution path is invariant.
-    // oxlint-disable-next-line react-hooks/rules-of-hooks
-    useInsertionEffect(
-      () => () => scheduleResourceFiberDisposal(fiber),
-      [fiber],
-    );
-  }
+  useInsertionEffect(() => {
+    if (parentFiber !== null) return undefined;
+    return () => scheduleResourceFiberDisposal(fiber);
+  }, [fiber, parentFiber]);
 
   const committedFiberRef = useRef<typeof fiber | null>(null);
   const committedFiber = committedFiberRef.current;

--- a/packages/tap/src/hooks/useResource.ts
+++ b/packages/tap/src/hooks/useResource.ts
@@ -29,10 +29,14 @@ export function useResource<E extends ResourceElement<any>>(
     hasContextDepsChanged(fiber),
   );
 
-  useInsertionEffect(() => {
-    if (parentFiber !== null) return undefined;
-    return () => scheduleResourceFiberDisposal(fiber);
-  }, [fiber, parentFiber]);
+  if (parentFiber === null) {
+    // The React-hosted or Tap-hosted execution path is invariant.
+    // oxlint-disable-next-line react-hooks/rules-of-hooks
+    useInsertionEffect(
+      () => () => scheduleResourceFiberDisposal(fiber),
+      [fiber],
+    );
+  }
 
   const committedFiberRef = useRef<typeof fiber | null>(null);
   const committedFiber = committedFiberRef.current;

--- a/packages/tap/src/hooks/useResource.ts
+++ b/packages/tap/src/hooks/useResource.ts
@@ -2,7 +2,7 @@ import type { ExtractResourceReturnType, ResourceElement } from "../core/types";
 import {
   attachResourceFiberToParent,
   disposeResourceFiber,
-  markResourceFiberForDisposal,
+  scheduleResourceFiberDisposal,
   unmountResourceFiber,
   renderResourceFiber,
   commitResourceFiber,
@@ -31,7 +31,7 @@ export function useResource<E extends ResourceElement<any>>(
 
   useInsertionEffect(() => {
     if (parentFiber !== null) return undefined;
-    return () => markResourceFiberForDisposal(fiber);
+    return () => scheduleResourceFiberDisposal(fiber);
   }, [fiber, parentFiber]);
 
   const committedFiberRef = useRef<typeof fiber | null>(null);
@@ -41,7 +41,7 @@ export function useResource<E extends ResourceElement<any>>(
     committedFiber !== null &&
     committedFiber !== fiber
   ) {
-    addCommit(parentFiber, () => markResourceFiberForDisposal(committedFiber));
+    addCommit(parentFiber, () => scheduleResourceFiberDisposal(committedFiber));
   }
 
   useEffect(() => {

--- a/packages/tap/src/hooks/useResourceDispose.ts
+++ b/packages/tap/src/hooks/useResourceDispose.ts
@@ -13,19 +13,32 @@ const useTapResourceDispose = (
 
 const useReactHostDispose = (callback: () => void) => {
   const disposePendingRef = useRef(false);
+  const passiveMountedRef = useRef(false);
+  const disposedRef = useRef(false);
+  const runDispose = useRef(() => {
+    if (disposedRef.current) return;
+    disposedRef.current = true;
+    callback();
+  }).current;
 
   useInsertionEffect(
     () => () => {
-      disposePendingRef.current = true;
+      if (passiveMountedRef.current) {
+        disposePendingRef.current = true;
+      } else {
+        // A hidden React subtree has already consumed its passive cleanup.
+        queueMicrotask(runDispose);
+      }
     },
-    [],
+    [runDispose],
   );
-  useEffect(
-    () => () => {
-      if (disposePendingRef.current) callback();
-    },
-    [callback],
-  );
+  useEffect(() => {
+    passiveMountedRef.current = true;
+    return () => {
+      passiveMountedRef.current = false;
+      if (disposePendingRef.current) runDispose();
+    };
+  }, [runDispose]);
 };
 
 /**

--- a/packages/tap/src/hooks/useResourceDispose.ts
+++ b/packages/tap/src/hooks/useResourceDispose.ts
@@ -1,45 +1,5 @@
 import { useEffect, useInsertionEffect, useRef } from "react";
 import { peekResourceFiber } from "../core/helpers/execution-context";
-import type { ResourceFiber } from "../core/types";
-
-const useTapResourceDispose = (
-  fiber: ResourceFiber<unknown>,
-  callback: () => void,
-) => {
-  useEffect(() => {
-    fiber.disposeCallbacks.add(callback);
-  }, [callback, fiber]);
-};
-
-const useReactHostDispose = (callback: () => void) => {
-  const disposePendingRef = useRef(false);
-  const passiveMountedRef = useRef(false);
-  const disposedRef = useRef(false);
-  const runDispose = useRef(() => {
-    if (disposedRef.current) return;
-    disposedRef.current = true;
-    callback();
-  }).current;
-
-  useInsertionEffect(
-    () => () => {
-      if (passiveMountedRef.current) {
-        disposePendingRef.current = true;
-      } else {
-        // A hidden React subtree has already consumed its passive cleanup.
-        runDispose();
-      }
-    },
-    [runDispose],
-  );
-  useEffect(() => {
-    passiveMountedRef.current = true;
-    return () => {
-      passiveMountedRef.current = false;
-      if (disposePendingRef.current) runDispose();
-    };
-  }, [runDispose]);
-};
 
 /**
  * Runs a callback when the current resource or React host is permanently
@@ -47,18 +7,47 @@ const useReactHostDispose = (callback: () => void) => {
  */
 export const useResourceDispose = (dispose: () => void): void => {
   const fiber = peekResourceFiber();
-  const disposeRef = useRef(dispose);
-  const callback = useRef(() => disposeRef.current()).current;
+  const stateRef = useRef({
+    dispose,
+    disposePending: false,
+    passiveMounted: false,
+    disposed: false,
+  });
+  const callback = useRef(() => {
+    const state = stateRef.current;
+    if (state.disposed) return;
+    state.disposed = true;
+    state.dispose();
+  }).current;
 
   useEffect(() => {
-    disposeRef.current = dispose;
+    stateRef.current.dispose = dispose;
   });
 
-  if (fiber === null) {
-    // oxlint-disable-next-line react-hooks/rules-of-hooks
-    useReactHostDispose(callback);
-  } else {
-    // oxlint-disable-next-line react-hooks/rules-of-hooks
-    useTapResourceDispose(fiber, callback);
-  }
+  useInsertionEffect(() => {
+    if (fiber !== null) return undefined;
+    return () => {
+      const state = stateRef.current;
+      if (state.passiveMounted) {
+        state.disposePending = true;
+      } else {
+        // A hidden React subtree has already consumed its passive cleanup.
+        callback();
+      }
+    };
+  }, [callback, fiber]);
+
+  useEffect(() => {
+    if (fiber !== null) {
+      fiber.disposeCallbacks.add(callback);
+      return undefined;
+    }
+
+    const state = stateRef.current;
+    state.passiveMounted = true;
+    return () => {
+      state.passiveMounted = false;
+      if (state.disposePending) callback();
+    };
+  }, [callback, fiber]);
 };

--- a/packages/tap/src/hooks/useResourceDispose.ts
+++ b/packages/tap/src/hooks/useResourceDispose.ts
@@ -1,0 +1,26 @@
+import { useEffect, useInsertionEffect, useRef } from "react";
+import { peekResourceFiber } from "../core/helpers/execution-context";
+
+/**
+ * Runs a callback when the current resource or React host is permanently
+ * disposed. Soft unmounts preserve the callback for a later remount.
+ */
+export const useResourceDispose = (dispose: () => void): void => {
+  const fiber = peekResourceFiber();
+  const disposeRef = useRef(dispose);
+  const callback = useRef(() => disposeRef.current()).current;
+
+  useEffect(() => {
+    disposeRef.current = dispose;
+  });
+
+  useEffect(() => {
+    if (fiber === null) return;
+    fiber.disposeCallbacks.add(callback);
+  }, [callback, fiber]);
+
+  useInsertionEffect(() => {
+    if (fiber !== null) return undefined;
+    return () => queueMicrotask(callback);
+  }, [callback, fiber]);
+};

--- a/packages/tap/src/hooks/useResourceDispose.ts
+++ b/packages/tap/src/hooks/useResourceDispose.ts
@@ -1,5 +1,32 @@
 import { useEffect, useInsertionEffect, useRef } from "react";
 import { peekResourceFiber } from "../core/helpers/execution-context";
+import type { ResourceFiber } from "../core/types";
+
+const useTapResourceDispose = (
+  fiber: ResourceFiber<unknown>,
+  callback: () => void,
+) => {
+  useEffect(() => {
+    fiber.disposeCallbacks.add(callback);
+  }, [callback, fiber]);
+};
+
+const useReactHostDispose = (callback: () => void) => {
+  const disposePendingRef = useRef(false);
+
+  useInsertionEffect(
+    () => () => {
+      disposePendingRef.current = true;
+    },
+    [],
+  );
+  useEffect(
+    () => () => {
+      if (disposePendingRef.current) callback();
+    },
+    [callback],
+  );
+};
 
 /**
  * Runs a callback when the current resource or React host is permanently
@@ -14,13 +41,11 @@ export const useResourceDispose = (dispose: () => void): void => {
     disposeRef.current = dispose;
   });
 
-  useEffect(() => {
-    if (fiber === null) return;
-    fiber.disposeCallbacks.add(callback);
-  }, [callback, fiber]);
-
-  useInsertionEffect(() => {
-    if (fiber !== null) return undefined;
-    return () => queueMicrotask(callback);
-  }, [callback, fiber]);
+  if (fiber === null) {
+    // oxlint-disable-next-line react-hooks/rules-of-hooks
+    useReactHostDispose(callback);
+  } else {
+    // oxlint-disable-next-line react-hooks/rules-of-hooks
+    useTapResourceDispose(fiber, callback);
+  }
 };

--- a/packages/tap/src/hooks/useResourceDispose.ts
+++ b/packages/tap/src/hooks/useResourceDispose.ts
@@ -27,7 +27,7 @@ const useReactHostDispose = (callback: () => void) => {
         disposePendingRef.current = true;
       } else {
         // A hidden React subtree has already consumed its passive cleanup.
-        queueMicrotask(runDispose);
+        runDispose();
       }
     },
     [runDispose],

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -165,14 +165,18 @@ export function useResources<E extends ResourceElement<any>>(
   );
 
   // Cleanup on unmount
-  useInsertionEffect(() => {
-    if (parentFiber !== null) return undefined;
-    return () => {
-      for (const state of fibers.values()) {
-        scheduleResourceFiberDisposal(state.fiber);
-      }
-    };
-  }, [fibers, parentFiber]);
+  if (parentFiber === null) {
+    // The React-hosted or Tap-hosted execution path is invariant.
+    // oxlint-disable-next-line react-hooks/rules-of-hooks
+    useInsertionEffect(
+      () => () => {
+        for (const state of fibers.values()) {
+          scheduleResourceFiberDisposal(state.fiber);
+        }
+      },
+      [fibers],
+    );
+  }
 
   useEffect(() => {
     return () => {

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -7,7 +7,7 @@ import {
   attachResourceFiberToParent,
   discardWipRender,
   disposeResourceFiber,
-  markResourceFiberForDisposal,
+  scheduleResourceFiberDisposal,
   unmountResourceFiber,
   renderResourceFiber,
   commitResourceFiber,
@@ -169,7 +169,7 @@ export function useResources<E extends ResourceElement<any>>(
     if (parentFiber !== null) return undefined;
     return () => {
       for (const state of fibers.values()) {
-        markResourceFiberForDisposal(state.fiber);
+        scheduleResourceFiberDisposal(state.fiber);
       }
     };
   }, [fibers, parentFiber]);

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -4,6 +4,7 @@ import type {
   ResourceFiber,
 } from "../core/types";
 import {
+  attachResourceFiberToParent,
   discardWipRender,
   disposeResourceFiber,
   markResourceFiberForDisposal,
@@ -201,6 +202,9 @@ export function useResources<E extends ResourceElement<any>>(
           disposeResourceFiber(state.fiber);
           state.fiber = next.remount;
         }
+        if (parentFiber !== null) {
+          attachResourceFiberToParent(state.fiber, parentFiber);
+        }
         commitResourceFiber(state.fiber);
         state.committedDeps = next.deps;
         state.committedValue = next.value;
@@ -208,7 +212,7 @@ export function useResources<E extends ResourceElement<any>>(
         state.next = "skip";
       }
     }
-  }, [val, fibers]);
+  }, [val, fibers, parentFiber]);
 
   return val;
 }

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -6,6 +6,7 @@ import type {
 import {
   discardWipRender,
   disposeResourceFiber,
+  markResourceFiberForDisposal,
   unmountResourceFiber,
   renderResourceFiber,
   commitResourceFiber,
@@ -167,7 +168,7 @@ export function useResources<E extends ResourceElement<any>>(
     if (parentFiber !== null) return undefined;
     return () => {
       for (const state of fibers.values()) {
-        disposeResourceFiber(state.fiber);
+        markResourceFiberForDisposal(state.fiber);
       }
     };
   }, [fibers, parentFiber]);
@@ -175,8 +176,9 @@ export function useResources<E extends ResourceElement<any>>(
   useEffect(() => {
     return () => {
       for (const state of fibers.values()) {
-        if (parentFiber?.isDisposing) disposeResourceFiber(state.fiber);
-        else unmountResourceFiber(state.fiber);
+        if (state.fiber.isDisposePending || parentFiber?.isDisposing) {
+          disposeResourceFiber(state.fiber);
+        } else unmountResourceFiber(state.fiber);
       }
     };
   }, [fibers, parentFiber]);

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -5,6 +5,7 @@ import type {
 } from "../core/types";
 import {
   discardWipRender,
+  disposeResourceFiber,
   unmountResourceFiber,
   renderResourceFiber,
   commitResourceFiber,
@@ -15,9 +16,10 @@ import {
   hasContextDepsChanged,
 } from "../core/context";
 import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
-import { useEffect, useState } from "react";
+import { useEffect, useInsertionEffect, useState } from "react";
 import { useRenderMemo } from "./utils/useRenderMemo";
 import { depsShallowEqual } from "./utils/depsShallowEqual";
+import { peekResourceFiber } from "../core/helpers/execution-context";
 
 // What this render decided for a child, applied in the commit phase.
 //   { ... }   render to commit; `remount` set when the hook changed
@@ -74,6 +76,7 @@ const hasAnyChildContextDepsChanged = (
 export function useResources<E extends ResourceElement<any>>(
   elements: readonly E[],
 ): ExtractResourceReturnType<E>[] {
+  const parentFiber = peekResourceFiber();
   const [fibers] = useState(() => new Map<string | number, FiberState>());
 
   // Process each element
@@ -160,13 +163,23 @@ export function useResources<E extends ResourceElement<any>>(
   );
 
   // Cleanup on unmount
-  useEffect(() => {
+  useInsertionEffect(() => {
+    if (parentFiber !== null) return undefined;
     return () => {
-      for (const key of fibers.keys()) {
-        unmountResourceFiber(fibers.get(key)!.fiber);
+      for (const state of fibers.values()) {
+        disposeResourceFiber(state.fiber);
       }
     };
-  }, [fibers]);
+  }, [fibers, parentFiber]);
+
+  useEffect(() => {
+    return () => {
+      for (const state of fibers.values()) {
+        if (parentFiber?.isDisposing) disposeResourceFiber(state.fiber);
+        else unmountResourceFiber(state.fiber);
+      }
+    };
+  }, [fibers, parentFiber]);
 
   useEffect(() => {
     void val; // as a performance optimization, we only run if the results have changed
@@ -174,7 +187,7 @@ export function useResources<E extends ResourceElement<any>>(
     for (const [key, state] of fibers.entries()) {
       const next = state.next;
       if (next === "delete") {
-        unmountResourceFiber(state.fiber);
+        disposeResourceFiber(state.fiber);
         fibers.delete(key);
       } else if (next === "skip") {
         // Bailed this render: nothing to commit, keep committed deps/value.
@@ -183,7 +196,7 @@ export function useResources<E extends ResourceElement<any>>(
         }
       } else {
         if (next.remount) {
-          unmountResourceFiber(state.fiber);
+          disposeResourceFiber(state.fiber);
           state.fiber = next.remount;
         }
         commitResourceFiber(state.fiber);

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -165,18 +165,14 @@ export function useResources<E extends ResourceElement<any>>(
   );
 
   // Cleanup on unmount
-  if (parentFiber === null) {
-    // The React-hosted or Tap-hosted execution path is invariant.
-    // oxlint-disable-next-line react-hooks/rules-of-hooks
-    useInsertionEffect(
-      () => () => {
-        for (const state of fibers.values()) {
-          scheduleResourceFiberDisposal(state.fiber);
-        }
-      },
-      [fibers],
-    );
-  }
+  useInsertionEffect(() => {
+    if (parentFiber !== null) return undefined;
+    return () => {
+      for (const state of fibers.values()) {
+        scheduleResourceFiberDisposal(state.fiber);
+      }
+    };
+  }, [fibers, parentFiber]);
 
   useEffect(() => {
     return () => {

--- a/packages/tap/src/hooks/useTapHost.ts
+++ b/packages/tap/src/hooks/useTapHost.ts
@@ -40,14 +40,10 @@ export const useTapHost = <R>(callback: () => R): useTapHost.Result<R> => {
 
   const render = renderResourceFiber(fiber, [callback]);
 
-  if (parentFiber === null) {
-    // The React-hosted or Tap-hosted execution path is invariant.
-    // oxlint-disable-next-line react-hooks/rules-of-hooks
-    useInsertionEffect(
-      () => () => scheduleResourceFiberDisposal(fiber),
-      [fiber],
-    );
-  }
+  useInsertionEffect(() => {
+    if (parentFiber !== null) return undefined;
+    return () => scheduleResourceFiberDisposal(fiber);
+  }, [fiber, parentFiber]);
 
   useEffect(() => {
     if (parentFiber !== null) attachResourceFiberToParent(fiber, parentFiber);

--- a/packages/tap/src/hooks/useTapHost.ts
+++ b/packages/tap/src/hooks/useTapHost.ts
@@ -1,10 +1,12 @@
 import {
+  disposeResourceFiber,
   unmountResourceFiber,
   renderResourceFiber,
   commitResourceFiber,
 } from "../core/ResourceFiber";
 import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
-import { useEffect, useMemo } from "react";
+import { useEffect, useInsertionEffect, useMemo } from "react";
+import { peekResourceFiber } from "../core/helpers/execution-context";
 
 export namespace useTapHost {
   export interface Result<R> {
@@ -27,6 +29,7 @@ export namespace useTapHost {
 const useHostRender = <R>(render: () => R): R => render();
 
 export const useTapHost = <R>(callback: () => R): useTapHost.Result<R> => {
+  const parentFiber = peekResourceFiber();
   const { createFiber } = useResourceFiberHost();
   const fiber = useMemo(
     () => createFiber(useHostRender<R>, undefined),
@@ -35,11 +38,17 @@ export const useTapHost = <R>(callback: () => R): useTapHost.Result<R> => {
 
   const render = renderResourceFiber(fiber, [callback]);
 
+  useInsertionEffect(() => {
+    if (parentFiber !== null) return undefined;
+    return () => disposeResourceFiber(fiber);
+  }, [fiber, parentFiber]);
+
   useEffect(() => {
     return () => {
-      unmountResourceFiber(fiber);
+      if (parentFiber?.isDisposing) disposeResourceFiber(fiber);
+      else unmountResourceFiber(fiber);
     };
-  }, [fiber]);
+  }, [fiber, parentFiber]);
 
   let renderCommitted = false;
   const effects = () => {

--- a/packages/tap/src/hooks/useTapHost.ts
+++ b/packages/tap/src/hooks/useTapHost.ts
@@ -1,5 +1,6 @@
 import {
   disposeResourceFiber,
+  markResourceFiberForDisposal,
   unmountResourceFiber,
   renderResourceFiber,
   commitResourceFiber,
@@ -40,13 +41,14 @@ export const useTapHost = <R>(callback: () => R): useTapHost.Result<R> => {
 
   useInsertionEffect(() => {
     if (parentFiber !== null) return undefined;
-    return () => disposeResourceFiber(fiber);
+    return () => markResourceFiberForDisposal(fiber);
   }, [fiber, parentFiber]);
 
   useEffect(() => {
     return () => {
-      if (parentFiber?.isDisposing) disposeResourceFiber(fiber);
-      else unmountResourceFiber(fiber);
+      if (fiber.isDisposePending || parentFiber?.isDisposing) {
+        disposeResourceFiber(fiber);
+      } else unmountResourceFiber(fiber);
     };
   }, [fiber, parentFiber]);
 

--- a/packages/tap/src/hooks/useTapHost.ts
+++ b/packages/tap/src/hooks/useTapHost.ts
@@ -1,4 +1,5 @@
 import {
+  attachResourceFiberToParent,
   disposeResourceFiber,
   markResourceFiberForDisposal,
   unmountResourceFiber,
@@ -45,6 +46,7 @@ export const useTapHost = <R>(callback: () => R): useTapHost.Result<R> => {
   }, [fiber, parentFiber]);
 
   useEffect(() => {
+    if (parentFiber !== null) attachResourceFiberToParent(fiber, parentFiber);
     return () => {
       if (fiber.isDisposePending || parentFiber?.isDisposing) {
         disposeResourceFiber(fiber);

--- a/packages/tap/src/hooks/useTapHost.ts
+++ b/packages/tap/src/hooks/useTapHost.ts
@@ -1,7 +1,7 @@
 import {
   attachResourceFiberToParent,
   disposeResourceFiber,
-  markResourceFiberForDisposal,
+  scheduleResourceFiberDisposal,
   unmountResourceFiber,
   renderResourceFiber,
   commitResourceFiber,
@@ -42,7 +42,7 @@ export const useTapHost = <R>(callback: () => R): useTapHost.Result<R> => {
 
   useInsertionEffect(() => {
     if (parentFiber !== null) return undefined;
-    return () => markResourceFiberForDisposal(fiber);
+    return () => scheduleResourceFiberDisposal(fiber);
   }, [fiber, parentFiber]);
 
   useEffect(() => {

--- a/packages/tap/src/hooks/useTapHost.ts
+++ b/packages/tap/src/hooks/useTapHost.ts
@@ -40,10 +40,14 @@ export const useTapHost = <R>(callback: () => R): useTapHost.Result<R> => {
 
   const render = renderResourceFiber(fiber, [callback]);
 
-  useInsertionEffect(() => {
-    if (parentFiber !== null) return undefined;
-    return () => scheduleResourceFiberDisposal(fiber);
-  }, [fiber, parentFiber]);
+  if (parentFiber === null) {
+    // The React-hosted or Tap-hosted execution path is invariant.
+    // oxlint-disable-next-line react-hooks/rules-of-hooks
+    useInsertionEffect(
+      () => () => scheduleResourceFiberDisposal(fiber),
+      [fiber],
+    );
+  }
 
   useEffect(() => {
     if (parentFiber !== null) attachResourceFiberToParent(fiber, parentFiber);

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -223,10 +223,14 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     inst.value = value;
   }
 
-  useInsertionEffect(() => {
-    if (parentFiber !== null) return undefined;
-    return () => scheduleResourceFiberDisposal(inst.fiber);
-  }, [inst, parentFiber]);
+  if (parentFiber === null) {
+    // The React-hosted or Tap-hosted execution path is invariant.
+    // oxlint-disable-next-line react-hooks/rules-of-hooks
+    useInsertionEffect(
+      () => () => scheduleResourceFiberDisposal(inst.fiber),
+      [inst],
+    );
+  }
 
   useEffect(() => {
     inst.isMounted = true;

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -223,14 +223,10 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     inst.value = value;
   }
 
-  if (parentFiber === null) {
-    // The React-hosted or Tap-hosted execution path is invariant.
-    // oxlint-disable-next-line react-hooks/rules-of-hooks
-    useInsertionEffect(
-      () => () => scheduleResourceFiberDisposal(inst.fiber),
-      [inst],
-    );
-  }
+  useInsertionEffect(() => {
+    if (parentFiber !== null) return undefined;
+    return () => scheduleResourceFiberDisposal(inst.fiber);
+  }, [inst, parentFiber]);
 
   useEffect(() => {
     inst.isMounted = true;

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -1,4 +1,5 @@
 import {
+  attachResourceFiberToParent,
   commitResourceFiber,
   createResourceFiber,
   disposeResourceFiber,
@@ -229,6 +230,9 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
   useEffect(() => {
     inst.isMounted = true;
+    if (parentFiber !== null) {
+      attachResourceFiberToParent(inst.fiber, parentFiber);
+    }
     return () => {
       inst.isMounted = false;
       if (inst.fiber.isDisposePending || parentFiber?.isDisposing) {

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -1,6 +1,7 @@
 import {
   commitResourceFiber,
   createResourceFiber,
+  disposeResourceFiber,
   renderResourceFiber,
   unmountResourceFiber,
 } from "../core/ResourceFiber";
@@ -15,8 +16,15 @@ import { cloneCurrentTapContext, withTapContextRoot } from "../core/context";
 import { isThenable } from "../core/helpers/thenable";
 import { throwAggregated } from "../core/helpers/throwAggregated";
 import type { ResourceContext, ResourceFiber } from "../core/types";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useEffect,
+  useInsertionEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useDevStrictMode } from "./utils/useDevStrictMode";
+import { peekResourceFiber } from "../core/helpers/execution-context";
 
 export namespace useTapRoot {
   export type Unsubscribe = () => void;
@@ -174,6 +182,7 @@ const createInstance = <R>(
 };
 
 export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
+  const parentFiber = peekResourceFiber();
   const [, forceHostRender] = useState(0);
   const getDevStrictMode = useDevStrictMode();
 
@@ -212,13 +221,19 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     inst.value = value;
   }
 
+  useInsertionEffect(() => {
+    if (parentFiber !== null) return undefined;
+    return () => disposeResourceFiber(inst.fiber);
+  }, [inst, parentFiber]);
+
   useEffect(() => {
     inst.isMounted = true;
     return () => {
       inst.isMounted = false;
-      unmountResourceFiber(inst.fiber);
+      if (parentFiber?.isDisposing) disposeResourceFiber(inst.fiber);
+      else unmountResourceFiber(inst.fiber);
     };
-  }, [inst]);
+  }, [inst, parentFiber]);
 
   useEffect(() => {
     if (renderState.processed) {

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -2,6 +2,7 @@ import {
   commitResourceFiber,
   createResourceFiber,
   disposeResourceFiber,
+  markResourceFiberForDisposal,
   renderResourceFiber,
   unmountResourceFiber,
 } from "../core/ResourceFiber";
@@ -223,15 +224,16 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
   useInsertionEffect(() => {
     if (parentFiber !== null) return undefined;
-    return () => disposeResourceFiber(inst.fiber);
+    return () => markResourceFiberForDisposal(inst.fiber);
   }, [inst, parentFiber]);
 
   useEffect(() => {
     inst.isMounted = true;
     return () => {
       inst.isMounted = false;
-      if (parentFiber?.isDisposing) disposeResourceFiber(inst.fiber);
-      else unmountResourceFiber(inst.fiber);
+      if (inst.fiber.isDisposePending || parentFiber?.isDisposing) {
+        disposeResourceFiber(inst.fiber);
+      } else unmountResourceFiber(inst.fiber);
     };
   }, [inst, parentFiber]);
 

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -3,7 +3,7 @@ import {
   commitResourceFiber,
   createResourceFiber,
   disposeResourceFiber,
-  markResourceFiberForDisposal,
+  scheduleResourceFiberDisposal,
   renderResourceFiber,
   unmountResourceFiber,
 } from "../core/ResourceFiber";
@@ -225,7 +225,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
   useInsertionEffect(() => {
     if (parentFiber !== null) return undefined;
-    return () => markResourceFiberForDisposal(inst.fiber);
+    return () => scheduleResourceFiberDisposal(inst.fiber);
   }, [inst, parentFiber]);
 
   useEffect(() => {

--- a/packages/tap/src/index.ts
+++ b/packages/tap/src/index.ts
@@ -15,6 +15,7 @@ import { useMemoCache as useMemoCacheInternal } from "./react-hooks/useMemoCache
  */
 export const useMemoCache = useMemoCacheInternal;
 export { useResource } from "./hooks/useResource";
+export { useResourceDispose } from "./hooks/useResourceDispose";
 export { useResources } from "./hooks/useResources";
 export { useTapRoot } from "./hooks/useTapRoot";
 export { useTapHost } from "./hooks/useTapHost";

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -1,8 +1,8 @@
 {
   "@assistant-ui/ai-sdk": {
     ".": {
-      "min": 37044,
-      "gzip": 13336
+      "min": 37875,
+      "gzip": 13640
     }
   },
   "@assistant-ui/cloud-ai-sdk": {
@@ -231,8 +231,8 @@
   },
   "@assistant-ui/tap": {
     ".": {
-      "min": 19564,
-      "gzip": 7232
+      "min": 20788,
+      "gzip": 7540
     },
     "./react-shim": {
       "min": 7589,


### PR DESCRIPTION
## Problem

Resource cleanup intentionally stays connected to the assistant client destroy signal across soft unmounts. However, a permanently replaced resource had no distinct teardown signal. Replacing a standalone resource therefore retained its previous chat and abort listener until the whole client was destroyed. The same gap let a nested React runtime keep streaming after its own panel was removed from a longer-lived provider.

Minimal reproduction: start an in-flight request, replace the configured resource hook without replacing the client, and observe that the first transport is not cancelled. Toggling a nested `useChatRuntime` panel under an unchanged provider produces the same result on current `main`.

## Root cause

Tap used the same effect cleanup path for temporary disconnection and permanent deletion. AI SDK cleanup could not remove its destroy listener during a normal effect cleanup because React `Activity` and `mountOnSubscribe` roots must preserve the retained chat across soft unmounts.

## Change

- Add `useResourceDispose` as the permanent-lifetime seam for both tap resources and React hosts.
- Mark permanent deletion during insertion cleanup and perform teardown during passive cleanup. When a hidden subtree has already consumed its passive cleanup, defer permanent disposal from the deletion seam.
- Propagate permanent disposal through replacement, keyed removal, nested ownership, tap roots, and hosts, including when the parent was already soft-unmounted.
- Stop effect reconciliation when cleanup disposes its fiber, preventing effects from being re-armed on a disposed resource.
- Remove each AI SDK destroy-signal listener and stop its chat exactly once when its resource is permanently disposed, independently of the client-destroy opt-in.
- Keep standalone soft-unmounted resources armed until the owning client is destroyed.
- Document soft unmount versus disposal and update the generated API surface and measured size budgets.

## Verification

- The standalone replacement and nested-panel regressions both fail against `origin/main` with cancel count `0` and pass on this branch with cancel count `1`.
- The replacement regression also verifies exactly one live listener remains on the shared destroy signal.
- React host contracts cover `useResource`, `useResources`, `useTapRoot`, and `useTapHost`: hidden Activity trees retain state, reveal still works, visible and hidden deletion dispose once, and Strict Mode mount replay does not dispose.
- The five hide-then-delete cases fail before the lifecycle fix and pass afterward, including the direct React-host path.
- Nested-host regressions cover permanent parent disposal after a soft unmount, and a reentrant cleanup contract verifies disposed effects are not set up again.
- Permanent disposal is covered while client-destroy cleanup is disabled, and direct React-host cleanup errors stay in React error handling.
- `pnpm -C packages/tap test` — 53 files, 610 tests passed.
- `pnpm -C packages/ai-sdk test` — 26 files, 277 tests passed.
- `pnpm -C packages/ai-sdk test:react-compiler` — 1 test passed.
- `pnpm -C packages/tap build` and `pnpm -C packages/ai-sdk build` passed.
- `pnpm -C apps/docs build` passed, including TypeScript and 758 generated pages.
- `pnpm lint`, `pnpm changesets:check`, filtered API-surface validation, and `pnpm size:check` passed.

## Public surface

- `@assistant-ui/tap`: adds the `useResourceDispose` export and lifecycle documentation.
- `@assistant-ui/ai-sdk`: changes cleanup behavior for permanently disposed chats.
- Patch changesets are included for both packages.
- No template or registry changes.

Fixes #7030