### PR TITLE
fix(assistant-stream): preserve prototype-named tool call IDs

### DIFF
--- a/.changeset/fix-prototype-tool-call-results.md
+++ b/.changeset/fix-prototype-tool-call-results.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix(assistant-stream): preserve prototype-named tool call IDs

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -84,6 +84,37 @@ describe("unstable_runPendingTools", () => {
     expect(settled.content).toEqual(settled.parts);
   });
 
+  it.each(["constructor", "toString", "__proto__"])(
+    "does not assign inherited results to a %s tool call ID",
+    async (toolCallId) => {
+      const message = createPendingToolMessage("executed");
+      const unavailablePart = {
+        ...message.parts[0],
+        toolCallId,
+        toolName: "unavailable",
+      } as ToolCallPart;
+      message.parts.push(unavailablePart);
+
+      const settled = await unstable_runPendingTools(
+        message,
+        {
+          tool: {
+            parameters: { type: "object", properties: {} },
+            execute: async () => "done",
+          },
+        },
+        new AbortController().signal,
+        async () => {},
+      );
+
+      expect(settled.parts[0]).toMatchObject({
+        state: "result",
+        result: "done",
+      });
+      expect(settled.parts[1]).toBe(unavailablePart);
+    },
+  );
+
   it("settles a tool that returns no value with a concrete result", async () => {
     const message: AssistantMessage = {
       role: "assistant",

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -251,17 +251,13 @@ export async function unstable_runPendingTools(
     return message;
   }
 
-  const toolCallResultsById = toolCallResults.reduce(
-    (acc, { toolCallId, result }) => {
-      acc[toolCallId] = result;
-      return acc;
-    },
-    {} as Record<string, ToolResponse<ReadonlyJSONValue>>,
+  const toolCallResultsById = new Map(
+    toolCallResults.map(({ toolCallId, result }) => [toolCallId, result]),
   );
 
   const updatedParts = message.parts.map((p) => {
     if (isPendingToolCall(p)) {
-      const toolResponse = toolCallResultsById[p.toolCallId];
+      const toolResponse = toolCallResultsById.get(p.toolCallId);
       if (toolResponse) {
         return {
           ...p,


### PR DESCRIPTION
## Problem

When at least one pending tool executes, another unresolved tool call whose ID is `constructor`, `toString`, or `__proto__` can be assigned a phantom result. The call is then marked complete even though no matching tool ran.

The regression combines one executable tool with an unavailable prototype-named call. Before this change, the unavailable call is rewritten with `state: "result"`; it remains pending here.

## Root cause

Executed results were collected in a plain object and read with `results[toolCallId]`. Missing prototype-named IDs resolve inherited `Object.prototype` properties, so the merge treats them as real tool responses.

## Change

Index tool responses with a `Map`. This preserves string IDs and last-result-wins behavior without inherited keys or `__proto__` assignment semantics.

## Verification

- `pnpm --filter assistant-stream test`: v6 and peer-v5 suites each pass 530 tests with 22 skipped; peer-v5 type check passes
- `pnpm --filter assistant-stream build`
- scoped Oxlint and Oxfmt checks
- `pnpm changesets:check`
- the three prototype-key cases fail on `origin/main` and pass here

## Public surface

`assistant-stream` behavior only. No exported signatures or documentation change. Includes a patch changeset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.hjrlfvK77L_5BEVvDUR7heQ9xVNjVkN82R-DZDhYcl1gO5wz_A5v3s3GSyo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->