### PR TITLE
feat(react-ag-ui): preserve queued messages across interrupted renders

### DIFF
--- a/.changeset/quiet-queues-commit.md
+++ b/.changeset/quiet-queues-commit.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: preserve queued messages across interrupted renders

--- a/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
+++ b/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { startTransition, useEffect } from "react";
 import {
   act,
   cleanup,
@@ -407,6 +408,59 @@ describe("useAgUiRuntime unstable_enableMessageQueue", () => {
     await waitFor(() =>
       expect(screen.getByTestId("queued").textContent).toBe(""),
     );
+  });
+
+  it("does not clear the committed queue from a suspended render", async () => {
+    const { agent, runAgent } = gatedAgent();
+    let runtime: AssistantRuntime | undefined;
+    const never = new Promise<void>(() => {});
+
+    const Harness = ({
+      enabled,
+      suspend,
+    }: {
+      enabled: boolean;
+      suspend: boolean;
+    }) => {
+      const nextRuntime = useAgUiRuntime({
+        agent,
+        unstable_enableMessageQueue: enabled,
+      });
+      useEffect(() => {
+        runtime = nextRuntime;
+      }, [nextRuntime]);
+      if (suspend) throw never;
+      return null;
+    };
+
+    const view = render(<Harness enabled suspend={false} />);
+    await waitFor(() => expect(runtime).toBeDefined());
+    mount(runtime!);
+
+    await act(async () => {
+      await runtime!.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "first" }],
+      });
+    });
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await runtime!.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "second" }],
+        parentId: runtime!.thread.getState().messages.at(-1)?.id ?? null,
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe("second"),
+    );
+
+    act(() => {
+      startTransition(() => view.rerender(<Harness enabled={false} suspend />));
+    });
+
+    expect(screen.getByTestId("queued").textContent).toBe("second");
   });
 
   it("leaves the queue capability off when the flag is not set", () => {

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -3,6 +3,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -139,13 +140,16 @@ export function useAgUiRuntime(
         });
       },
     });
-  } else if (!options.unstable_enableMessageQueue && queueRef.current) {
-    queueRef.current.clear();
-    queueRef.current = null;
   }
   const queueController = options.unstable_enableMessageQueue
     ? queueRef.current
     : null;
+  useLayoutEffect(() => {
+    if (options.unstable_enableMessageQueue || !queueRef.current) return;
+    const controller = queueRef.current;
+    queueRef.current = null;
+    controller.clear();
+  }, [options.unstable_enableMessageQueue]);
 
   // Feeds the store memo below: the runtime core skips an adapter whose
   // identity is unchanged, so queue items have to move the store reference or

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -149,7 +149,7 @@ export function useAgUiRuntime(
     const controller = queueRef.current;
     queueRef.current = null;
     controller.clear();
-  });
+  }, [options.unstable_enableMessageQueue]);
 
   // Feeds the store memo below: the runtime core skips an adapter whose
   // identity is unchanged, so queue items have to move the store reference or

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -149,7 +149,7 @@ export function useAgUiRuntime(
     const controller = queueRef.current;
     queueRef.current = null;
     controller.clear();
-  }, [options.unstable_enableMessageQueue]);
+  });
 
   // Feeds the store memo below: the runtime core skips an adapter whose
   // identity is unchanged, so queue items have to move the store reference or


### PR DESCRIPTION
## Problem

With `unstable_enableMessageQueue` enabled, rendering the runtime with the flag disabled cleared queued messages immediately during render. If that concurrent render suspended and never committed, the currently committed runtime still lost its queued messages and React reported a render-phase subscriber update.

Reproduced on current main (`0afb5989c`): start one gated run, queue a second message, then start a transition that disables the queue and suspends. The committed queue changed from `second` to empty even though the disabling render never committed.

## Root cause

The queue controller was cleared and removed from its shared ref during render. `clear()` mutates the external queue and notifies subscribers, so an abandoned work-in-progress render could alter committed state.

## Change

Keep the existing lazy queue creation, but clear and release the controller from a layout effect after the disabled render commits. Add a concurrent-render regression test that keeps the previous runtime committed while the disabling render suspends.

## Verification

- `pnpm --filter @assistant-ui/react-ag-ui exec vitest run src/useAgUiRuntime.queue.test.tsx` (9 tests passed)
- `pnpm --filter @assistant-ui/react-ag-ui build`
- `pnpm exec oxlint packages/react-ag-ui/src/useAgUiRuntime.ts packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx`
- `pnpm exec oxfmt --check packages/react-ag-ui/src/useAgUiRuntime.ts packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx .changeset/quiet-queues-commit.md`
- `pnpm changesets:check`

The complete package run passed 579 tests and hit one unrelated existing failure in `useAgUiRuntime.toolDeferral.test.tsx`; the same failure reproduces in the separate untouched AG-UI worktree.

## Public surface

- `@assistant-ui/react-ag-ui`: patch changeset
- Exports, types, docs, templates, and API reference: unchanged

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Y6h9CygcH_17ZcrFt7qwYiXyRYCXEbh1JVCCGGJ8YWDTmMR9noct5BwuJqg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->