### PR TITLE
docs(mcp-apps): explain state-preserving frame relocation

### DIFF
--- a/apps/docs/content/docs/guides/part-grouping.mdx
+++ b/apps/docs/content/docs/guides/part-grouping.mdx
@@ -287,6 +287,8 @@ Adjacent `reasoning` parts still coalesce into one `group-thought`, while each t
 
   For MCP Apps, keep one host-owned container mounted for the lifetime of the app. Switching between an inline element and a portal, or changing a portal's target, remounts the frame. Reparenting its live iframe with `appendChild` or `insertBefore` also reloads the document and loses in-app state.
 
+  In React hosts, create and insert the movable container imperatively under a stable host element; do not render it as a JSX child. Moving a React-owned DOM node behind React's back can make later reconciliation fail.
+
   Feature-detect [`moveBefore`](https://developer.mozilla.org/en-US/docs/Web/API/Element/moveBefore) on `Element.prototype`, not `Node.prototype`. When available, use it to move the container between connected parents without reloading the frame. Both the container and destination parent must be connected before the move; otherwise `moveBefore` throws `HierarchyRequestError`. Insert the container normally on its first mount. In browsers without `moveBefore`, leave the container in place and reposition it with CSS, or treat relocation as a reload and reinitialize the app.
 </Callout>
 

--- a/apps/docs/content/docs/guides/part-grouping.mdx
+++ b/apps/docs/content/docs/guides/part-grouping.mdx
@@ -287,7 +287,7 @@ Adjacent `reasoning` parts still coalesce into one `group-thought`, while each t
 
   For MCP Apps, keep one host-owned container mounted for the lifetime of the app. Switching between an inline element and a portal, or changing a portal's target, remounts the frame. Reparenting its live iframe with `appendChild` or `insertBefore` also reloads the document and loses in-app state.
 
-  When [`Element.prototype.moveBefore`](https://developer.mozilla.org/en-US/docs/Web/API/Element/moveBefore) is available, use it to move the already-connected container without reloading the frame. Insert the container normally on its first mount because `moveBefore` cannot move a detached node. In browsers without `moveBefore`, leave the container in place and reposition it with CSS, or treat relocation as a reload and reinitialize the app.
+  Feature-detect [`moveBefore`](https://developer.mozilla.org/en-US/docs/Web/API/Element/moveBefore) on `Element.prototype`, not `Node.prototype`. When available, use it to move the already-connected container without reloading the frame. Insert the container normally on its first mount because `moveBefore` cannot move a detached node. In browsers without `moveBefore`, leave the container in place and reposition it with CSS, or treat relocation as a reload and reinitialize the app.
 </Callout>
 
 ### Group by Custom Metadata

--- a/apps/docs/content/docs/guides/part-grouping.mdx
+++ b/apps/docs/content/docs/guides/part-grouping.mdx
@@ -284,6 +284,10 @@ Adjacent `reasoning` parts still coalesce into one `group-thought`, while each t
 
 <Callout type="warn">
   This renders tool calls flat **in the message flow** — each leaf sits where the part appears, in order. It does not pin, portal, float, or otherwise move tool UIs out of the flow into a sidebar or fixed region. For out-of-flow placement you still own the layout outside `GroupedParts`.
+
+  For MCP Apps, keep one host-owned container mounted for the lifetime of the app. Switching between an inline element and a portal, or changing a portal's target, remounts the frame. Reparenting its live iframe with `appendChild` or `insertBefore` also reloads the document and loses in-app state.
+
+  When [`Element.prototype.moveBefore`](https://developer.mozilla.org/en-US/docs/Web/API/Element/moveBefore) is available, use it to move the already-connected container without reloading the frame. Insert the container normally on its first mount because `moveBefore` cannot move a detached node. In browsers without `moveBefore`, leave the container in place and reposition it with CSS, or treat relocation as a reload and reinitialize the app.
 </Callout>
 
 ### Group by Custom Metadata

--- a/apps/docs/content/docs/guides/part-grouping.mdx
+++ b/apps/docs/content/docs/guides/part-grouping.mdx
@@ -287,7 +287,7 @@ Adjacent `reasoning` parts still coalesce into one `group-thought`, while each t
 
   For MCP Apps, keep one host-owned container mounted for the lifetime of the app. Switching between an inline element and a portal, or changing a portal's target, remounts the frame. Reparenting its live iframe with `appendChild` or `insertBefore` also reloads the document and loses in-app state.
 
-  Feature-detect [`moveBefore`](https://developer.mozilla.org/en-US/docs/Web/API/Element/moveBefore) on `Element.prototype`, not `Node.prototype`. When available, use it to move the already-connected container without reloading the frame. Insert the container normally on its first mount because `moveBefore` cannot move a detached node. In browsers without `moveBefore`, leave the container in place and reposition it with CSS, or treat relocation as a reload and reinitialize the app.
+  Feature-detect [`moveBefore`](https://developer.mozilla.org/en-US/docs/Web/API/Element/moveBefore) on `Element.prototype`, not `Node.prototype`. When available, use it to move the container between connected parents without reloading the frame. Both the container and destination parent must be connected before the move; otherwise `moveBefore` throws `HierarchyRequestError`. Insert the container normally on its first mount. In browsers without `moveBefore`, leave the container in place and reposition it with CSS, or treat relocation as a reload and reinitialize the app.
 </Callout>
 
 ### Group by Custom Metadata

--- a/apps/docs/content/docs/tools/mcp-apps.mdx
+++ b/apps/docs/content/docs/tools/mcp-apps.mdx
@@ -103,7 +103,7 @@ McpAppRenderer({
 });
 ```
 
-`requestDisplayMode` should update host chrome and return the mode that was actually honored. Echoing `{ mode }` without applying it tells the widget the change succeeded while the host stays `inline`.
+`requestDisplayMode` should update host chrome and return the mode that was actually honored. Echoing `{ mode }` without applying it tells the widget the change succeeded while the host stays `inline`. If changing modes moves the app between layout regions, follow the [state-preserving placement guidance](/docs/guides/part-grouping#render-tool-calls-as-flat-rows) to avoid reloading its iframe.
 
 Caller handlers override the default `openLink` and `sendMessage` behavior and can provide `requestDisplayMode`, `updateModelContext`, and lifecycle hooks such as `onInitialized` and `onSizeChange`. `callTool`, `readResource`, and `listResources` remain bound to the configured `host`; use a custom host to change those data-plane operations.
 


### PR DESCRIPTION
Closes #6757

## Problem

The MCP App placement guide says hosts own out-of-flow layout, but it does not warn that moving a mounted app can reload its iframe. Switching portal targets or reparenting the live iframe can silently erase form, scroll, selection, and other in-app state.

## Root cause

The guide did not distinguish visual relocation from DOM relocation. A portal target change remounts the subtree, while `appendChild` and `insertBefore` remove and reinsert the iframe document.

## Change

Expand the existing placement warning to recommend one stable host-owned container for the app lifetime. The guide now covers state-preserving relocation with `Element.prototype.moveBefore`, its connected-node constraint, and safe fallbacks for browsers where it is unavailable.

## Verification

- Checked the guidance against the MCP App host lifecycle and iframe cleanup behavior.
- Confirmed the documented `moveBefore` behavior and connected-node constraint against the Web API reference.
- `git diff --check`

## Public surface

Docs only. No package exports, API-reference output, templates, or changesets are affected.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.QPm-z9-zNuN0_BSYqirnVRXToCB6ZbrvoDzk15Ci7TchONVcPaq39QsBt30?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->