### PR TITLE
fix(core): notify every remote thread lifecycle subscriber

### DIFF
--- a/.changeset/calm-threads-listen.md
+++ b/.changeset/calm-threads-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: notify every remote thread lifecycle subscriber

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.running.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.running.test.tsx
@@ -155,6 +155,39 @@ describe("RemoteThreadListHookInstanceManager run tracking", () => {
     expect(onChange).toHaveBeenCalledTimes(2);
   });
 
+  it("notifies every running subscriber when one throws", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    const thread = makeRuntime({ isRunning: false });
+    publish(manager, "thread-1", thread.runtime);
+    const error = new Error("listener failed");
+    manager.__internal_subscribeRunningChanged(() => {
+      throw error;
+    });
+    const laterSubscriber = vi.fn();
+    manager.__internal_subscribeRunningChanged(laterSubscriber);
+
+    expect(() => thread.setRunning(true)).toThrow(error);
+    expect(laterSubscriber).toHaveBeenCalledOnce();
+  });
+
+  it("notifies every replacement subscriber when one throws", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    publish(manager, "thread-1", makeRuntime().runtime);
+    const error = new Error("listener failed");
+    manager.__internal_subscribeRuntimeReplaced(() => {
+      throw error;
+    });
+    const laterSubscriber = vi.fn();
+    manager.__internal_subscribeRuntimeReplaced(laterSubscriber);
+
+    expect(() => publish(manager, "thread-1", makeRuntime().runtime)).toThrow(
+      error,
+    );
+    expect(laterSubscriber).toHaveBeenCalledOnce();
+  });
+
   it("moves tracking to the runtime a restart publishes", () => {
     const manager = makeManager();
     start(manager, "thread-1");

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -24,6 +24,7 @@ import type {
 import type { Unsubscribe } from "../../types/unsubscribe";
 import {
   BaseSubscribable,
+  notifySubscribers,
   WritableSubscribable,
 } from "../../subscribable/subscribable";
 import { useSubscribable } from "../../store/runtime-clients/useSubscribable";
@@ -218,7 +219,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     }
     this._notifySubscribers();
     if (previousRuntime !== undefined && previousRuntime !== runtime) {
-      for (const callback of this.replacedSubscribers) callback();
+      notifySubscribers(this.replacedSubscribers);
     }
   }
 
@@ -270,7 +271,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   ) {
     if (instance.isRunning === isRunning) return;
     instance.isRunning = isRunning;
-    for (const callback of this.runningSubscribers) callback();
+    notifySubscribers(this.runningSubscribers);
   }
 
   public stopThreadRuntime(threadId: string) {


### PR DESCRIPTION
## Problem

Remote thread lifecycle observers are invoked in raw loops. If one running-state or runtime-replacement subscriber throws, later subscribers are skipped and can remain stale even though runtime state already changed.

On current main, a focused reproduction registered a throwing subscriber followed by a second subscriber; the second subscriber received zero calls.

## Root cause

The running and replacement subscriber sets bypass the aggregating `notifySubscribers` helper used by the runtime store.

## Change

Route both lifecycle subscriber sets through `notifySubscribers`. Every subscriber now runs, then the original error is rethrown to preserve internal state-propagation semantics. Add focused regression coverage for both notification paths.

## Verification

- `pnpm --filter @assistant-ui/core exec vitest run src/react/runtimes/RemoteThreadListHookInstanceManager.running.test.tsx`
- `pnpm --filter @assistant-ui/core test` (168 files, 1,791 tests)
- `pnpm lint`
- `pnpm changesets:check`
- `pnpm build` reached 63 successful tasks, then stopped because the local volume ran out of space while Next.js wrote a generated `.next` cache (`ENOSPC`); no source, type, or test failure was reported

## Public surface

`@assistant-ui/core` behavior only. No export, API, documentation, or template changes. Includes a patch changeset.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ZUofnxJG1xh9KYmiVHMJTNh366SESMHqvw1pDv9C9ZtqQRwE-y30a-klV6o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->