### PR TITLE
fix(ai-sdk): keep replacement MCP clients after stale timeouts

### DIFF
--- a/.changeset/fix-stale-mcp-timeout-eviction.md
+++ b/.changeset/fix-stale-mcp-timeout-eviction.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+fix(ai-sdk): keep replacement MCP clients after stale timeouts

--- a/packages/ai-sdk/src/tools/generativeTools.test.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.test.ts
@@ -478,6 +478,61 @@ describe("AISDKToolkit", () => {
     }
   });
 
+  it("does not evict a replacement client after an older listing timeout", async () => {
+    vi.useFakeTimers();
+    const oldClient = {
+      tools: vi.fn(() => never()),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const replacementClient = {
+      tools: vi.fn().mockResolvedValue({ echo: { inputSchema: {} } }),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    mocks.createMCPClient
+      .mockResolvedValueOnce(oldClient)
+      .mockResolvedValue(replacementClient);
+
+    const toolkit = new AISDKToolkit({
+      toolkit: {
+        docs: {
+          type: "mcp",
+          server: {
+            type: "http",
+            url: "http://localhost:3001/mcp",
+            connectionTimeout: 100,
+          },
+        },
+      },
+    });
+
+    try {
+      const first = toolkit.tools();
+      const firstRejection = expect(first).rejects.toThrow(
+        /timed out while listing tools/,
+      );
+      await vi.advanceTimersByTimeAsync(50);
+
+      const second = toolkit.tools();
+      const secondRejection = expect(second).rejects.toThrow(
+        /timed out while listing tools/,
+      );
+      await vi.advanceTimersByTimeAsync(50);
+      await firstRejection;
+
+      await expect(toolkit.tools()).resolves.toHaveProperty("echo");
+      expect(mocks.createMCPClient).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(50);
+      await secondRejection;
+
+      await expect(toolkit.tools()).resolves.toHaveProperty("echo");
+      expect(mocks.createMCPClient).toHaveBeenCalledTimes(2);
+      expect(oldClient.close).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("includes the MCP toolkit entry name when listing tools fails", async () => {
     const error = new Error("list failed");
     mocks.tools.mockRejectedValue(error);

--- a/packages/ai-sdk/src/tools/generativeTools.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.ts
@@ -227,11 +227,8 @@ export class AISDKToolkit {
         )
         .map(async ([name, tool]) => {
           const startedAt = Date.now();
-          const client = await this.#mcpClient(
-            name,
-            tool.server,
-            startedAt,
-          ).catch((error: unknown) => {
+          const clientPromise = this.#mcpClient(name, tool.server, startedAt);
+          const client = await clientPromise.catch((error: unknown) => {
             if (error instanceof MCPConnectionTimeoutError) throw error;
             throw toMcpToolkitError(name, "connect", error);
           });
@@ -245,8 +242,10 @@ export class AISDKToolkit {
             return [name, tool, tools] as const;
           } catch (error) {
             if (error instanceof MCPConnectionTimeoutError) {
-              this.#mcpClients.delete(name);
-              void client.close().catch(() => {});
+              if (this.#mcpClients.get(name) === clientPromise) {
+                this.#mcpClients.delete(name);
+                void client.close().catch(() => {});
+              }
               throw error;
             }
             throw toMcpToolkitError(name, "list tools", error);


### PR DESCRIPTION
## Problem

Concurrent `AISDKToolkit.tools()` calls can share one MCP client while carrying different timeout deadlines. If the first call times out, a later call may create a healthy replacement. When another old call subsequently times out, it deletes the replacement from the pool and the next request opens a duplicate connection.

The regression reproduces the interleaving with staggered callers. Before this change, the fourth lookup creates a third client instead of reusing the second client.

## Root cause

The tool-list timeout handler deleted the pool entry by server name without checking whether that entry still referred to the client used by the timed-out request.

## Change

Capture the exact pooled client promise used by each request. Timeout cleanup now evicts and closes the client only while that promise is still the current entry for the server name. Stale callers still reject with their timeout, but cannot remove a newer connection.

## Verification

- `pnpm --filter @assistant-ui/ai-sdk test`: 25 files, 275 tests passed
- `pnpm --filter @assistant-ui/ai-sdk build`
- scoped Oxlint and Oxfmt checks
- `pnpm changesets:check`
- the new regression fails on `origin/main` with three client creations and passes here with two

## Public surface

`@assistant-ui/ai-sdk` behavior only. No exported signatures or documentation change. Includes a patch changeset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.40QTfTuRHaWnFj7jh5NxddcNCag5wof8i5lxmT_UmgowNu0jfL-u32ZhyDI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->