### PR TITLE
ci: require changesets for published source changes

### DIFF
--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -36,6 +36,13 @@ jobs:
       - name: Verify changesets only name releasable packages
         run: node scripts/check-changesets.mjs
 
+      - name: Verify changed API surfaces have changesets
+        if: ${{ startsWith(github.head_ref, 'changeset-release/') == false }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/check-changesets.mjs --changed-api-surface
+
       - name: Test the changeset semver checker
         run: node --test scripts/check-changeset-semver.test.mjs
 

--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -36,13 +36,6 @@ jobs:
       - name: Verify changesets only name releasable packages
         run: node scripts/check-changesets.mjs
 
-      - name: Verify changed API surfaces have changesets
-        if: ${{ startsWith(github.head_ref, 'changeset-release/') == false }}
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: node scripts/check-changesets.mjs --changed-api-surface
-
       - name: Test the changeset semver checker
         run: node --test scripts/check-changeset-semver.test.mjs
 
@@ -51,3 +44,9 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/check-changeset-semver.mjs
+
+      - name: Verify changed published sources have changesets
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/check-changesets.mjs --changed-packages

--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -17,7 +17,7 @@ jobs:
   analyze:
     name: Semver Check
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - name: Checkout PR merge ref
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
@@ -29,6 +29,9 @@ jobs:
         with:
           runtime: node@24
           install: false
+
+      - name: Install checker dependencies
+        run: pnpm install --filter @assistant-ui/monorepo --frozen-lockfile --ignore-scripts
 
       - name: Test the changeset checker
         run: node --test scripts/check-changesets.test.mjs

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@assistant-ui/x-changelog": "workspace:*",
+    "@babel/parser": "^8.0.4",
     "@changesets/cli": "^3.0.2",
     "husky": "^9.1.7",
     "lint-staged": "^17.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       '@assistant-ui/x-changelog':
         specifier: workspace:*
         version: link:packages/x-changelog
+      '@babel/parser':
+        specifier: ^8.0.4
+        version: 8.0.4
       '@changesets/cli':
         specifier: ^3.0.2
         version: 3.0.2

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { execFileSync } from "node:child_process";
 import { globSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -45,7 +46,7 @@ export function parseBumpLine(line) {
   return { name: entry[1] ?? entry[2] ?? entry[3], bump };
 }
 
-function readWorkspacePackages(root) {
+export function readWorkspacePackages(root) {
   const globs = parseWorkspaceGlobs(
     readFileSync(path.join(root, "pnpm-workspace.yaml"), "utf8"),
   );
@@ -69,11 +70,12 @@ function readWorkspacePackages(root) {
   return byName;
 }
 
-function readChangesetBumps(root) {
+export function readChangesetBumps(root, files = null) {
   const changesetDir = path.join(root, ".changeset");
   const bumps = [];
   for (const file of readdirSync(changesetDir).sort()) {
     if (!file.endsWith(".md") || file === "README.md") continue;
+    if (files && !files.has(file)) continue;
     const frontmatter = readFileSync(
       path.join(changesetDir, file),
       "utf8",
@@ -166,6 +168,82 @@ export function findUnreleasablePackages(packages, bumps, rules) {
   return problems;
 }
 
+export function apiSurfaceFileName(packageName) {
+  return `api-surface/${packageName.replace(/^@/, "").replaceAll("/", "__")}.ts`;
+}
+
+export function findMissingApiSurfaceChangesets(
+  packages,
+  bumps,
+  changedFiles,
+  rules,
+) {
+  const ignored = expandPackageGlobs(packages.keys(), rules.ignored);
+  const bumped = new Set(bumps.map(({ name }) => name));
+  const missing = [];
+
+  for (const [name, pkg] of packages) {
+    if (
+      ignored.has(name) ||
+      (pkg.isPrivate && rules.skipsPrivate) ||
+      !pkg.hasVersion
+    ) {
+      continue;
+    }
+
+    const file = apiSurfaceFileName(name);
+    if (changedFiles.has(file) && !bumped.has(name)) {
+      missing.push({ file, name });
+    }
+  }
+
+  return missing;
+}
+
+function diffChangedFiles(root, baseSha, headSha) {
+  return execFileSync(
+    "git",
+    [
+      "diff",
+      "--name-only",
+      "--diff-filter=ACMR",
+      `${baseSha}...${headSha}`,
+      "--",
+      "api-surface/*.ts",
+      ".changeset/*.md",
+    ],
+    { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  )
+    .trim()
+    .split("\n")
+    .filter(Boolean);
+}
+
+export function runChangedApiSurfaceCheck(root, baseSha, headSha) {
+  const changedFiles = diffChangedFiles(root, baseSha, headSha);
+  const packages = readWorkspacePackages(root);
+  const rules = readSkipRules(
+    readJson(path.join(root, ".changeset", "config.json")),
+  );
+  const changesetFiles = new Set(
+    changedFiles
+      .filter((file) => file.startsWith(".changeset/"))
+      .map((file) => path.basename(file)),
+  );
+
+  return {
+    changedSurfaceCount: changedFiles.filter((file) =>
+      file.startsWith("api-surface/"),
+    ).length,
+    missingChangesets: findMissingApiSurfaceChangesets(
+      packages,
+      readChangesetBumps(root, changesetFiles),
+      new Set(changedFiles),
+      rules,
+    ),
+  };
+}
+
 export function runCheck(root = repoRoot) {
   const packages = readWorkspacePackages(root);
   const rules = readSkipRules(
@@ -182,7 +260,8 @@ export function runCheck(root = repoRoot) {
 }
 
 function main() {
-  const { packageCount, problems } = runCheck(process.env.CHANGESET_CHECK_ROOT);
+  const root = process.env.CHANGESET_CHECK_ROOT ?? repoRoot;
+  const { packageCount, problems } = runCheck(root);
 
   if (problems.length > 0) {
     console.error("Changesets name packages that cannot be released:\n");
@@ -197,6 +276,33 @@ function main() {
     );
     console.error("\nDrop the offending line from the changeset frontmatter.");
     process.exit(1);
+  }
+
+  if (process.argv.includes("--changed-api-surface")) {
+    const { BASE_SHA, HEAD_SHA } = process.env;
+    if (!BASE_SHA || !HEAD_SHA) {
+      console.error(
+        "BASE_SHA and HEAD_SHA are required for changed API surface validation.",
+      );
+      process.exit(1);
+    }
+
+    const { changedSurfaceCount, missingChangesets } =
+      runChangedApiSurfaceCheck(root, BASE_SHA, HEAD_SHA);
+    if (missingChangesets.length > 0) {
+      console.error("Changed API surfaces without a changeset:\n");
+      for (const { file, name } of missingChangesets) {
+        console.error(`  ${file}: add a changeset for "${name}"`);
+      }
+      console.error(
+        "\nEvery changed public API must name its published package in a changeset added by this PR.",
+      );
+      process.exit(1);
+    }
+
+    console.log(
+      `All changed API surfaces have changesets. (${changedSurfaceCount} surfaces scanned)`,
+    );
   }
 
   console.log(

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { parse } from "@babel/parser";
 import { execFileSync } from "node:child_process";
 import { globSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
@@ -12,6 +13,26 @@ const repoRoot = path.resolve(
 );
 
 const BUMP_VALUES = new Set(["patch", "minor", "major"]);
+const PARSED_SOURCE_EXTENSIONS = new Set([
+  ".cjs",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".mts",
+  ".ts",
+  ".tsx",
+]);
+const AST_METADATA_KEYS = new Set([
+  "comments",
+  "end",
+  "errors",
+  "extra",
+  "loc",
+  "start",
+]);
+const OPERATIONAL_COMMENT =
+  /(?:^\s*\/\s*<reference\b|@(?:jsx|ts-(?:check|nocheck|ignore|expect-error))\b|[#@]__(?:NO_SIDE_EFFECTS|PURE)__\b|\b(?:sourceMappingURL|sourceURL|vite-ignore|webpack\w*)\b|^!)/i;
 
 export function parseWorkspaceGlobs(source) {
   const globs = [];
@@ -214,6 +235,111 @@ function isReleaseRelevantPackageFile(file, pkg) {
   return pkg.releaseRoots.includes(root) && isReleaseRelevantFile(relative);
 }
 
+function isOperationalComment(comment) {
+  return (
+    typeof comment?.value === "string" &&
+    OPERATIONAL_COMMENT.test(comment.value.trim())
+  );
+}
+
+function pruneSyntaxTree(value) {
+  if (Array.isArray(value)) return value.map(pruneSyntaxTree);
+  if (value === null || typeof value !== "object") return value;
+
+  const result = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (
+      key === "innerComments" ||
+      key === "leadingComments" ||
+      key === "trailingComments"
+    ) {
+      const comments = child
+        .filter(isOperationalComment)
+        .map(({ type, value: commentValue }) => ({
+          type,
+          value: commentValue.trim(),
+        }));
+      if (comments.length > 0) result[key] = comments;
+    } else if (!AST_METADATA_KEYS.has(key)) {
+      result[key] = pruneSyntaxTree(child);
+    }
+  }
+  return result;
+}
+
+function sourceSignature(file, contents) {
+  if (!PARSED_SOURCE_EXTENSIONS.has(path.extname(file))) return contents;
+
+  const source = contents.toString("utf8");
+  const isTypeScript = /\.[cm]?tsx?$/.test(file);
+  const isDts = /\.d\.[cm]?ts$/.test(file);
+  const usesJsx = /\.[jt]sx$/.test(file);
+  const plugins = ["decorators-legacy"];
+  if (isTypeScript) plugins.push(["typescript", { dts: isDts }]);
+  if (usesJsx) plugins.push("jsx");
+
+  try {
+    const syntaxTree = parse(source, {
+      attachComment: true,
+      plugins,
+      sourceType: "unambiguous",
+    });
+    const unattachedOperationalComments = syntaxTree.comments
+      .filter(isOperationalComment)
+      .map(({ type, value }) => ({ type, value: value.trim() }));
+    return JSON.stringify({
+      program: pruneSyntaxTree(syntaxTree.program),
+      operationalComments: unattachedOperationalComments,
+    });
+  } catch {
+    return contents;
+  }
+}
+
+function contentsDiffer(file, baseContents, headContents) {
+  const empty = Buffer.alloc(0);
+  const baseSignature = sourceSignature(file, baseContents ?? empty);
+  const headSignature = sourceSignature(file, headContents ?? empty);
+  if (Buffer.isBuffer(baseSignature) && Buffer.isBuffer(headSignature)) {
+    return !baseSignature.equals(headSignature);
+  }
+  return baseSignature !== headSignature;
+}
+
+function readGitFile(root, sha, file) {
+  return execFileSync("git", ["show", `${sha}:${file}`], {
+    cwd: root,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function findReleaseOwner(packages, file) {
+  for (const [name, pkg] of packages) {
+    if (isReleaseRelevantPackageFile(file, pkg)) return name;
+  }
+  return null;
+}
+
+function parseNameStatus(output) {
+  const fields = output.toString("utf8").split("\0");
+  if (fields.at(-1) === "") fields.pop();
+
+  const entries = [];
+  for (let index = 0; index < fields.length;) {
+    const status = fields[index++];
+    if (status.startsWith("R") || status.startsWith("C")) {
+      entries.push({
+        status: status[0],
+        oldFile: fields[index++],
+        file: fields[index++],
+      });
+    } else {
+      entries.push({ status: status[0], file: fields[index++] });
+    }
+  }
+  return entries;
+}
+
 export function findMissingPackageChangesets(
   packages,
   bumps,
@@ -245,61 +371,73 @@ export function findMissingPackageChangesets(
   return missing;
 }
 
-function diffChangedFiles(root, baseSha, headSha) {
+function diffChangedFiles(root, baseSha, headSha, packages) {
   try {
     const range = `${baseSha}...${headSha}`;
-    const addedDeletedOrRenamed = execFileSync(
-      "git",
-      [
-        "diff",
-        "--name-only",
-        "--diff-filter=ACDR",
-        "--no-renames",
-        range,
-        "--",
-        "packages/**",
-      ],
-      { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-    )
-      .trim()
-      .split("\n")
-      .filter(Boolean);
-    const modifiedPatch = execFileSync(
-      "git",
-      [
-        "diff",
-        "--unified=0",
-        "--no-color",
-        "--no-ext-diff",
-        "--diff-filter=M",
-        "--ignore-all-space",
-        "--ignore-matching-lines=^[[:space:]]*//",
-        range,
-        "--",
-        "packages/**",
-      ],
-      { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    const packageChanges = parseNameStatus(
+      execFileSync(
+        "git",
+        [
+          "diff",
+          "--name-status",
+          "-z",
+          "--find-renames",
+          "--diff-filter=ACDMRT",
+          range,
+          "--",
+          "packages/**",
+        ],
+        { cwd: root, stdio: ["ignore", "pipe", "pipe"] },
+      ),
     );
-    const modified = modifiedPatch
-      .split("\n")
-      .filter((line) => line.startsWith("+++ b/"))
-      .map((line) => line.slice("+++ b/".length));
+    const changedPackageFiles = [];
+    for (const { status, oldFile, file } of packageChanges) {
+      const owner = findReleaseOwner(packages, file);
+      if (status === "R") {
+        const oldOwner = findReleaseOwner(packages, oldFile);
+        if (oldOwner && oldOwner === owner) changedPackageFiles.push(file);
+        else {
+          if (oldOwner) changedPackageFiles.push(oldFile);
+          if (owner) changedPackageFiles.push(file);
+        }
+        continue;
+      }
+      if (status === "C") {
+        if (
+          owner &&
+          contentsDiffer(file, null, readGitFile(root, headSha, file))
+        ) {
+          changedPackageFiles.push(file);
+        }
+        continue;
+      }
+      if (!owner) continue;
+
+      const baseContents =
+        status === "A" ? null : readGitFile(root, baseSha, file);
+      const headContents =
+        status === "D" ? null : readGitFile(root, headSha, file);
+      if (contentsDiffer(file, baseContents, headContents)) {
+        changedPackageFiles.push(file);
+      }
+    }
     const changesets = execFileSync(
       "git",
       [
         "diff",
+        "-z",
         "--name-only",
         "--diff-filter=ACMR",
         range,
         "--",
         ".changeset/*.md",
       ],
-      { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      { cwd: root, stdio: ["ignore", "pipe", "pipe"] },
     )
-      .trim()
-      .split("\n")
+      .toString("utf8")
+      .split("\0")
       .filter(Boolean);
-    return [...new Set([...addedDeletedOrRenamed, ...modified, ...changesets])];
+    return [...new Set([...changedPackageFiles, ...changesets])];
   } catch (error) {
     const stderr = String(error.stderr ?? "").trim();
     return { error: stderr.split("\n").at(-1) || error.message };
@@ -307,10 +445,10 @@ function diffChangedFiles(root, baseSha, headSha) {
 }
 
 export function runChangedPackageCheck(root, baseSha, headSha) {
-  const changedFiles = diffChangedFiles(root, baseSha, headSha);
+  const packages = readWorkspacePackages(root);
+  const changedFiles = diffChangedFiles(root, baseSha, headSha, packages);
   if (!Array.isArray(changedFiles)) return changedFiles;
 
-  const packages = readWorkspacePackages(root);
   const rules = readSkipRules(
     readJson(path.join(root, ".changeset", "config.json")),
   );
@@ -365,6 +503,13 @@ function annotateError(message) {
   console.error(`::error::${data}`);
 }
 
+function summarizeFiles(files) {
+  const limit = 5;
+  const summary = files.slice(0, limit).join(", ");
+  const remaining = files.length - limit;
+  return remaining > 0 ? `${summary}, and ${remaining} more` : summary;
+}
+
 function main() {
   const root = process.env.CHANGESET_CHECK_ROOT ?? repoRoot;
   const checksChangedPackages = process.argv.includes("--changed-packages");
@@ -415,7 +560,7 @@ function main() {
   if (missingChangesets.length > 0) {
     console.error("Changed published packages without a changeset:\n");
     for (const { files, name } of missingChangesets) {
-      console.error(`  "${name}" (${files.join(", ")})`);
+      console.error(`  "${name}" (${summarizeFiles(files)})`);
     }
     console.error(
       "\nAdd a changeset from this PR that names every changed published package.",

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -92,7 +92,7 @@ export function readWorkspacePackages(root) {
         manifest: manifest.replaceAll("\\", "/"),
         isPrivate: pkg.private === true,
         hasVersion: Boolean(pkg.version),
-        releaseFiles: (Array.isArray(pkg.files) ? pkg.files : ["src"])
+        releaseFiles: (Array.isArray(pkg.files) ? pkg.files : ["."])
           .filter((entry) => typeof entry === "string")
           .map((entry) => entry.replace(/^(!?)\.\//, "$1"))
           .filter(Boolean),
@@ -233,7 +233,7 @@ export function isReleaseRelevantPackageFile(file, pkg) {
     relative === "package.json" ||
     relative === "dist" ||
     relative.startsWith("dist/") ||
-    /\.md$/i.test(relative)
+    (!relative.includes("/") && /\.md$/i.test(relative))
   ) {
     return false;
   }

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -168,11 +168,32 @@ export function findUnreleasablePackages(packages, bumps, rules) {
   return problems;
 }
 
-export function apiSurfaceFileName(packageName) {
-  return `api-surface/${packageName.replace(/^@/, "").replaceAll("/", "__")}.ts`;
+export function isReleaseRelevantSourceFile(file) {
+  const match = file.match(/^packages\/[^/]+\/src\/(.+)$/);
+  if (!match) return false;
+
+  const relative = match[1];
+  const segments = relative.split("/");
+  if (
+    segments.some((segment) =>
+      [
+        "__fixtures__",
+        "__generated__",
+        "__tests__",
+        "fixtures",
+        "generated",
+        "test",
+        "tests",
+      ].includes(segment),
+    )
+  ) {
+    return false;
+  }
+
+  return !/\.(?:bench|generated|spec|stories|test)\.[^/]+$/.test(relative);
 }
 
-export function findMissingApiSurfaceChangesets(
+export function findMissingPackageChangesets(
   packages,
   bumps,
   changedFiles,
@@ -191,9 +212,12 @@ export function findMissingApiSurfaceChangesets(
       continue;
     }
 
-    const file = apiSurfaceFileName(name);
-    if (changedFiles.has(file) && !bumped.has(name)) {
-      missing.push({ file, name });
+    const packageRoot = path.posix.dirname(pkg.manifest);
+    const files = [...changedFiles].filter((file) =>
+      file.startsWith(`${packageRoot}/src/`),
+    );
+    if (files.length > 0 && !bumped.has(name)) {
+      missing.push({ files, name });
     }
   }
 
@@ -201,26 +225,69 @@ export function findMissingApiSurfaceChangesets(
 }
 
 function diffChangedFiles(root, baseSha, headSha) {
-  return execFileSync(
-    "git",
-    [
-      "diff",
-      "--name-only",
-      "--diff-filter=ACMR",
-      `${baseSha}...${headSha}`,
-      "--",
-      "api-surface/*.ts",
-      ".changeset/*.md",
-    ],
-    { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-  )
-    .trim()
-    .split("\n")
-    .filter(Boolean);
+  try {
+    const range = `${baseSha}...${headSha}`;
+    const addedDeletedOrRenamed = execFileSync(
+      "git",
+      [
+        "diff",
+        "--name-only",
+        "--diff-filter=ACDR",
+        range,
+        "--",
+        "packages/*/src/**",
+      ],
+      { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    )
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    const modifiedPatch = execFileSync(
+      "git",
+      [
+        "diff",
+        "--unified=0",
+        "--no-color",
+        "--no-ext-diff",
+        "--diff-filter=M",
+        "--ignore-all-space",
+        "--ignore-matching-lines=^[[:space:]]*//",
+        range,
+        "--",
+        "packages/*/src/**",
+      ],
+      { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const modified = modifiedPatch
+      .split("\n")
+      .filter((line) => line.startsWith("+++ b/"))
+      .map((line) => line.slice("+++ b/".length));
+    const changesets = execFileSync(
+      "git",
+      [
+        "diff",
+        "--name-only",
+        "--diff-filter=ACMR",
+        range,
+        "--",
+        ".changeset/*.md",
+      ],
+      { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    )
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    return [...new Set([...addedDeletedOrRenamed, ...modified, ...changesets])];
+  } catch (error) {
+    const stderr = String(error.stderr ?? "").trim();
+    return { error: stderr.split("\n").at(-1) || error.message };
+  }
 }
 
-export function runChangedApiSurfaceCheck(root, baseSha, headSha) {
+export function runChangedPackageCheck(root, baseSha, headSha) {
   const changedFiles = diffChangedFiles(root, baseSha, headSha);
+  if (!Array.isArray(changedFiles)) return changedFiles;
+
   const packages = readWorkspacePackages(root);
   const rules = readSkipRules(
     readJson(path.join(root, ".changeset", "config.json")),
@@ -230,15 +297,14 @@ export function runChangedApiSurfaceCheck(root, baseSha, headSha) {
       .filter((file) => file.startsWith(".changeset/"))
       .map((file) => path.basename(file)),
   );
+  const sourceFiles = new Set(changedFiles.filter(isReleaseRelevantSourceFile));
 
   return {
-    changedSurfaceCount: changedFiles.filter((file) =>
-      file.startsWith("api-surface/"),
-    ).length,
-    missingChangesets: findMissingApiSurfaceChangesets(
+    changedSourceCount: sourceFiles.size,
+    missingChangesets: findMissingPackageChangesets(
       packages,
       readChangesetBumps(root, changesetFiles),
-      new Set(changedFiles),
+      sourceFiles,
       rules,
     ),
   };
@@ -278,30 +344,37 @@ function main() {
     process.exit(1);
   }
 
-  if (process.argv.includes("--changed-api-surface")) {
+  if (process.argv.includes("--changed-packages")) {
     const { BASE_SHA, HEAD_SHA } = process.env;
     if (!BASE_SHA || !HEAD_SHA) {
       console.error(
-        "BASE_SHA and HEAD_SHA are required for changed API surface validation.",
+        "BASE_SHA and HEAD_SHA are required for changed package validation.",
       );
       process.exit(1);
     }
 
-    const { changedSurfaceCount, missingChangesets } =
-      runChangedApiSurfaceCheck(root, BASE_SHA, HEAD_SHA);
+    const result = runChangedPackageCheck(root, BASE_SHA, HEAD_SHA);
+    if ("error" in result) {
+      console.error(
+        `Could not diff ${BASE_SHA}...${HEAD_SHA}: ${result.error}. Failing instead of skipping changeset validation.`,
+      );
+      process.exit(1);
+    }
+
+    const { changedSourceCount, missingChangesets } = result;
     if (missingChangesets.length > 0) {
-      console.error("Changed API surfaces without a changeset:\n");
-      for (const { file, name } of missingChangesets) {
-        console.error(`  ${file}: add a changeset for "${name}"`);
+      console.error("Changed published packages without a changeset:\n");
+      for (const { files, name } of missingChangesets) {
+        console.error(`  "${name}" (${files.join(", ")})`);
       }
       console.error(
-        "\nEvery changed public API must name its published package in a changeset added by this PR.",
+        "\nAdd a changeset from this PR that names every changed published package.",
       );
       process.exit(1);
     }
 
     console.log(
-      `All changed API surfaces have changesets. (${changedSurfaceCount} surfaces scanned)`,
+      `All changed published packages have changesets. (${changedSourceCount} source files scanned)`,
     );
   }
 

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -233,6 +233,7 @@ function diffChangedFiles(root, baseSha, headSha) {
         "diff",
         "--name-only",
         "--diff-filter=ACDR",
+        "--no-renames",
         range,
         "--",
         "packages/*/src/**",
@@ -325,61 +326,78 @@ export function runCheck(root = repoRoot) {
   };
 }
 
+function annotateError(message) {
+  if (!process.env.GITHUB_ACTIONS) {
+    console.error(message);
+    return;
+  }
+  const data = message
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A");
+  console.error(`::error::${data}`);
+}
+
 function main() {
   const root = process.env.CHANGESET_CHECK_ROOT ?? repoRoot;
-  const { packageCount, problems } = runCheck(root);
+  const checksChangedPackages = process.argv.includes("--changed-packages");
 
-  if (problems.length > 0) {
-    console.error("Changesets name packages that cannot be released:\n");
-    for (const { file, name, reason } of problems) {
-      console.error(`  .changeset/${file}: "${name}" ${reason}`);
-    }
-    console.error(
-      "\nChangesets refuses a changeset that mixes a skipped package with a released one,",
-    );
-    console.error(
-      "so `changeset version` aborts and every release stays blocked until the line is removed.",
-    );
-    console.error("\nDrop the offending line from the changeset frontmatter.");
-    process.exit(1);
-  }
+  if (!checksChangedPackages) {
+    const { packageCount, problems } = runCheck(root);
 
-  if (process.argv.includes("--changed-packages")) {
-    const { BASE_SHA, HEAD_SHA } = process.env;
-    if (!BASE_SHA || !HEAD_SHA) {
-      console.error(
-        "BASE_SHA and HEAD_SHA are required for changed package validation.",
-      );
-      process.exit(1);
-    }
-
-    const result = runChangedPackageCheck(root, BASE_SHA, HEAD_SHA);
-    if ("error" in result) {
-      console.error(
-        `Could not diff ${BASE_SHA}...${HEAD_SHA}: ${result.error}. Failing instead of skipping changeset validation.`,
-      );
-      process.exit(1);
-    }
-
-    const { changedSourceCount, missingChangesets } = result;
-    if (missingChangesets.length > 0) {
-      console.error("Changed published packages without a changeset:\n");
-      for (const { files, name } of missingChangesets) {
-        console.error(`  "${name}" (${files.join(", ")})`);
+    if (problems.length > 0) {
+      console.error("Changesets name packages that cannot be released:\n");
+      for (const { file, name, reason } of problems) {
+        console.error(`  .changeset/${file}: "${name}" ${reason}`);
       }
       console.error(
-        "\nAdd a changeset from this PR that names every changed published package.",
+        "\nChangesets refuses a changeset that mixes a skipped package with a released one,",
+      );
+      console.error(
+        "so `changeset version` aborts and every release stays blocked until the line is removed.",
+      );
+      console.error(
+        "\nDrop the offending line from the changeset frontmatter.",
       );
       process.exit(1);
     }
 
     console.log(
-      `All changed published packages have changesets. (${changedSourceCount} source files scanned)`,
+      `All changeset bumps name releasable workspace packages. (${packageCount} packages scanned)`,
     );
+    return;
+  }
+
+  const { BASE_SHA, HEAD_SHA } = process.env;
+  if (!BASE_SHA || !HEAD_SHA) {
+    console.error(
+      "BASE_SHA and HEAD_SHA are required for changed package validation.",
+    );
+    process.exit(1);
+  }
+
+  const result = runChangedPackageCheck(root, BASE_SHA, HEAD_SHA);
+  if ("error" in result) {
+    annotateError(
+      `Could not diff ${BASE_SHA}...${HEAD_SHA}: ${result.error}. Failing instead of skipping changeset validation.`,
+    );
+    process.exit(1);
+  }
+
+  const { changedSourceCount, missingChangesets } = result;
+  if (missingChangesets.length > 0) {
+    console.error("Changed published packages without a changeset:\n");
+    for (const { files, name } of missingChangesets) {
+      console.error(`  "${name}" (${files.join(", ")})`);
+    }
+    console.error(
+      "\nAdd a changeset from this PR that names every changed published package.",
+    );
+    process.exit(1);
   }
 
   console.log(
-    `All changeset bumps name releasable workspace packages. (${packageCount} packages scanned)`,
+    `All changed published packages have changesets. (${changedSourceCount} source files scanned)`,
   );
 }
 

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { parse } from "@babel/parser";
 import { execFileSync } from "node:child_process";
 import { globSync, readFileSync, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isExecutedAsMain } from "./check-built-declarations.mjs";
@@ -33,6 +33,13 @@ const AST_METADATA_KEYS = new Set([
 ]);
 const OPERATIONAL_COMMENT =
   /(?:^\s*\/\s*<reference\b|@(?:jsx|ts-(?:check|nocheck|ignore|expect-error))\b|[#@]__(?:NO_SIDE_EFFECTS|PURE)__\b|\b(?:sourceMappingURL|sourceURL|vite-ignore|webpack\w*)\b|^!)/i;
+const require = createRequire(import.meta.url);
+let parseSource;
+
+function getSourceParser() {
+  parseSource ??= require("@babel/parser").parse;
+  return parseSource;
+}
 
 export function parseWorkspaceGlobs(source) {
   const globs = [];
@@ -292,7 +299,7 @@ function sourceSignature(file, contents) {
   if (usesJsx) plugins.push("jsx");
 
   try {
-    const syntaxTree = parse(source, {
+    const syntaxTree = getSourceParser()(source, {
       attachComment: true,
       plugins,
       sourceType: "unambiguous",

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -64,6 +64,15 @@ export function readWorkspacePackages(root) {
         manifest: manifest.replaceAll("\\", "/"),
         isPrivate: pkg.private === true,
         hasVersion: Boolean(pkg.version),
+        releaseRoots: (Array.isArray(pkg.files) ? pkg.files : ["src"])
+          .filter(
+            (entry) =>
+              typeof entry === "string" &&
+              !entry.startsWith("!") &&
+              !entry.endsWith(".md"),
+          )
+          .map((entry) => entry.replace(/^\.\//, "").split("/")[0])
+          .filter((entry) => entry && entry !== "dist"),
       });
     }
   }
@@ -172,7 +181,10 @@ export function isReleaseRelevantSourceFile(file) {
   const match = file.match(/^packages\/[^/]+\/src\/(.+)$/);
   if (!match) return false;
 
-  const relative = match[1];
+  return isReleaseRelevantFile(match[1]);
+}
+
+function isReleaseRelevantFile(relative) {
   const segments = relative.split("/");
   if (
     segments.some((segment) =>
@@ -191,6 +203,15 @@ export function isReleaseRelevantSourceFile(file) {
   }
 
   return !/\.(?:bench|generated|spec|stories|test)\.[^/]+$/.test(relative);
+}
+
+function isReleaseRelevantPackageFile(file, pkg) {
+  const packageRoot = path.posix.dirname(pkg.manifest);
+  if (!file.startsWith(`${packageRoot}/`)) return false;
+
+  const relative = file.slice(packageRoot.length + 1);
+  const root = relative.split("/")[0];
+  return pkg.releaseRoots.includes(root) && isReleaseRelevantFile(relative);
 }
 
 export function findMissingPackageChangesets(
@@ -214,7 +235,7 @@ export function findMissingPackageChangesets(
 
     const packageRoot = path.posix.dirname(pkg.manifest);
     const files = [...changedFiles].filter((file) =>
-      file.startsWith(`${packageRoot}/src/`),
+      file.startsWith(`${packageRoot}/`),
     );
     if (files.length > 0 && !bumped.has(name)) {
       missing.push({ files, name });
@@ -236,7 +257,7 @@ function diffChangedFiles(root, baseSha, headSha) {
         "--no-renames",
         range,
         "--",
-        "packages/*/src/**",
+        "packages/**",
       ],
       { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
     )
@@ -255,7 +276,7 @@ function diffChangedFiles(root, baseSha, headSha) {
         "--ignore-matching-lines=^[[:space:]]*//",
         range,
         "--",
-        "packages/*/src/**",
+        "packages/**",
       ],
       { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
     );
@@ -298,7 +319,13 @@ export function runChangedPackageCheck(root, baseSha, headSha) {
       .filter((file) => file.startsWith(".changeset/"))
       .map((file) => path.basename(file)),
   );
-  const sourceFiles = new Set(changedFiles.filter(isReleaseRelevantSourceFile));
+  const sourceFiles = new Set(
+    changedFiles.filter((file) =>
+      [...packages.values()].some((pkg) =>
+        isReleaseRelevantPackageFile(file, pkg),
+      ),
+    ),
+  );
 
   return {
     changedSourceCount: sourceFiles.size,

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -85,15 +85,10 @@ export function readWorkspacePackages(root) {
         manifest: manifest.replaceAll("\\", "/"),
         isPrivate: pkg.private === true,
         hasVersion: Boolean(pkg.version),
-        releaseRoots: (Array.isArray(pkg.files) ? pkg.files : ["src"])
-          .filter(
-            (entry) =>
-              typeof entry === "string" &&
-              !entry.startsWith("!") &&
-              !entry.endsWith(".md"),
-          )
-          .map((entry) => entry.replace(/^\.\//, "").split("/")[0])
-          .filter((entry) => entry && entry !== "dist"),
+        releaseFiles: (Array.isArray(pkg.files) ? pkg.files : ["src"])
+          .filter((entry) => typeof entry === "string")
+          .map((entry) => entry.replace(/^(!?)\.\//, "$1"))
+          .filter(Boolean),
       });
     }
   }
@@ -198,13 +193,6 @@ export function findUnreleasablePackages(packages, bumps, rules) {
   return problems;
 }
 
-export function isReleaseRelevantSourceFile(file) {
-  const match = file.match(/^packages\/[^/]+\/src\/(.+)$/);
-  if (!match) return false;
-
-  return isReleaseRelevantFile(match[1]);
-}
-
 function isReleaseRelevantFile(relative) {
   const segments = relative.split("/");
   if (
@@ -226,13 +214,38 @@ function isReleaseRelevantFile(relative) {
   return !/\.(?:bench|generated|spec|stories|test)\.[^/]+$/.test(relative);
 }
 
-function isReleaseRelevantPackageFile(file, pkg) {
+function matchesReleasePattern(relative, rawPattern) {
+  const pattern = rawPattern.replace(/^!/, "").replace(/\/$/, "");
+  if (pattern === ".") return true;
+  if (!/[*?{}[\]]/.test(pattern)) {
+    return relative === pattern || relative.startsWith(`${pattern}/`);
+  }
+  return path.matchesGlob(relative, pattern);
+}
+
+export function isReleaseRelevantPackageFile(file, pkg) {
   const packageRoot = path.posix.dirname(pkg.manifest);
   if (!file.startsWith(`${packageRoot}/`)) return false;
 
   const relative = file.slice(packageRoot.length + 1);
-  const root = relative.split("/")[0];
-  return pkg.releaseRoots.includes(root) && isReleaseRelevantFile(relative);
+  if (
+    relative === "package.json" ||
+    relative === "dist" ||
+    relative.startsWith("dist/") ||
+    /\.md$/i.test(relative)
+  ) {
+    return false;
+  }
+
+  const included = pkg.releaseFiles.some(
+    (pattern) =>
+      !pattern.startsWith("!") && matchesReleasePattern(relative, pattern),
+  );
+  const excluded = pkg.releaseFiles.some(
+    (pattern) =>
+      pattern.startsWith("!") && matchesReleasePattern(relative, pattern),
+  );
+  return included && !excluded && isReleaseRelevantFile(relative);
 }
 
 function isOperationalComment(comment) {

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -204,21 +204,15 @@ function isReleaseRelevantFile(relative) {
   const segments = relative.split("/");
   if (
     segments.some((segment) =>
-      [
-        "__fixtures__",
-        "__generated__",
-        "__tests__",
-        "fixtures",
-        "generated",
-        "test",
-        "tests",
-      ].includes(segment),
+      ["__fixtures__", "__tests__", "fixtures", "test", "tests"].includes(
+        segment,
+      ),
     )
   ) {
     return false;
   }
 
-  return !/\.(?:bench|generated|spec|stories|test)\.[^/]+$/.test(relative);
+  return !/\.(?:bench|spec|stories|test)\.[^/]+$/.test(relative);
 }
 
 function matchesReleasePattern(relative, rawPattern) {
@@ -393,7 +387,19 @@ export function findMissingPackageChangesets(
 
 function diffChangedFiles(root, baseSha, headSha, packages) {
   try {
-    const range = `${baseSha}...${headSha}`;
+    const mergeBase = execFileSync("git", ["merge-base", baseSha, headSha], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    const range = `${mergeBase}..${headSha}`;
+    const packageRoots = [
+      ...new Set(
+        [...packages.values()].map(
+          (pkg) => `${path.posix.dirname(pkg.manifest)}/**`,
+        ),
+      ),
+    ];
     const packageChanges = parseNameStatus(
       execFileSync(
         "git",
@@ -402,10 +408,10 @@ function diffChangedFiles(root, baseSha, headSha, packages) {
           "--name-status",
           "-z",
           "--find-renames",
-          "--diff-filter=ACDMRT",
+          "--diff-filter=ADMRT",
           range,
           "--",
-          "packages/**",
+          ...packageRoots,
         ],
         { cwd: root, stdio: ["ignore", "pipe", "pipe"] },
       ),
@@ -422,19 +428,10 @@ function diffChangedFiles(root, baseSha, headSha, packages) {
         }
         continue;
       }
-      if (status === "C") {
-        if (
-          owner &&
-          contentsDiffer(file, null, readGitFile(root, headSha, file))
-        ) {
-          changedPackageFiles.push(file);
-        }
-        continue;
-      }
       if (!owner) continue;
 
       const baseContents =
-        status === "A" ? null : readGitFile(root, baseSha, file);
+        status === "A" ? null : readGitFile(root, mergeBase, file);
       const headContents =
         status === "D" ? null : readGitFile(root, headSha, file);
       if (contentsDiffer(file, baseContents, headContents)) {

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -354,25 +354,28 @@ function parseNameStatus(output) {
   return entries;
 }
 
+function releasablePackages(packages, rules) {
+  const ignored = expandPackageGlobs(packages.keys(), rules.ignored);
+  return new Map(
+    [...packages].filter(
+      ([name, pkg]) =>
+        !ignored.has(name) &&
+        !(pkg.isPrivate && rules.skipsPrivate) &&
+        pkg.hasVersion,
+    ),
+  );
+}
+
 export function findMissingPackageChangesets(
   packages,
   bumps,
   changedFiles,
   rules,
 ) {
-  const ignored = expandPackageGlobs(packages.keys(), rules.ignored);
   const bumped = new Set(bumps.map(({ name }) => name));
   const missing = [];
 
-  for (const [name, pkg] of packages) {
-    if (
-      ignored.has(name) ||
-      (pkg.isPrivate && rules.skipsPrivate) ||
-      !pkg.hasVersion
-    ) {
-      continue;
-    }
-
+  for (const [name, pkg] of releasablePackages(packages, rules)) {
     const packageRoot = path.posix.dirname(pkg.manifest);
     const files = [...changedFiles].filter((file) =>
       file.startsWith(`${packageRoot}/`),
@@ -462,13 +465,13 @@ function diffChangedFiles(root, baseSha, headSha, packages) {
 }
 
 export function runChangedPackageCheck(root, baseSha, headSha) {
-  const packages = readWorkspacePackages(root);
-  const changedFiles = diffChangedFiles(root, baseSha, headSha, packages);
-  if (!Array.isArray(changedFiles)) return changedFiles;
-
   const rules = readSkipRules(
     readJson(path.join(root, ".changeset", "config.json")),
   );
+  const packages = releasablePackages(readWorkspacePackages(root), rules);
+  const changedFiles = diffChangedFiles(root, baseSha, headSha, packages);
+  if (!Array.isArray(changedFiles)) return changedFiles;
+
   const changesetFiles = new Set(
     changedFiles
       .filter((file) => file.startsWith(".changeset/"))

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -176,7 +176,7 @@ test("isReleaseRelevantPackageFile excludes non-release package files", () => {
     "packages/core/src/tests/helper.ts",
     "packages/core/src/fixtures/messages.ts",
     "packages/core/src/internal/private.ts",
-    "packages/core/src/guide.md",
+    "packages/core/README.md",
     "packages/core/dist/index.js",
     "packages/core/package.json",
     "apps/docs/src/page.tsx",
@@ -190,6 +190,10 @@ test("isReleaseRelevantPackageFile excludes non-release package files", () => {
   );
   assert.equal(
     isReleaseRelevantPackageFile("packages/core/plugin/index.js", pkg),
+    true,
+  );
+  assert.equal(
+    isReleaseRelevantPackageFile("packages/core/plugin/SKILL.md", pkg),
     true,
   );
   assert.equal(
@@ -632,7 +636,7 @@ test("changed package validation scans published packages outside packages", () 
       path.join(root, "pnpm-workspace.yaml"),
       "packages:\n  - packages/*\n  - libs/*\n",
     );
-    const sourceDir = path.join(root, "libs", "published", "src");
+    const sourceDir = path.join(root, "libs", "published", "plugin");
     mkdirSync(sourceDir, { recursive: true });
     writeFileSync(
       path.join(root, "libs", "published", "package.json"),
@@ -650,7 +654,7 @@ test("changed package validation scans published packages outside packages", () 
       changedSourceCount: 1,
       missingChangesets: [
         {
-          files: ["libs/published/src/index.ts"],
+          files: ["libs/published/plugin/index.ts"],
           name: "@fixture/outside",
         },
       ],

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -1,14 +1,17 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
+  apiSurfaceFileName,
+  findMissingApiSurfaceChangesets,
   findUnreleasablePackages,
   parseBumpLine,
   parseWorkspaceGlobs,
   readSkipRules,
+  runChangedApiSurfaceCheck,
   runCheck,
 } from "./check-changesets.mjs";
 
@@ -153,6 +156,64 @@ test("findUnreleasablePackages flags private and unknown names", () => {
   assert.match(problems[1].reason, /is not a workspace package/);
 });
 
+test("apiSurfaceFileName matches generated surface names", () => {
+  assert.equal(
+    apiSurfaceFileName("@assistant-ui/store"),
+    "api-surface/assistant-ui__store.ts",
+  );
+  assert.equal(
+    apiSurfaceFileName("assistant-stream"),
+    "api-surface/assistant-stream.ts",
+  );
+});
+
+test("findMissingApiSurfaceChangesets requires the changed package bump", () => {
+  const packages = new Map([
+    [
+      "@assistant-ui/store",
+      {
+        manifest: "packages/store/package.json",
+        isPrivate: false,
+        hasVersion: true,
+      },
+    ],
+    [
+      "@assistant-ui/core",
+      {
+        manifest: "packages/core/package.json",
+        isPrivate: false,
+        hasVersion: true,
+      },
+    ],
+  ]);
+  const changedFiles = new Set(["api-surface/assistant-ui__store.ts"]);
+  const rules = { ignored: [], skipsPrivate: true };
+
+  assert.deepEqual(
+    findMissingApiSurfaceChangesets(
+      packages,
+      [{ file: "core.md", name: "@assistant-ui/core" }],
+      changedFiles,
+      rules,
+    ),
+    [
+      {
+        file: "api-surface/assistant-ui__store.ts",
+        name: "@assistant-ui/store",
+      },
+    ],
+  );
+  assert.deepEqual(
+    findMissingApiSurfaceChangesets(
+      packages,
+      [{ file: "store.md", name: "@assistant-ui/store" }],
+      changedFiles,
+      rules,
+    ),
+    [],
+  );
+});
+
 test("runCheck accepts a workspace whose changesets are all releasable", () => {
   const root = createWorkspace(
     '---\n"@fixture/published": patch\n---\n\nfix: something\n',
@@ -287,13 +348,93 @@ test("runCheck allows a private package when the config versions it", () => {
   }
 });
 
-function runExecutable(root) {
+function git(root, ...args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+}
+
+function commitAll(root, message) {
+  git(root, "add", ".");
+  git(
+    root,
+    "-c",
+    "user.name=fixture",
+    "-c",
+    "user.email=fixture@example.com",
+    "commit",
+    "-q",
+    "-m",
+    message,
+  );
+  return git(root, "rev-parse", "HEAD");
+}
+
+function runExecutable(root, { args = [], env = {} } = {}) {
   return spawnSync(
     process.execPath,
-    [path.join(repoRoot, "scripts", "check-changesets.mjs")],
-    { encoding: "utf8", env: { ...process.env, CHANGESET_CHECK_ROOT: root } },
+    [path.join(repoRoot, "scripts", "check-changesets.mjs"), ...args],
+    {
+      encoding: "utf8",
+      env: { ...process.env, CHANGESET_CHECK_ROOT: root, ...env },
+    },
   );
 }
+
+test("changed API surface validation only accepts a changeset from the PR", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/published": patch\n---\n\nfix: already on base\n',
+  );
+  try {
+    mkdirSync(path.join(root, "api-surface"));
+    const surface = path.join(root, "api-surface", "fixture__published.ts");
+    writeFileSync(surface, "export type Existing = string;\n");
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+
+    writeFileSync(
+      surface,
+      "export type Existing = string;\nexport type Added = string;\n",
+    );
+    const missingHead = commitAll(root, "surface without changeset");
+
+    assert.deepEqual(
+      runChangedApiSurfaceCheck(root, base, missingHead).missingChangesets.map(
+        ({ name }) => name,
+      ),
+      ["@fixture/published"],
+    );
+    const missingResult = runExecutable(root, {
+      args: ["--changed-api-surface"],
+      env: { BASE_SHA: base, HEAD_SHA: missingHead },
+    });
+    assert.equal(missingResult.status, 1);
+    assert.match(
+      missingResult.stderr,
+      /add a changeset for "@fixture\/published"/,
+    );
+
+    writeFileSync(
+      path.join(root, ".changeset", "added-by-pr.md"),
+      '---\n"@fixture/published": patch\n---\n\nfeat: publish added type\n',
+    );
+    const coveredHead = commitAll(root, "add changeset");
+    const coveredResult = runExecutable(root, {
+      args: ["--changed-api-surface"],
+      env: { BASE_SHA: base, HEAD_SHA: coveredHead },
+    });
+
+    assert.equal(
+      coveredResult.status,
+      0,
+      coveredResult.stdout + coveredResult.stderr,
+    );
+    assert.match(
+      coveredResult.stdout,
+      /All changed API surfaces have changesets\./,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("the executable reports success and exits 0", () => {
   const root = createWorkspace(

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -5,13 +5,13 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
-  apiSurfaceFileName,
-  findMissingApiSurfaceChangesets,
+  findMissingPackageChangesets,
   findUnreleasablePackages,
+  isReleaseRelevantSourceFile,
   parseBumpLine,
   parseWorkspaceGlobs,
   readSkipRules,
-  runChangedApiSurfaceCheck,
+  runChangedPackageCheck,
   runCheck,
 } from "./check-changesets.mjs";
 
@@ -156,18 +156,29 @@ test("findUnreleasablePackages flags private and unknown names", () => {
   assert.match(problems[1].reason, /is not a workspace package/);
 });
 
-test("apiSurfaceFileName matches generated surface names", () => {
+test("isReleaseRelevantSourceFile excludes non-release source files", () => {
+  for (const file of [
+    "packages/core/src/runtime.test.ts",
+    "packages/core/src/runtime.spec.tsx",
+    "packages/core/src/runtime.stories.tsx",
+    "packages/core/src/runtime.bench.ts",
+    "packages/core/src/__tests__/runtime.ts",
+    "packages/core/src/tests/helper.ts",
+    "packages/core/src/fixtures/messages.ts",
+    "packages/core/src/generated/protocol.ts",
+    "packages/core/src/protocol.generated.ts",
+    "apps/docs/src/page.tsx",
+  ]) {
+    assert.equal(isReleaseRelevantSourceFile(file), false, file);
+  }
+
   assert.equal(
-    apiSurfaceFileName("@assistant-ui/store"),
-    "api-surface/assistant-ui__store.ts",
-  );
-  assert.equal(
-    apiSurfaceFileName("assistant-stream"),
-    "api-surface/assistant-stream.ts",
+    isReleaseRelevantSourceFile("packages/core/src/runtime.ts"),
+    true,
   );
 });
 
-test("findMissingApiSurfaceChangesets requires the changed package bump", () => {
+test("findMissingPackageChangesets requires each changed package bump", () => {
   const packages = new Map([
     [
       "@assistant-ui/store",
@@ -186,11 +197,11 @@ test("findMissingApiSurfaceChangesets requires the changed package bump", () => 
       },
     ],
   ]);
-  const changedFiles = new Set(["api-surface/assistant-ui__store.ts"]);
+  const changedFiles = new Set(["packages/store/src/index.ts"]);
   const rules = { ignored: [], skipsPrivate: true };
 
   assert.deepEqual(
-    findMissingApiSurfaceChangesets(
+    findMissingPackageChangesets(
       packages,
       [{ file: "core.md", name: "@assistant-ui/core" }],
       changedFiles,
@@ -198,13 +209,13 @@ test("findMissingApiSurfaceChangesets requires the changed package bump", () => 
     ),
     [
       {
-        file: "api-surface/assistant-ui__store.ts",
+        files: ["packages/store/src/index.ts"],
         name: "@assistant-ui/store",
       },
     ],
   );
   assert.deepEqual(
-    findMissingApiSurfaceChangesets(
+    findMissingPackageChangesets(
       packages,
       [{ file: "store.md", name: "@assistant-ui/store" }],
       changedFiles,
@@ -379,38 +390,46 @@ function runExecutable(root, { args = [], env = {} } = {}) {
   );
 }
 
-test("changed API surface validation only accepts a changeset from the PR", () => {
+test("changed package validation ignores non-release edits and requires a PR changeset", () => {
   const root = createWorkspace(
     '---\n"@fixture/published": patch\n---\n\nfix: already on base\n',
   );
   try {
-    mkdirSync(path.join(root, "api-surface"));
-    const surface = path.join(root, "api-surface", "fixture__published.ts");
-    writeFileSync(surface, "export type Existing = string;\n");
+    const sourceDir = path.join(root, "packages", "published", "src");
+    mkdirSync(sourceDir);
+    const source = path.join(sourceDir, "index.ts");
+    const testFile = path.join(sourceDir, "index.test.ts");
+    writeFileSync(source, "// original\nexport const existing = 1;\n");
+    writeFileSync(testFile, "// original test\n");
     git(root, "init", "-q", "-b", "main");
     const base = commitAll(root, "base");
 
+    writeFileSync(source, "// clarified\nexport const existing = 1;\n");
+    writeFileSync(testFile, "// expanded test\n");
+    const nonReleaseHead = commitAll(root, "comments and tests");
+    assert.deepEqual(runChangedPackageCheck(root, base, nonReleaseHead), {
+      changedSourceCount: 0,
+      missingChangesets: [],
+    });
+
     writeFileSync(
-      surface,
-      "export type Existing = string;\nexport type Added = string;\n",
+      source,
+      "// clarified\nexport const existing = 1;\nexport const added = 2;\n",
     );
-    const missingHead = commitAll(root, "surface without changeset");
+    const missingHead = commitAll(root, "source without changeset");
 
     assert.deepEqual(
-      runChangedApiSurfaceCheck(root, base, missingHead).missingChangesets.map(
+      runChangedPackageCheck(root, base, missingHead).missingChangesets.map(
         ({ name }) => name,
       ),
       ["@fixture/published"],
     );
     const missingResult = runExecutable(root, {
-      args: ["--changed-api-surface"],
+      args: ["--changed-packages"],
       env: { BASE_SHA: base, HEAD_SHA: missingHead },
     });
     assert.equal(missingResult.status, 1);
-    assert.match(
-      missingResult.stderr,
-      /add a changeset for "@fixture\/published"/,
-    );
+    assert.match(missingResult.stderr, /"@fixture\/published"/);
 
     writeFileSync(
       path.join(root, ".changeset", "added-by-pr.md"),
@@ -418,7 +437,7 @@ test("changed API surface validation only accepts a changeset from the PR", () =
     );
     const coveredHead = commitAll(root, "add changeset");
     const coveredResult = runExecutable(root, {
-      args: ["--changed-api-surface"],
+      args: ["--changed-packages"],
       env: { BASE_SHA: base, HEAD_SHA: coveredHead },
     });
 
@@ -429,8 +448,93 @@ test("changed API surface validation only accepts a changeset from the PR", () =
     );
     assert.match(
       coveredResult.stdout,
-      /All changed API surfaces have changesets\./,
+      /All changed published packages have changesets\./,
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("deleting published source requires a changeset", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/held": patch\n---\n\nfix: unrelated package\n',
+  );
+  try {
+    const sourceDir = path.join(root, "packages", "published", "src");
+    mkdirSync(sourceDir);
+    const source = path.join(sourceDir, "removed.ts");
+    writeFileSync(source, "export const removed = true;\n");
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+
+    rmSync(source);
+    const head = commitAll(root, "delete source");
+
+    assert.deepEqual(runChangedPackageCheck(root, base, head), {
+      changedSourceCount: 1,
+      missingChangesets: [
+        {
+          files: ["packages/published/src/removed.ts"],
+          name: "@fixture/published",
+        },
+      ],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a version-only PR passes without a branch-name exemption", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/published": patch\n---\n\nfix: release\n',
+  );
+  try {
+    const sourceDir = path.join(root, "packages", "published", "src");
+    mkdirSync(sourceDir);
+    writeFileSync(
+      path.join(sourceDir, "index.ts"),
+      "export const value = 1;\n",
+    );
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+
+    const manifest = path.join(root, "packages", "published", "package.json");
+    writeFileSync(
+      manifest,
+      JSON.stringify({ name: "@fixture/published", version: "1.0.1" }),
+    );
+    rmSync(path.join(root, ".changeset", "entry.md"));
+    const head = commitAll(root, "version packages");
+
+    assert.deepEqual(runChangedPackageCheck(root, base, head), {
+      changedSourceCount: 0,
+      missingChangesets: [],
+    });
+    const result = runExecutable(root, {
+      args: ["--changed-packages"],
+      env: { BASE_SHA: base, HEAD_SHA: head },
+    });
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("changed package validation reports an unresolvable range", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/published": patch\n---\n\nfix: fixture\n',
+  );
+  try {
+    git(root, "init", "-q", "-b", "main");
+    const head = commitAll(root, "base");
+    const result = runExecutable(root, {
+      args: ["--changed-packages"],
+      env: { BASE_SHA: "missing-base", HEAD_SHA: head },
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Could not diff missing-base/);
+    assert.doesNotMatch(result.stderr, /at diffChangedFiles/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -13,7 +13,7 @@ import test from "node:test";
 import {
   findMissingPackageChangesets,
   findUnreleasablePackages,
-  isReleaseRelevantSourceFile,
+  isReleaseRelevantPackageFile,
   parseBumpLine,
   parseWorkspaceGlobs,
   readSkipRules,
@@ -162,7 +162,11 @@ test("findUnreleasablePackages flags private and unknown names", () => {
   assert.match(problems[1].reason, /is not a workspace package/);
 });
 
-test("isReleaseRelevantSourceFile excludes non-release source files", () => {
+test("isReleaseRelevantPackageFile excludes non-release package files", () => {
+  const pkg = {
+    manifest: "packages/core/package.json",
+    releaseFiles: ["src", "!src/internal", "plugin"],
+  };
   for (const file of [
     "packages/core/src/runtime.test.ts",
     "packages/core/src/runtime.spec.tsx",
@@ -173,13 +177,21 @@ test("isReleaseRelevantSourceFile excludes non-release source files", () => {
     "packages/core/src/fixtures/messages.ts",
     "packages/core/src/generated/protocol.ts",
     "packages/core/src/protocol.generated.ts",
+    "packages/core/src/internal/private.ts",
+    "packages/core/src/guide.md",
+    "packages/core/dist/index.js",
+    "packages/core/package.json",
     "apps/docs/src/page.tsx",
   ]) {
-    assert.equal(isReleaseRelevantSourceFile(file), false, file);
+    assert.equal(isReleaseRelevantPackageFile(file, pkg), false, file);
   }
 
   assert.equal(
-    isReleaseRelevantSourceFile("packages/core/src/runtime.ts"),
+    isReleaseRelevantPackageFile("packages/core/src/runtime.ts", pkg),
+    true,
+  );
+  assert.equal(
+    isReleaseRelevantPackageFile("packages/core/plugin/index.js", pkg),
     true,
   );
 });
@@ -644,16 +656,30 @@ test("published code outside src requires a changeset", () => {
     const pkg = JSON.parse(readFileSync(manifest, "utf8"));
     writeFileSync(
       manifest,
-      JSON.stringify({ ...pkg, files: ["dist", "src", "plugin", "README.md"] }),
+      JSON.stringify({
+        ...pkg,
+        files: ["dist", "src", "!src/internal", "plugin", "README.md"],
+      }),
     );
     const pluginDir = path.join(root, "packages", "published", "plugin");
+    const internalDir = path.join(
+      root,
+      "packages",
+      "published",
+      "src",
+      "internal",
+    );
     mkdirSync(pluginDir);
+    mkdirSync(internalDir, { recursive: true });
     const plugin = path.join(pluginDir, "entry.js");
+    const internal = path.join(internalDir, "private.ts");
     writeFileSync(plugin, "export const value = 1;\n");
+    writeFileSync(internal, "export const privateValue = 1;\n");
     git(root, "init", "-q", "-b", "main");
     const base = commitAll(root, "base");
 
     writeFileSync(plugin, "export const value = 2;\n");
+    writeFileSync(internal, "export const privateValue = 2;\n");
     const head = commitAll(root, "change published plugin");
 
     assert.deepEqual(runChangedPackageCheck(root, base, head), {

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -475,6 +481,41 @@ test("deleting published source requires a changeset", () => {
       missingChangesets: [
         {
           files: ["packages/published/src/removed.ts"],
+          name: "@fixture/published",
+        },
+      ],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("published code outside src requires a changeset", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/held": patch\n---\n\nfix: unrelated package\n',
+  );
+  try {
+    const manifest = path.join(root, "packages", "published", "package.json");
+    const pkg = JSON.parse(readFileSync(manifest, "utf8"));
+    writeFileSync(
+      manifest,
+      JSON.stringify({ ...pkg, files: ["dist", "src", "plugin", "README.md"] }),
+    );
+    const pluginDir = path.join(root, "packages", "published", "plugin");
+    mkdirSync(pluginDir);
+    const plugin = path.join(pluginDir, "entry.js");
+    writeFileSync(plugin, "export const value = 1;\n");
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+
+    writeFileSync(plugin, "export const value = 2;\n");
+    const head = commitAll(root, "change published plugin");
+
+    assert.deepEqual(runChangedPackageCheck(root, base, head), {
+      changedSourceCount: 1,
+      missingChangesets: [
+        {
+          files: ["packages/published/plugin/entry.js"],
           name: "@fixture/published",
         },
       ],

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -484,6 +484,39 @@ test("deleting published source requires a changeset", () => {
   }
 });
 
+test("moving source between published packages requires both changesets", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/unversioned": patch\n---\n\nfix: unrelated package\n',
+  );
+  try {
+    mkdirSync(path.join(root, "packages", "published", "src"));
+    mkdirSync(path.join(root, "packages", "held", "src"));
+    writeFileSync(
+      path.join(root, "packages", "published", "src", "moved.ts"),
+      "export const moved = true;\n",
+    );
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+
+    git(
+      root,
+      "mv",
+      "packages/published/src/moved.ts",
+      "packages/held/src/moved.ts",
+    );
+    const head = commitAll(root, "move source");
+
+    assert.deepEqual(
+      runChangedPackageCheck(root, base, head).missingChangesets.map(
+        ({ name }) => name,
+      ),
+      ["@fixture/published", "@fixture/held"],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("a version-only PR passes without a branch-name exemption", () => {
   const root = createWorkspace(
     '---\n"@fixture/published": patch\n---\n\nfix: release\n',

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -522,6 +522,83 @@ test("changed package validation ignores formatting and ordinary block comments"
   }
 });
 
+for (const directory of ["internal", "held", "unversioned"]) {
+  test(`changed package validation does not read skipped ${directory} source`, () => {
+    const root = createWorkspace("---\n---\n", {
+      ignore: [
+        "@fixture/*",
+        "!@fixture/published",
+        "!@fixture/internal",
+        "!@fixture/unversioned",
+      ],
+    });
+    try {
+      writeFileSync(
+        path.join(root, "packages", "internal", "package.json"),
+        JSON.stringify({
+          name: "@fixture/internal",
+          version: "1.0.0",
+          private: true,
+        }),
+      );
+      git(root, "init", "-q", "-b", "main");
+      const base = commitAll(root, "base");
+      const sourceDir = path.join(root, "packages", directory, "src");
+      mkdirSync(sourceDir);
+      // Exceeds execFileSync's default buffer so reading a skipped blob fails the check.
+      writeFileSync(
+        path.join(sourceDir, "index.ts"),
+        "// skipped source\n".repeat(70_000),
+      );
+      const head = commitAll(root, "change skipped package");
+
+      assert.deepEqual(runChangedPackageCheck(root, base, head), {
+        changedSourceCount: 0,
+        missingChangesets: [],
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+}
+
+test("changed package validation includes private packages opted into versioning", () => {
+  const root = createWorkspace("---\n---\n", {
+    privatePackages: { version: true },
+  });
+  try {
+    writeFileSync(
+      path.join(root, "packages", "internal", "package.json"),
+      JSON.stringify({
+        name: "@fixture/internal",
+        version: "1.0.0",
+        private: true,
+      }),
+    );
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+    const sourceDir = path.join(root, "packages", "internal", "src");
+    mkdirSync(sourceDir);
+    writeFileSync(
+      path.join(sourceDir, "index.ts"),
+      "export const value = 1;\n",
+    );
+    const head = commitAll(root, "change versioned private package");
+
+    assert.deepEqual(runChangedPackageCheck(root, base, head), {
+      changedSourceCount: 1,
+      missingChangesets: [
+        {
+          name: "@fixture/internal",
+          files: ["packages/internal/src/index.ts"],
+        },
+      ],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("changed package validation keeps semantic whitespace", () => {
   const root = createWorkspace(
     '---\n"@fixture/held": patch\n---\n\nfix: unrelated package\n',

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -175,8 +175,6 @@ test("isReleaseRelevantPackageFile excludes non-release package files", () => {
     "packages/core/src/__tests__/runtime.ts",
     "packages/core/src/tests/helper.ts",
     "packages/core/src/fixtures/messages.ts",
-    "packages/core/src/generated/protocol.ts",
-    "packages/core/src/protocol.generated.ts",
     "packages/core/src/internal/private.ts",
     "packages/core/src/guide.md",
     "packages/core/dist/index.js",
@@ -192,6 +190,13 @@ test("isReleaseRelevantPackageFile excludes non-release package files", () => {
   );
   assert.equal(
     isReleaseRelevantPackageFile("packages/core/plugin/index.js", pkg),
+    true,
+  );
+  assert.equal(
+    isReleaseRelevantPackageFile(
+      "packages/core/src/generated/protocol.generated.ts",
+      pkg,
+    ),
     true,
   );
 });
@@ -609,6 +614,77 @@ test("changed package validation handles non-ASCII paths", () => {
       missingChangesets: [
         {
           files: ["packages/published/src/café.ts"],
+          name: "@fixture/published",
+        },
+      ],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("changed package validation scans published packages outside packages", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/held": patch\n---\n\nfix: unrelated package\n',
+  );
+  try {
+    writeFileSync(
+      path.join(root, "pnpm-workspace.yaml"),
+      "packages:\n  - packages/*\n  - libs/*\n",
+    );
+    const sourceDir = path.join(root, "libs", "published", "src");
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(
+      path.join(root, "libs", "published", "package.json"),
+      JSON.stringify({ name: "@fixture/outside", version: "1.0.0" }),
+    );
+    const source = path.join(sourceDir, "index.ts");
+    writeFileSync(source, "export const value = 1;\n");
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+
+    writeFileSync(source, "export const value = 2;\n");
+    const head = commitAll(root, "change published package outside packages");
+
+    assert.deepEqual(runChangedPackageCheck(root, base, head), {
+      changedSourceCount: 1,
+      missingChangesets: [
+        {
+          files: ["libs/published/src/index.ts"],
+          name: "@fixture/outside",
+        },
+      ],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("changed package validation reads old contents from the merge base", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/held": patch\n---\n\nfix: unrelated package\n',
+  );
+  try {
+    const sourceDir = path.join(root, "packages", "published", "src");
+    mkdirSync(sourceDir);
+    const source = path.join(sourceDir, "index.ts");
+    writeFileSync(source, "export const value = 1;\n");
+    git(root, "init", "-q", "-b", "main");
+    commitAll(root, "fork point");
+
+    git(root, "switch", "-q", "-c", "feature");
+    writeFileSync(source, "export const value = 2;\n");
+    const head = commitAll(root, "change source on feature");
+
+    git(root, "switch", "-q", "main");
+    rmSync(source);
+    const base = commitAll(root, "delete source on target");
+
+    assert.deepEqual(runChangedPackageCheck(root, base, head), {
+      changedSourceCount: 1,
+      missingChangesets: [
+        {
+          files: ["packages/published/src/index.ts"],
           name: "@fixture/published",
         },
       ],

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -461,6 +461,151 @@ test("changed package validation ignores non-release edits and requires a PR cha
   }
 });
 
+test("changed package validation ignores formatting and ordinary block comments", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/held": patch\n---\n\nfix: unrelated package\n',
+  );
+  try {
+    const sourceDir = path.join(root, "packages", "published", "src");
+    mkdirSync(sourceDir);
+    const source = path.join(sourceDir, "index.ts");
+    const deletedComment = path.join(sourceDir, "deleted-comment.ts");
+    writeFileSync(
+      source,
+      "/** Original documentation. */\nexport const value = { nested: 1 };\n",
+    );
+    writeFileSync(
+      deletedComment,
+      "/* Nothing is published from this file. */\n",
+    );
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+
+    writeFileSync(
+      source,
+      "/**\n * Expanded documentation.\n */\nexport const value={\n  nested: 1\n}\n",
+    );
+    writeFileSync(
+      path.join(sourceDir, "added-comment.ts"),
+      "/* Nothing is published from this file either. */\n",
+    );
+    rmSync(deletedComment);
+    const head = commitAll(root, "format and document source");
+
+    assert.deepEqual(runChangedPackageCheck(root, base, head), {
+      changedSourceCount: 0,
+      missingChangesets: [],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("changed package validation keeps semantic whitespace", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/held": patch\n---\n\nfix: unrelated package\n',
+  );
+  try {
+    const sourceDir = path.join(root, "packages", "published", "src");
+    mkdirSync(sourceDir);
+    const source = path.join(sourceDir, "content.tsx");
+    writeFileSync(
+      source,
+      [
+        'export const stringValue = "a b";',
+        "export const templateValue = `a b`;",
+        "export const regexpValue = /a b/;",
+        "export const jsxValue = <span> a </span>;",
+        "export const templateComment = `${stringValue}\\n// original`;",
+        "",
+      ].join("\n"),
+    );
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+
+    writeFileSync(
+      source,
+      [
+        'export const stringValue = "ab";',
+        "export const templateValue = `ab`;",
+        "export const regexpValue = /ab/;",
+        "export const jsxValue = <span>a</span>;",
+        "export const templateComment = `${stringValue}\\n// changed`;",
+        "",
+      ].join("\n"),
+    );
+    const head = commitAll(root, "change meaningful whitespace");
+
+    assert.deepEqual(runChangedPackageCheck(root, base, head), {
+      changedSourceCount: 1,
+      missingChangesets: [
+        {
+          files: ["packages/published/src/content.tsx"],
+          name: "@fixture/published",
+        },
+      ],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("changed package validation keeps compiler directives", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/held": patch\n---\n\nfix: unrelated package\n',
+  );
+  try {
+    const sourceDir = path.join(root, "packages", "published", "src");
+    mkdirSync(sourceDir);
+    const source = path.join(sourceDir, "directive.ts");
+    writeFileSync(
+      source,
+      "// @ts-expect-error intentional fixture\nmissing();\n",
+    );
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+
+    writeFileSync(source, "missing();\n");
+    const head = commitAll(root, "remove compiler directive");
+
+    assert.equal(
+      runChangedPackageCheck(root, base, head).changedSourceCount,
+      1,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("changed package validation handles non-ASCII paths", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/held": patch\n---\n\nfix: unrelated package\n',
+  );
+  try {
+    const sourceDir = path.join(root, "packages", "published", "src");
+    mkdirSync(sourceDir);
+    const source = path.join(sourceDir, "café.ts");
+    writeFileSync(source, "export const value = 1;\n");
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+
+    writeFileSync(source, "export const value = 2;\n");
+    const head = commitAll(root, "change non-ASCII path");
+
+    assert.deepEqual(runChangedPackageCheck(root, base, head), {
+      changedSourceCount: 1,
+      missingChangesets: [
+        {
+          files: ["packages/published/src/café.ts"],
+          name: "@fixture/published",
+        },
+      ],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("deleting published source requires a changeset", () => {
   const root = createWorkspace(
     '---\n"@fixture/held": patch\n---\n\nfix: unrelated package\n',
@@ -553,6 +698,79 @@ test("moving source between published packages requires both changesets", () => 
       ),
       ["@fixture/published", "@fixture/held"],
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("renaming source within a published package is counted once", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/held": patch\n---\n\nfix: unrelated package\n',
+  );
+  try {
+    const sourceDir = path.join(root, "packages", "published", "src");
+    mkdirSync(sourceDir);
+    writeFileSync(
+      path.join(sourceDir, "before.ts"),
+      "export const value = true;\n",
+    );
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+
+    git(
+      root,
+      "mv",
+      "packages/published/src/before.ts",
+      "packages/published/src/after.ts",
+    );
+    const head = commitAll(root, "rename source");
+
+    assert.deepEqual(runChangedPackageCheck(root, base, head), {
+      changedSourceCount: 1,
+      missingChangesets: [
+        {
+          files: ["packages/published/src/after.ts"],
+          name: "@fixture/published",
+        },
+      ],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("changed package validation bounds file lists in errors", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/held": patch\n---\n\nfix: unrelated package\n',
+  );
+  try {
+    const sourceDir = path.join(root, "packages", "published", "src");
+    mkdirSync(sourceDir);
+    for (let index = 0; index < 7; index++) {
+      writeFileSync(
+        path.join(sourceDir, `file-${index}.ts`),
+        `export const value${index} = 1;\n`,
+      );
+    }
+    git(root, "init", "-q", "-b", "main");
+    const base = commitAll(root, "base");
+
+    for (let index = 0; index < 7; index++) {
+      writeFileSync(
+        path.join(sourceDir, `file-${index}.ts`),
+        `export const value${index} = 2;\n`,
+      );
+    }
+    const head = commitAll(root, "change many source files");
+    const result = runExecutable(root, {
+      args: ["--changed-packages"],
+      env: { BASE_SHA: base, HEAD_SHA: head },
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /file-0\.ts/);
+    assert.match(result.stderr, /and 2 more/);
+    assert.doesNotMatch(result.stderr, /file-6\.ts/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem

a PR can change code a published package ships without a changeset naming that package. `changeset version` then releases only the packages other changesets name, so a sibling can publish against a version that does not contain the code it imports. #3639 did exactly this to `@assistant-ui/store`; #6692 has the sequence.

closes #6692

## Root cause

`scripts/check-changesets.mjs` only validated the packages changesets already named. nothing compared a PR's changed files with the changesets that PR added.

## Change

`node scripts/check-changesets.mjs --changed-packages` runs as a new step in the Changeset Semver Check:

- lists the PR's changed paths with one `git diff --name-only --no-renames -z $BASE_SHA...$HEAD_SHA`, the same three-dot range `check-changeset-semver.mjs` diffs, so commits that landed on main after the fork are never attributed to the PR, and a move between packages reports both packages
- keeps releasable packages only, reusing the skip rules the existing guard applies (ignored, private unless versioned, versionless)
- counts a path when the package's `files` list ships it, minus `dist/`, `package.json`, top-level Markdown and test files (`.test.`, `.spec.`, `.bench.`, `__tests__/`, `__fixtures__/`, `tests/`, the names that occur inside shipped roots today)
- requires every such package to be named by a changeset the PR added or modified, and fails closed when the range cannot be diffed

a version PR passes without a branch name bypass, because it only touches manifests, changelogs and consumed changesets. a comment-only or formatting-only edit to a shipped file needs a changeset too; `AGENTS.md` and `CONTRIBUTING.md` say so. a contract test fails when a releasable package stops listing `src` in `files`, since the gate could no longer see its source.

the check stays dependency free. an earlier revision parsed JS and TS with `@babel/parser` to ignore comment and formatting edits, which needed a root devDependency, an install step and a longer job timeout. replayed over the last 300 main commits it changed the verdict once (#7394, a comment fix), so it is gone.

hand edits to a published `package.json` are not covered; #7628 tracks that.

## Verification

- `node --test scripts/check-changesets.test.mjs` (34 tests); together with the `check-changeset-semver`, `check-unmanaged-pins`, `check-workspace-ranges` and `lib/workspace` suites, 91 pass
- mutation checks: diffing `base..head` instead of `base...head` fails "ignores target branch changes after the fork", and dropping the skip filter fails "skips packages that are never released"
- replayed the gate over main's last 300 first-parent commits (`9312e447d` to `fd31eda58`): 299 pass, #7394 is flagged, 0 errors, 58 ms at most
- #3639 is flagged for `@assistant-ui/store`; the oxfmt reformat PRs (#4976, #5726, #5910, #6543), the comment sweeps (#3831, #4125) and version PRs #7192 and #6816 pass
- `node scripts/check-changesets.mjs`, `oxfmt --check`, `oxlint`

## Public surface

none. repository CI, `AGENTS.md` and `CONTRIBUTING.md` only; no published package changes.
