### PR TITLE
fix(react-generative-ui): preserve A2UI prototype-named fields

### DIFF
--- a/.changeset/brave-frames-convert.md
+++ b/.changeset/brave-frames-convert.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: preserve prototype-named A2UI action context fields

--- a/packages/react-generative-ui/src/a2ui/convert.test.ts
+++ b/packages/react-generative-ui/src/a2ui/convert.test.ts
@@ -201,6 +201,42 @@ describe("convertSurfaceToUISpec", () => {
     });
   });
 
+  it("preserves prototype-named action context fields", () => {
+    const context = JSON.parse(
+      '{"__proto__":{"admin":true},"literal":"kept"}',
+    ) as Record<string, unknown>;
+    const surface = surfaceFrom([
+      {
+        id: "root",
+        component: "Button",
+        label: "Run",
+        action: { name: "run", context },
+      },
+    ]);
+
+    const result = convertSurfaceToUISpec(surface);
+    const convertedContext = (result.spec as UIElement).$action
+      ?.context as Record<string, unknown>;
+
+    expect(Object.getPrototypeOf(convertedContext)).toBe(Object.prototype);
+    expect(Object.hasOwn(convertedContext, "__proto__")).toBe(true);
+    expect(convertedContext["__proto__"]).toEqual({ admin: true });
+    expect(JSON.stringify(convertedContext)).toBe(
+      '{"__proto__":{"admin":true},"literal":"kept"}',
+    );
+  });
+
+  it("does not read component fields through a prototype-named prop", () => {
+    const component = JSON.parse(
+      '{"id":"root","component":"Text","__proto__":{"text":"injected"}}',
+    ) as Record<string, unknown>;
+
+    expect(convertSurfaceToUISpec(surfaceFrom([component]))).toEqual({
+      spec: { $type: "Markdown" },
+      warnings: [],
+    });
+  });
+
   it("expands template children relative to each bound item", () => {
     const surface = surfaceFrom(
       [

--- a/packages/react-generative-ui/src/a2ui/convert.ts
+++ b/packages/react-generative-ui/src/a2ui/convert.ts
@@ -30,6 +30,23 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> => {
   return prototype === Object.prototype || prototype === null;
 };
 
+const setOwnProperty = (
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+) => {
+  if (key === "__proto__") {
+    Object.defineProperty(target, key, {
+      value,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  } else {
+    target[key] = value;
+  }
+};
+
 const isBinding = (value: unknown): value is { readonly path: string } =>
   isPlainObject(value) &&
   Object.keys(value).length === 1 &&
@@ -90,7 +107,9 @@ const materialize = (value: unknown, source: unknown): unknown => {
   const result: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
     const resolved = materialize(entry, source);
-    if (resolved !== undefined) result[key] = resolved;
+    if (resolved !== undefined) {
+      setOwnProperty(result, key, resolved);
+    }
   }
   return result;
 };
@@ -419,7 +438,7 @@ function convertComponent(
     for (const [key, value] of Object.entries(node)) {
       if (key === "id" || key === "component" || key === "children") continue;
       const resolved = materialize(value, dataSource);
-      if (resolved !== undefined) props[key] = resolved;
+      if (resolved !== undefined) setOwnProperty(props, key, resolved);
     }
     const mapped = mappedProps(node, props, dataSource, context);
     if (!mapped) return null;


### PR DESCRIPTION
## Problem

A2UI conversion mishandles own `__proto__` fields in two places. Action context loses the field during materialization, while a component node such as `{"__proto__":{"text":"injected"}}` changes the temporary props prototype and can make inherited values render as real component props.

Focused reproductions on current main showed the action context field missing from serialized output and the component rendering the inherited `text` value.

## Root cause

Both converter accumulators assign untrusted JSON keys into `{}`. Assignment to the legacy `__proto__` accessor changes the target prototype instead of creating an own JSON property.

## Change

Use a shared own-property writer for materialized objects and component props. Ordinary keys keep the fast assignment path; `__proto__` is defined as an enumerable, writable, configurable own property, matching parsed JSON without changing the object prototype. Add focused regressions for both conversion paths.

## Verification

- `vitest run src/a2ui/convert.test.ts` (11 tests)
- full `@assistant-ui/react-generative-ui` suite (29 files, 634 tests)
- `aui-build` for `@assistant-ui/react-generative-ui`
- `node packages/x-performance/bin/aui-perf.mjs size`
- focused oxlint and oxfmt checks
- `node scripts/check-changesets.mjs`
- both regressions fail on current main and pass with this change

## Public surface

`@assistant-ui/react-generative-ui` conversion behavior only. No export, API, documentation, template, or size-budget changes. Includes a patch changeset.