### PR TITLE
fix(react-a2a): notify subscribers after server cancellation

### DIFF
--- a/.changeset/tidy-a2a-cancellation.md
+++ b/.changeset/tidy-a2a-cancellation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+Preserve newer task state when a previous cancellation response arrives, and retain the original server cancellation target across callbacks.

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -1226,6 +1226,118 @@ describe("A2AThreadRuntimeCore", () => {
   // --- Cancel ---
 
   describe("cancel", () => {
+    it.each(["same-task", "new-task", "new-thread"] as const)(
+      "ignores a late cancel response after %s takes ownership",
+      async (replacement) => {
+        let resolveCancel!: (task: A2ATask) => void;
+        const cancelTask = vi.fn().mockImplementation(
+          () =>
+            new Promise<A2ATask>((resolve) => {
+              resolveCancel = resolve;
+            }),
+        );
+        let streamCount = 0;
+        const core = createCore({
+          cancelTask,
+          streamMessage: vi.fn().mockImplementation(async function* (
+            _message,
+            _configuration,
+            _metadata,
+            signal: AbortSignal,
+          ) {
+            streamCount++;
+            yield {
+              type: "task",
+              task: {
+                id:
+                  streamCount === 1 || replacement === "same-task"
+                    ? "old"
+                    : "new",
+                status: { state: "working" },
+              },
+            } satisfies A2AStreamEvent;
+            await new Promise<void>((resolve) => {
+              if (signal.aborted) resolve();
+              else
+                signal.addEventListener("abort", () => resolve(), {
+                  once: true,
+                });
+            });
+          }),
+        });
+        const first = core.append(createUserAppendMessage("first"));
+        await vi.waitFor(() => expect(core.getTask()?.id).toBe("old"));
+        const originalTask = core.getTask();
+        const cancellation = core.cancel();
+        await first;
+        expect(cancelTask).toHaveBeenCalledWith("old");
+        let second: Promise<void> | undefined;
+        if (replacement === "new-thread") {
+          core.applyExternalMessages([]);
+          core.resetContext();
+        } else {
+          second = core.append(createUserAppendMessage("second"));
+          await vi.waitFor(() => expect(streamCount).toBe(2));
+          await vi.waitFor(() => expect(core.getTask()).not.toBe(originalTask));
+          expect(core.getTask()?.id).toBe(
+            replacement === "same-task" ? "old" : "new",
+          );
+          expect(core.isRunning()).toBe(true);
+        }
+        const ownedTask = core.getTask();
+        resolveCancel({ id: "old", status: { state: "canceled" } });
+        await cancellation;
+        try {
+          expect(core.getTask()).toBe(ownedTask);
+        } finally {
+          core.detachRuntime();
+          await second;
+        }
+      },
+    );
+
+    it("cancels the original server task when onCancel clears the thread", async () => {
+      const cancelTask = vi.fn().mockResolvedValue({
+        id: "old",
+        status: { state: "canceled" },
+      } satisfies A2ATask);
+      const core = createCore(
+        {
+          cancelTask,
+          streamMessage: vi.fn().mockImplementation(async function* (
+            _message,
+            _configuration,
+            _metadata,
+            signal: AbortSignal,
+          ) {
+            yield {
+              type: "task",
+              task: { id: "old", status: { state: "working" } },
+            } satisfies A2AStreamEvent;
+            await new Promise<void>((resolve) => {
+              if (signal.aborted) resolve();
+              else
+                signal.addEventListener("abort", () => resolve(), {
+                  once: true,
+                });
+            });
+          }),
+        },
+        {
+          onCancel: () => {
+            core.applyExternalMessages([]);
+            core.resetContext();
+          },
+        },
+      );
+      const append = core.append(createUserAppendMessage("first"));
+      await vi.waitFor(() => expect(core.getTask()?.id).toBe("old"));
+      await core.cancel();
+      await append;
+      expect(cancelTask).toHaveBeenCalledWith("old");
+      expect(core.getTask()).toBeUndefined();
+    });
+
     it("updates task from server cancel response", async () => {
       const cancelTask = vi.fn().mockResolvedValue({
         id: "t1",

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -283,14 +283,16 @@ export class A2AThreadRuntimeCore {
   async cancel(): Promise<void> {
     if (!this.abortController) return;
 
+    const task = this.currentTask;
+
     // Abort locally first so the stream stops immediately
     this.abortController.abort();
 
     // Then try to cancel the task on the server
-    if (this.currentTask?.id) {
+    if (task?.id) {
       try {
-        const updated = await this.client.cancelTask(this.currentTask.id);
-        this.currentTask = updated;
+        const updated = await this.client.cancelTask(task.id);
+        if (this.currentTask === task) this.currentTask = updated;
       } catch {
         // Server cancel failed; local abort already handled
       }


### PR DESCRIPTION
## Problem

When an owned A2A server cancellation response updates the task, subscribers are not notified and task consumers can keep displaying the previous snapshot.

Fixes #7108. Current main already incorporates the cancellation target and run-generation ownership guards; this PR retains that upstream implementation and addresses the remaining notification gap.

## Change

Call `notifyUpdate()` after applying the owned cancellation response. Keep the upstream identity and run-generation guards. Extend the existing cancellation test to require one notification. Includes a patch changeset.

## Verification

On main `359f73ce`, adding the notification assertion without the source fix gives 1 failed / 308 passed. With the fix, all 309 tests across four files pass. Package typecheck, repository lint/format, changeset check, eight package/dependency builds and size check pass. No size budget changes; stale AG-UI artifacts were rebuilt before the final size check.

Validation used frozen-lockfile dependencies with install scripts disabled, pnpm 12.4.2 and Vitest 5.0.1. No model API calls. Work used Codex assistance. The notification fix was contributed by Kinfe123 in c0ce5a086 and retained through the upstream merge; overlapping race tests were removed in favor of upstream coverage.

## Public surface

A2A cancellation notification behavior only. No new exports or configuration.
