### PR TITLE
fix(assistant-stream): settle cancellation during tool validation

### DIFF
--- a/.changeset/fix-pending-tool-validation-abort.md
+++ b/.changeset/fix-pending-tool-validation-abort.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix(assistant-stream): settle cancellation during asynchronous tool validation

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -378,6 +378,52 @@ describe("unstable_runPendingTools", () => {
     });
   });
 
+  it("settles cancellation while async validation remains pending", async () => {
+    const abortController = new AbortController();
+    const removeEventListener = vi.spyOn(
+      abortController.signal,
+      "removeEventListener",
+    );
+    const validation = promiseWithResolvers<{
+      value: Record<string, unknown>;
+    }>();
+    const execute = vi.fn(() => "executed");
+    const pending = unstable_runPendingTools(
+      createPendingToolMessage("pending-validation"),
+      {
+        tool: {
+          parameters: {
+            "~standard": {
+              version: 1,
+              vendor: "test",
+              validate: () => validation.promise,
+            },
+          },
+          execute,
+        },
+      },
+      abortController.signal,
+      async () => {},
+    );
+
+    abortController.abort();
+    const settled = await pending;
+
+    expect(settled.parts[0]).toMatchObject({
+      state: "result",
+      result: "Tool execution was cancelled.",
+      isError: true,
+    });
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    );
+
+    validation.resolve({ value: {} });
+    await validation.promise;
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it.each(["resolves", "rejects"] as const)(
     "does not enqueue pending tool output after cancellation when execution %s",
     async (settlement) => {

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -342,6 +342,32 @@ describe("unstable_runPendingTools", () => {
     });
   });
 
+  it("lets a synchronously aborting tool settle during the abort grace period", async () => {
+    const abortController = new AbortController();
+    const execute = vi.fn(() => {
+      abortController.abort();
+      return "executed";
+    });
+
+    const settled = await unstable_runPendingTools(
+      createPendingToolMessage("self-aborting-tool"),
+      {
+        tool: {
+          parameters: { type: "object", properties: {} },
+          execute,
+        },
+      },
+      abortController.signal,
+      async () => {},
+    );
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(settled.parts[0]).toMatchObject({
+      result: "executed",
+      isError: false,
+    });
+  });
+
   it("does not execute a tool cancelled during async validation", async () => {
     const abortController = new AbortController();
     const validation = promiseWithResolvers<{

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -380,10 +380,6 @@ describe("unstable_runPendingTools", () => {
 
   it("settles cancellation while async validation remains pending", async () => {
     const abortController = new AbortController();
-    const removeEventListener = vi.spyOn(
-      abortController.signal,
-      "removeEventListener",
-    );
     const validation = promiseWithResolvers<{
       value: Record<string, unknown>;
     }>();
@@ -414,10 +410,6 @@ describe("unstable_runPendingTools", () => {
       result: "Tool execution was cancelled.",
       isError: true,
     });
-    expect(removeEventListener).toHaveBeenCalledWith(
-      "abort",
-      expect.any(Function),
-    );
 
     validation.resolve({ value: {} });
     await validation.promise;

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -442,6 +442,47 @@ describe("unstable_runPendingTools", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
+  it("observes validation rejection after validation cancels the tool", async () => {
+    const abortController = new AbortController();
+    const validation = promiseWithResolvers<{
+      value: Record<string, unknown>;
+    }>();
+    const execute = vi.fn(() => "executed");
+    const pending = unstable_runPendingTools(
+      createPendingToolMessage("self-cancelling-validation"),
+      {
+        tool: {
+          parameters: {
+            "~standard": {
+              version: 1,
+              vendor: "test",
+              validate: () => {
+                abortController.abort();
+                return validation.promise;
+              },
+            },
+          },
+          execute,
+        },
+      },
+      abortController.signal,
+      async () => {},
+    );
+
+    const unhandledRejections = await captureUnhandledRejections(async () => {
+      const settled = await pending;
+      expect(settled.parts[0]).toMatchObject({
+        state: "result",
+        result: "Tool execution was cancelled.",
+        isError: true,
+      });
+      validation.reject(new Error("validation failed after cancellation"));
+    });
+
+    expect(unhandledRejections).toEqual([]);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it.each(["resolves", "rejects"] as const)(
     "does not enqueue pending tool output after cancellation when execution %s",
     async (settlement) => {

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -69,12 +69,19 @@ const isThenable = <T>(value: T | PromiseLike<T>): value is PromiseLike<T> =>
 const raceWithAbort = async <T>(
   value: PromiseLike<T>,
   abortSignal: AbortSignal,
+  delayAbort = false,
 ): Promise<T | typeof TOOL_ABORTED> => {
   if (abortSignal.aborted) return TOOL_ABORTED;
 
   let onAbort!: () => void;
   const abortPromise = new Promise<typeof TOOL_ABORTED>((resolve) => {
-    onAbort = () => resolve(TOOL_ABORTED);
+    onAbort = () => {
+      if (delayAbort) {
+        queueMicrotask(() => queueMicrotask(() => resolve(TOOL_ABORTED)));
+      } else {
+        resolve(TOOL_ABORTED);
+      }
+    };
     abortSignal.addEventListener("abort", onAbort, { once: true });
   });
 
@@ -139,26 +146,6 @@ function getToolResponse(
       return cancelledToolResponse();
     }
 
-    // Create abort promise that resolves after 2 microtasks
-    // This gives tools that handle abort a chance to win the race
-    let onAbort!: () => void;
-    const abortPromise = new Promise<ToolResponse<ReadonlyJSONValue>>(
-      (resolve) => {
-        onAbort = () => {
-          queueMicrotask(() => {
-            queueMicrotask(() => {
-              resolve(cancelledToolResponse());
-            });
-          });
-        };
-        if (abortSignal.aborted) {
-          onAbort();
-        } else {
-          abortSignal.addEventListener("abort", onAbort, { once: true });
-        }
-      },
-    );
-
     const executePromise = (async () => {
       const executionContext = {
         toolCallId: toolCall.toolCallId,
@@ -200,11 +187,14 @@ function getToolResponse(
       return response;
     })();
 
-    try {
-      return await Promise.race([executePromise, abortPromise]);
-    } finally {
-      abortSignal.removeEventListener("abort", onAbort);
-    }
+    const executionResult = await raceWithAbort(
+      executePromise,
+      abortSignal,
+      true,
+    );
+    return executionResult === TOOL_ABORTED
+      ? cancelledToolResponse()
+      : executionResult;
   };
 
   return getResult(tool.execute);

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -72,8 +72,6 @@ const raceWithAbort = async <T>(
   // Tool execution gets two microtasks to settle after handling an abort.
   delayAbort = false,
 ): Promise<T | typeof TOOL_ABORTED> => {
-  if (abortSignal.aborted && !delayAbort) return TOOL_ABORTED;
-
   let onAbort!: () => void;
   const abortPromise = new Promise<typeof TOOL_ABORTED>((resolve) => {
     onAbort = () => {

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -11,6 +11,7 @@ import type { AssistantMessage, ToolCallPart } from "../utils/types";
 import type { ReadonlyJSONObject, ReadonlyJSONValue } from "../../utils";
 
 const TOOL_EXECUTION_ID = Symbol.for("assistant-stream.tool-execution-id");
+const TOOL_ABORTED = Symbol("assistant-stream.tool-aborted");
 
 type InternalHumanCallback = (
   toolCallId: string,
@@ -62,9 +63,27 @@ const isStandardSchemaV1 = (
   );
 };
 
-const isThenable = (value: unknown): value is PromiseLike<unknown> =>
-  typeof (value as PromiseLike<unknown> | null | undefined)?.then ===
-  "function";
+const isThenable = <T>(value: T | PromiseLike<T>): value is PromiseLike<T> =>
+  typeof (value as PromiseLike<T> | null | undefined)?.then === "function";
+
+const raceWithAbort = async <T>(
+  value: PromiseLike<T>,
+  abortSignal: AbortSignal,
+): Promise<T | typeof TOOL_ABORTED> => {
+  if (abortSignal.aborted) return TOOL_ABORTED;
+
+  let onAbort!: () => void;
+  const abortPromise = new Promise<typeof TOOL_ABORTED>((resolve) => {
+    onAbort = () => resolve(TOOL_ABORTED);
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+  });
+
+  try {
+    return await Promise.race([value, abortPromise]);
+  } finally {
+    abortSignal.removeEventListener("abort", onAbort);
+  }
+};
 
 const cancelledToolResponse = (): ToolResponse<ReadonlyJSONValue> =>
   new ToolResponse({
@@ -97,7 +116,13 @@ function getToolResponse(
 
     if (isStandardSchemaV1(tool.parameters)) {
       const result = tool.parameters["~standard"].validate(toolCall.args);
-      const validationResult = isThenable(result) ? await result : result;
+      const validationResult = isThenable(result)
+        ? await raceWithAbort(result, abortSignal)
+        : result;
+
+      if (validationResult === TOOL_ABORTED) {
+        return cancelledToolResponse();
+      }
 
       if (validationResult.issues) {
         executeFn =

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -69,9 +69,10 @@ const isThenable = <T>(value: T | PromiseLike<T>): value is PromiseLike<T> =>
 const raceWithAbort = async <T>(
   value: PromiseLike<T>,
   abortSignal: AbortSignal,
+  // Tool execution gets two microtasks to settle after handling an abort.
   delayAbort = false,
 ): Promise<T | typeof TOOL_ABORTED> => {
-  if (abortSignal.aborted) return TOOL_ABORTED;
+  if (abortSignal.aborted && !delayAbort) return TOOL_ABORTED;
 
   let onAbort!: () => void;
   const abortPromise = new Promise<typeof TOOL_ABORTED>((resolve) => {
@@ -82,7 +83,11 @@ const raceWithAbort = async <T>(
         resolve(TOOL_ABORTED);
       }
     };
-    abortSignal.addEventListener("abort", onAbort, { once: true });
+    if (abortSignal.aborted) {
+      onAbort();
+    } else {
+      abortSignal.addEventListener("abort", onAbort, { once: true });
+    }
   });
 
   try {


### PR DESCRIPTION
## Problem

Cancelling a pending tool call while its asynchronous Standard Schema validator never settles leaves `unstable_runPendingTools()` pending forever. The tool does not execute, but the run cannot finish cancellation and consumers can remain stuck in a running state.

A focused regression starts a validator promise, aborts the run without settling that promise, and waits for the pending-tool pass. Before this change, that await never completes.

## Root cause

The tool execution abort race was created only after schema validation finished. An asynchronous validator therefore sat outside the cancellation boundary.

## Change

Race asynchronous validation against the existing abort signal. Cancellation returns the established cancelled-tool response and removes the temporary listener. Synchronous validation and already-started tool execution retain their existing ordering and behavior.

## Verification

- `pnpm --filter assistant-stream test`: v6 and peer-v5 suites each pass 528 tests with 22 skipped; peer-v5 type check passes
- `pnpm --filter assistant-stream build`
- scoped Oxlint and Oxfmt checks
- `pnpm changesets:check`
- the regression hangs on `origin/main` and settles as cancelled here; resolving validation afterward does not execute the tool

## Public surface

`assistant-stream` behavior only. No exported signatures or documentation change. Includes a patch changeset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.6qOH5rd_YEjTqMBzXjhRk1RB0fEc_xx4MYa-EHnV7_7r3ZmEMmLhkbZzy1I?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->