### PR TITLE
fix(ui): render non-json tool values safely

### DIFF
--- a/packages/ui/src/components/react/assistant-ui/elements/tool-fallback.aui.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/tool-fallback.aui.test.tsx
@@ -59,6 +59,24 @@ describe("ToolFallback", () => {
       />,
     );
     expect(view.container.textContent).toContain("1");
+
+    view.rerender(
+      <ToolFallback.Error
+        status={{ type: "incomplete", reason: "error", error: false }}
+      />,
+    );
+    expect(view.container.textContent).toContain("false");
+
+    view.rerender(
+      <ToolFallback.Error
+        status={{
+          type: "incomplete",
+          reason: "error",
+          error: new Error("tool failed"),
+        }}
+      />,
+    );
+    expect(view.container.textContent).toContain("Error: tool failed");
   });
 
   it("renders a placeholder when a result cannot be converted to text", () => {

--- a/packages/ui/src/components/react/assistant-ui/elements/tool-fallback.aui.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/tool-fallback.aui.test.tsx
@@ -92,6 +92,18 @@ describe("ToolFallback", () => {
     render(<ToolFallback.Result result={result} />);
 
     expect(screen.getByText("[Unserializable value]")).toBeTruthy();
+
+    const error = new Error("cannot convert");
+    error.toString = () => {
+      throw new Error("cannot convert");
+    };
+
+    const view = render(
+      <ToolFallback.Error
+        status={{ type: "incomplete", reason: "error", error }}
+      />,
+    );
+    expect(view.container.textContent).toContain("[Unserializable value]");
   });
 
   it("does not offer a fabricated result for an unprojected interrupt", () => {

--- a/packages/ui/src/components/react/assistant-ui/elements/tool-fallback.aui.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/tool-fallback.aui.test.tsx
@@ -43,6 +43,39 @@ const renderTool = (props: Partial<ToolCallMessagePartProps> = {}) => {
 };
 
 describe("ToolFallback", () => {
+  it("renders non-JSON tool values without throwing", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    const view = render(<ToolFallback.Result result={1n} />);
+    expect(view.container.textContent).toContain("1");
+
+    view.rerender(<ToolFallback.Result result={circular} />);
+    expect(view.container.textContent).toContain("[object Object]");
+
+    view.rerender(
+      <ToolFallback.Error
+        status={{ type: "incomplete", reason: "error", error: 1n }}
+      />,
+    );
+    expect(view.container.textContent).toContain("1");
+  });
+
+  it("renders a placeholder when a result cannot be converted to text", () => {
+    const result = {
+      toJSON() {
+        throw new Error("cannot serialize");
+      },
+      [Symbol.toPrimitive]() {
+        throw new Error("cannot convert");
+      },
+    };
+
+    render(<ToolFallback.Result result={result} />);
+
+    expect(screen.getByText("[Unserializable value]")).toBeTruthy();
+  });
+
   it("does not offer a fabricated result for an unprojected interrupt", () => {
     renderTool({ addResult: vi.fn() });
 

--- a/packages/ui/src/components/react/assistant-ui/elements/tool-fallback.aui.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/tool-fallback.aui.tsx
@@ -243,15 +243,17 @@ function ToolFallbackArgs({
 
 const formatUnknownValue = (value: unknown, space?: number): string => {
   if (typeof value === "string") return value;
+  if (value instanceof Error) return String(value);
 
   try {
-    return JSON.stringify(value, null, space) ?? String(value);
+    const json = JSON.stringify(value, null, space);
+    if (json !== undefined) return json;
+  } catch {}
+
+  try {
+    return String(value);
   } catch {
-    try {
-      return String(value);
-    } catch {
-      return "[Unserializable value]";
-    }
+    return "[Unserializable value]";
   }
 };
 
@@ -290,9 +292,10 @@ function ToolFallbackError({
   if (status?.type !== "incomplete") return null;
 
   const error = status.error;
-  const errorText = error ? formatUnknownValue(error) : null;
+  const errorText =
+    error === undefined || error === null ? null : formatUnknownValue(error);
 
-  if (!errorText) return null;
+  if (errorText === null) return null;
 
   const isCancelled = status.reason === "cancelled";
   const headerText = isCancelled ? "Cancelled reason:" : "Error:";

--- a/packages/ui/src/components/react/assistant-ui/elements/tool-fallback.aui.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/tool-fallback.aui.tsx
@@ -241,6 +241,20 @@ function ToolFallbackArgs({
   );
 }
 
+const formatUnknownValue = (value: unknown, space?: number): string => {
+  if (typeof value === "string") return value;
+
+  try {
+    return JSON.stringify(value, null, space) ?? String(value);
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return "[Unserializable value]";
+    }
+  }
+};
+
 function ToolFallbackResult({
   result,
   className,
@@ -260,7 +274,7 @@ function ToolFallbackResult({
         Result:
       </p>
       <pre className="aui-tool-fallback-result-content bg-muted/50 text-foreground/90 mt-1 rounded-md p-2.5 text-xs whitespace-pre-wrap">
-        {typeof result === "string" ? result : JSON.stringify(result, null, 2)}
+        {formatUnknownValue(result, 2)}
       </pre>
     </div>
   );
@@ -276,11 +290,7 @@ function ToolFallbackError({
   if (status?.type !== "incomplete") return null;
 
   const error = status.error;
-  const errorText = error
-    ? typeof error === "string"
-      ? error
-      : JSON.stringify(error)
-    : null;
+  const errorText = error ? formatUnknownValue(error) : null;
 
   if (!errorText) return null;
 

--- a/packages/ui/src/components/react/assistant-ui/elements/tool-fallback.aui.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/tool-fallback.aui.tsx
@@ -243,9 +243,10 @@ function ToolFallbackArgs({
 
 const formatUnknownValue = (value: unknown, space?: number): string => {
   if (typeof value === "string") return value;
-  if (value instanceof Error) return String(value);
 
   try {
+    if (value instanceof Error) return String(value);
+
     const json = JSON.stringify(value, null, space);
     if (json !== undefined) return json;
   } catch {}
@@ -295,7 +296,7 @@ function ToolFallbackError({
   const errorText =
     error === undefined || error === null ? null : formatUnknownValue(error);
 
-  if (errorText === null) return null;
+  if (!errorText) return null;
 
   const isCancelled = status.reason === "cancelled";
   const headerText = isCancelled ? "Cancelled reason:" : "Error:";

--- a/templates/minimal/components/assistant-ui/elements/tool-fallback.aui.tsx
+++ b/templates/minimal/components/assistant-ui/elements/tool-fallback.aui.tsx
@@ -243,15 +243,17 @@ function ToolFallbackArgs({
 
 const formatUnknownValue = (value: unknown, space?: number): string => {
   if (typeof value === "string") return value;
+  if (value instanceof Error) return String(value);
 
   try {
-    return JSON.stringify(value, null, space) ?? String(value);
+    const json = JSON.stringify(value, null, space);
+    if (json !== undefined) return json;
+  } catch {}
+
+  try {
+    return String(value);
   } catch {
-    try {
-      return String(value);
-    } catch {
-      return "[Unserializable value]";
-    }
+    return "[Unserializable value]";
   }
 };
 
@@ -290,9 +292,10 @@ function ToolFallbackError({
   if (status?.type !== "incomplete") return null;
 
   const error = status.error;
-  const errorText = error ? formatUnknownValue(error) : null;
+  const errorText =
+    error === undefined || error === null ? null : formatUnknownValue(error);
 
-  if (!errorText) return null;
+  if (errorText === null) return null;
 
   const isCancelled = status.reason === "cancelled";
   const headerText = isCancelled ? "Cancelled reason:" : "Error:";

--- a/templates/minimal/components/assistant-ui/elements/tool-fallback.aui.tsx
+++ b/templates/minimal/components/assistant-ui/elements/tool-fallback.aui.tsx
@@ -241,6 +241,20 @@ function ToolFallbackArgs({
   );
 }
 
+const formatUnknownValue = (value: unknown, space?: number): string => {
+  if (typeof value === "string") return value;
+
+  try {
+    return JSON.stringify(value, null, space) ?? String(value);
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return "[Unserializable value]";
+    }
+  }
+};
+
 function ToolFallbackResult({
   result,
   className,
@@ -260,7 +274,7 @@ function ToolFallbackResult({
         Result:
       </p>
       <pre className="aui-tool-fallback-result-content bg-muted/50 text-foreground/90 mt-1 rounded-md p-2.5 text-xs whitespace-pre-wrap">
-        {typeof result === "string" ? result : JSON.stringify(result, null, 2)}
+        {formatUnknownValue(result, 2)}
       </pre>
     </div>
   );
@@ -276,11 +290,7 @@ function ToolFallbackError({
   if (status?.type !== "incomplete") return null;
 
   const error = status.error;
-  const errorText = error
-    ? typeof error === "string"
-      ? error
-      : JSON.stringify(error)
-    : null;
+  const errorText = error ? formatUnknownValue(error) : null;
 
   if (!errorText) return null;
 

--- a/templates/minimal/components/assistant-ui/elements/tool-fallback.aui.tsx
+++ b/templates/minimal/components/assistant-ui/elements/tool-fallback.aui.tsx
@@ -243,9 +243,10 @@ function ToolFallbackArgs({
 
 const formatUnknownValue = (value: unknown, space?: number): string => {
   if (typeof value === "string") return value;
-  if (value instanceof Error) return String(value);
 
   try {
+    if (value instanceof Error) return String(value);
+
     const json = JSON.stringify(value, null, space);
     if (json !== undefined) return json;
   } catch {}
@@ -295,7 +296,7 @@ function ToolFallbackError({
   const errorText =
     error === undefined || error === null ? null : formatUnknownValue(error);
 
-  if (errorText === null) return null;
+  if (!errorText) return null;
 
   const isCancelled = status.reason === "cancelled";
   const headerText = isCancelled ? "Cancelled reason:" : "Error:";


### PR DESCRIPTION
## Problem

The canonical ToolFallback renderers pass arbitrary tool results and errors directly to JSON.stringify(). Valid runtime values such as bigint and circular objects therefore throw during React rendering and can take down the fallback message UI.

On current main (9b9d5e936), rendering <ToolFallback.Result result={1n} /> fails with TypeError: Do not know how to serialize a BigInt.

## Root cause

The fallback assumes every non-string unknown value is JSON-serializable even though the public result and error fields are typed as unknown.

## Change

Use a local best-effort formatter that preserves existing JSON output, falls back to String(value) for non-JSON values, and uses a final placeholder when even string coercion throws. Apply it consistently to tool results and incomplete-status errors, then sync the canonical component into the minimal template.

## Verification

- Confirmed the focused bigint reproduction fails on unchanged main and passes with this change.
- ./node_modules/.bin/vitest run src/components/react/assistant-ui/elements/tool-fallback.aui.test.tsx --reporter=dot (19 passed)
- ./node_modules/.bin/vitest run --reporter=dot (730 passed, 16 skipped)
- bash scripts/sync-templates.sh
- oxlint on both changed source/test files
- git diff --check

## Public surface

@assistant-ui/ui canonical registry component behavior and the synchronized minimal template. No exports, API reference, or documentation change. The package is private, so no changeset is required.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.MUGxwx1oc2_R3vbh0ZpiuM8TqQ3gcVFzmfEX3y9kQV7xP8vSWwwCR7Ik3aM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->