### PR TITLE
fix(core): avoid frontend execution after backend tool results

### DIFF
--- a/.changeset/backend-result-prevents-frontend-execution.md
+++ b/.changeset/backend-result-prevents-frontend-execution.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: avoid executing frontend tools when a pending call receives a backend result, and preserve backend results when streamed arguments are incomplete.

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -44,6 +44,8 @@ const createAssistantMessage = (
   options?: {
     result?: ReadonlyJSONValue;
     isError?: boolean;
+    artifact?: ReadonlyJSONValue;
+    modelContent?: { type: "text"; text: string }[];
     toolCallId?: string;
     toolName?: string;
     nestedMessages?: ThreadAssistantMessage[];
@@ -70,6 +72,10 @@ const createAssistantMessage = (
       argsText,
       ...(options?.result !== undefined && { result: options.result }),
       ...(options?.isError !== undefined && { isError: options.isError }),
+      ...(options?.artifact !== undefined && { artifact: options.artifact }),
+      ...(options?.modelContent !== undefined && {
+        modelContent: options.modelContent,
+      }),
       ...(options?.nestedMessages && { messages: options.nestedMessages }),
       ...(options?.approval && { approval: options.approval }),
     },
@@ -1318,6 +1324,176 @@ describe("ToolInvocationTracker", () => {
     }
   });
 
+  it.each([
+    [true, { source: "backend" }],
+    [false, { source: "backend" }],
+    [true, null],
+    [true, false],
+    [true, 0],
+    [true, ""],
+  ] as const)(
+    "does not execute a pending call answered by the backend (running=%s, result=%j)",
+    async (isRunning, result) => {
+      const execute = vi.fn(async () => ({ source: "client" }));
+      const streamCall = vi.fn(
+        async (reader: Parameters<NonNullable<Tool["streamCall"]>>[0]) => {
+          for await (const value of reader.args.streamValues()) {
+            void value;
+          }
+          return reader.response.get();
+        },
+      );
+      const onResult = vi.fn();
+      const tracker = new ToolInvocationTracker(
+        () => ({
+          weatherSearch: {
+            parameters: { type: "object", properties: {} },
+            execute,
+            streamCall,
+          },
+        }),
+        {
+          onResult,
+          onStatusesChange: () => {},
+        },
+      );
+      tracker.setState(createState([]));
+      tracker.setState(
+        createState([createAssistantMessage('{"a":1}', { a: 1 })]),
+      );
+      await waitFor(() => expect(streamCall).toHaveBeenCalledTimes(1));
+      await streamCall.mock.calls[0]![0].args.get("a");
+      expect(execute).not.toHaveBeenCalled();
+
+      tracker.setState(
+        createState(
+          [createAssistantMessage('{"a":1}', { a: 1 }, { result })],
+          isRunning,
+        ),
+      );
+
+      const response = await streamCall.mock.results[0]!.value;
+      expect(response.result).toEqual(result);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(execute).not.toHaveBeenCalled();
+      expect(streamCall).toHaveBeenCalledTimes(1);
+      expect(onResult).not.toHaveBeenCalled();
+      expect(tracker.getStatuses().size).toBe(0);
+    },
+  );
+
+  it("suppresses queued execution when a backend result arrives before execute starts", async () => {
+    const execute = vi.fn(async () => ({ source: "client" }));
+    const streamCall = vi.fn(
+      async (reader: Parameters<NonNullable<Tool["streamCall"]>>[0]) =>
+        reader.response.get(),
+    );
+    const onResult = vi.fn();
+    const tracker = new ToolInvocationTracker(
+      () => ({
+        weatherSearch: {
+          parameters: { type: "object", properties: {} },
+          execute,
+          streamCall,
+        },
+      }),
+      {
+        onResult,
+        onStatusesChange: () => {},
+      },
+    );
+    tracker.setState(createState([]));
+    tracker.setState(
+      createState([createAssistantMessage('{"a":1}', { a: 1 })]),
+    );
+    await waitFor(() => expect(streamCall).toHaveBeenCalledTimes(1));
+    await streamCall.mock.calls[0]![0].args.get("a");
+    expect(execute).not.toHaveBeenCalled();
+
+    tracker.setState(
+      createState([createAssistantMessage('{"a":1}', { a: 1 })], false),
+    );
+    tracker.setState(
+      createState(
+        [
+          createAssistantMessage(
+            '{"a":1}',
+            { a: 1 },
+            { result: { source: "backend" } },
+          ),
+        ],
+        false,
+      ),
+    );
+
+    expect(await streamCall.mock.results[0]!.value).toMatchObject({
+      result: { source: "backend" },
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(execute).not.toHaveBeenCalled();
+    expect(onResult).not.toHaveBeenCalled();
+    expect(tracker.getStatuses().size).toBe(0);
+  });
+
+  it.each([
+    ['{"a":', '{"a":1,"b":2}'],
+    ['{"a":1,"b":2}', '{"b":2,"a":1}'],
+    ['{"a":', '{"divergent":true}'],
+  ])(
+    "preserves backend response metadata while closing args %s -> %s",
+    async (initialArgsText, finalArgsText) => {
+      const execute = vi.fn(async () => ({ source: "client" }));
+      const streamCall = vi.fn(
+        async (reader: Parameters<NonNullable<Tool["streamCall"]>>[0]) => {
+          for await (const value of reader.args.streamValues()) {
+            void value;
+          }
+          return reader.response.get();
+        },
+      );
+      const onResult = vi.fn();
+      const tracker = new ToolInvocationTracker(
+        () => ({
+          weatherSearch: {
+            parameters: { type: "object", properties: {} },
+            execute,
+            streamCall,
+          },
+        }),
+        {
+          onResult,
+          onStatusesChange: () => {},
+        },
+      );
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        tracker.setState(createState([]));
+        tracker.setState(
+          createState([createAssistantMessage(initialArgsText, {})]),
+        );
+        await waitFor(() => expect(streamCall).toHaveBeenCalledTimes(1));
+        const expected = {
+          result: { source: "backend" },
+          isError: true,
+          artifact: { reference: "artifact-1" },
+          modelContent: [{ type: "text" as const, text: "Backend result" }],
+        };
+        tracker.setState(
+          createState([createAssistantMessage(finalArgsText, {}, expected)]),
+        );
+        const response = await streamCall.mock.results[0]!.value;
+        expect(response).toMatchObject(expected);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(execute).not.toHaveBeenCalled();
+        expect(streamCall).toHaveBeenCalledTimes(1);
+        expect(onResult).not.toHaveBeenCalled();
+        expect(tracker.getStatuses().size).toBe(0);
+      } finally {
+        warn.mockRestore();
+      }
+    },
+  );
+
   it("handles backend result when equivalent complete argsText reorders keys", async () => {
     let resolveExecute: ((value: unknown) => void) | undefined;
     const execute = vi.fn(
@@ -1893,15 +2069,7 @@ describe("ToolInvocationTracker", () => {
 
       // The hard contract.
       expect(streamCall).toHaveBeenCalledTimes(1);
-      // execute is suppressed because the tool call resolved via a backend
-      // result on the resolution snapshot (pre-resolved path activates
-      // skipExecute at startActiveEntry time — but here we created the
-      // entry pre-resolution and transitioned in. The non-skipExecute
-      // execute path won't fire either, because by the time args close,
-      // the reader's response has already resolved, and ToolExecutionStream
-      // routes the result chunk back without invoking execute again).
-      // We don't pin the exact path; just that it's at most one.
-      expect(execute.mock.calls.length).toBeLessThanOrEqual(1);
+      expect(execute).not.toHaveBeenCalled();
       // No second onResult either (entry.hasResult short-circuits both
       // the parse-failure error chunk and the redundant backend result).
       expect(onResult).not.toHaveBeenCalled();

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
@@ -634,7 +634,8 @@ export class ToolInvocationTracker {
     hasResult: boolean;
     clientOwned: boolean;
   }): boolean {
-    if (hasResult) return true;
+    // setResponse must enqueue the backend result before closing the args stream.
+    if (hasResult) return false;
     if (!isArgsTextComplete(argsText)) return false;
     return clientOwned || !this._isRunning;
   }
@@ -851,7 +852,8 @@ export class ToolInvocationTracker {
         );
       }
 
-      if (content.approval !== undefined) entry.skipExecute = true;
+      if (content.result !== undefined || content.approval !== undefined)
+        entry.skipExecute = true;
 
       this._processArgsText(entry, content);
 


### PR DESCRIPTION
## Problem

A pending tool call can invoke a same-name frontend tool when a later snapshot supplies its backend result. The displayed result may still be correct, hiding the extra side effect. With divergent/incomplete streamed arguments, the argument reader can instead settle with a parse error and lose the backend response metadata.

Reproduced against `3a45a01c0d6141102638ecd4f32d1af4d01fb510` (the source manifest declares `@assistant-ui/core@0.3.17`), Node 24.14.0, pnpm 12.3.4, and Vitest 4.1.11 on Windows 10. This is a source-checkout reproduction, not a separate npm-only test.

The trigger is a call first observed without a result while the run is open, followed by a snapshot for that same call with a backend result. The frontend tool has not started when that snapshot arrives.

<details>
<summary>Complete standalone reproduction (fails on the baseline, passes with this patch)</summary>

In a fresh clone, check out the exact revision above, install the locked dependencies and build the core dependency graph:

```sh
pnpm install --filter '@assistant-ui/core...' --filter '@assistant-ui/react-devtools...' --frozen-lockfile
pnpm turbo build --filter=@assistant-ui/core
```

Save the following as `packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.backend-result.repro.test.ts`:

```ts
import type { Tool } from "assistant-stream";
import { expect, it, vi } from "vitest";
import type { ThreadAssistantMessage } from "../../types/message";
import { ToolInvocationTracker } from "./ToolInvocationTracker";

const message = (result?: string): ThreadAssistantMessage => ({
  id: "message-1",
  role: "assistant",
  createdAt: new Date(0),
  status: { type: "requires-action", reason: "tool-calls" },
  metadata: {
    unstable_state: null,
    unstable_annotations: [],
    unstable_data: [],
    steps: [],
    custom: {},
  },
  content: [
    {
      type: "tool-call",
      toolCallId: "call-1",
      toolName: "lookup",
      args: { a: 1 },
      argsText: '{"a":1}',
      ...(result !== undefined ? { result } : {}),
    },
  ],
});

it("repro: does not execute a pending call answered by the backend", async () => {
  const execute = vi.fn(async () => "frontend result");
  const streamCall = vi.fn(
    async (reader: Parameters<NonNullable<Tool["streamCall"]>>[0]) => {
      for await (const value of reader.args.streamValues()) {
        void value;
      }
      return reader.response.get();
    },
  );
  const onResult = vi.fn();
  const tracker = new ToolInvocationTracker(
    () => ({
      lookup: {
        parameters: { type: "object", properties: { a: { type: "number" } } },
        execute,
        streamCall,
      },
    }),
    { onResult, onStatusesChange: () => {} },
  );

  try {
    tracker.setState({ messages: [], isRunning: true });
    tracker.setState({ messages: [message()], isRunning: true });
    await vi.waitFor(() => expect(streamCall).toHaveBeenCalledTimes(1));
    await streamCall.mock.calls[0]![0].args.get("a");
    expect(execute).not.toHaveBeenCalled();

    tracker.setState({
      messages: [message("backend result")],
      isRunning: true,
    });
    const response = await streamCall.mock.results[0]!.value;
    expect(response.result).toBe("backend result");
    await new Promise<void>((resolve) => setImmediate(resolve));
    expect(execute).not.toHaveBeenCalled();
    expect(streamCall).toHaveBeenCalledTimes(1);
    expect(onResult).not.toHaveBeenCalled();
    expect(tracker.getStatuses().size).toBe(0);
  } finally {
    await tracker.abort({ discardPending: true });
  }
});
```

From `packages/core`, run `./node_modules/.bin/vitest run src/runtimes/tool-invocations/ToolInvocationTracker.backend-result.repro.test.ts --reporter=verbose` (use `vitest.cmd` on Windows). The baseline first fails the response assertion: it receives `"frontend result"` instead of `"backend result"`, before reaching the zero-executions assertion; the patched source passes. This temporary standalone test was removed after verification; the permanent cases are in the existing tracker suite.

</details>

## Root cause

`_processArgsText` explicitly closes the argument stream before `_processMessages` calls `setResponse`. In this reproducer the executor processes argument completion before the backend response and invokes the frontend tool. The existing lower-level `setResponse` already emits the result before closing arguments, but the tracker closes them first.

An existing entry also lacks `skipExecute` when a result arrives after a previous snapshot has queued argument completion. Changing the close order alone does not cover that path.

Related history: #6719 established the pending-call deferral contract, and #5107 supplies the lower-level result-before-close behavior. #5217 proposed a related close change but was closed because its tests stayed green without the patch. This PR uses a fresh, executed reproduction on the revision above, including a previously started argument reader, and does not rely on that PR's rejected synchronous-flush explanation. It does not decide the already-executed frontend/late-backend result policy discussed in #5688.

## Change

- Let `setResponse` close arguments when the snapshot already contains a backend result.
- Set the existing per-entry execution skip marker before processing an arriving result, preserving `streamCall` delivery.
- Cover open/settled runs, falsy results, argument completion/reordering/divergence, response metadata, and an already queued execution. Tighten the existing lifecycle assertion to require zero frontend executions.

This does not undo side effects from a frontend tool that has already started. Calls without a backend result still execute through the existing frontend path.

## Verification

All results below were run locally for this patch:

- Final permanent tracker suite against unmodified baseline source: **9 failed, 42 passed**; patched tracker: **51 passed** within the full core suite.
- Standalone reproduction above: fails against baseline source and passes against patched source.
- With only the new result `skipExecute` guard removed, the queued-execution case fails; it passes with both changes.
- `packages/core`: `vitest run --reporter=dot` — **1,802 passed** (168 files).
- `packages/react-ag-ui`: `vitest run --reporter=dot` — **580 passed** (18 files).
- Core `vitest run --config vitest.react-compiler.config.ts --reporter=dot` — **9 passed**.
- **11 `aui-build` tasks** succeeded, in dependency order from Turbo's `build --filter=@assistant-ui/react-ag-ui --dry=json` graph. Installed binaries were invoked directly after a frozen filtered install.
- Repository `oxlint`, changed-file `oxfmt --check`, resource memoization, workspace ranges, changeset validation/semver, and `git diff --check` passed. AG-UI `tsc --noEmit` passed.

Local limitations: full-core `tsc --noEmit` reports **103 existing diagnostics** on both the original source/tests and the patch (identical text after normalizing line positions). Full-repository `oxfmt --check` reports **18 unchanged docs files**; the modified files pass. The size check could not start because `rolldown` is not installed in the filtered performance-tooling workspace. Full monorepo CI and API-reference generation are not claimed as locally passing.

### September 10 review follow-up

The [raw September 9 baseline output and September 10 focused checks](https://github.com/assistant-ui/assistant-ui/pull/7114#discussion_r3976749370) are in the review thread. In an isolated copy of this exact PR head, the unchanged 51-case tracker suite passes. Reverting only the close-order hunk while retaining the result `skipExecute` guard produces **1 failed / 50 passed**: the divergent incomplete-arguments case settles with a parsing error and loses the backend response metadata. The result skip marker is sufficient for the complete-argument frontend-execution cases in this suite; the close change independently protects that parsing-error path. The September 9 full-core and build checks were not rerun on September 10.

## Public surface

`@assistant-ui/core` behavior fix with a patch changeset. No exports, signatures, dependencies, templates, or generated reference pages change. The existing `EDGE_CASES.md` result-before-close contract is preserved.

Implementation, tests, and verification were developed with AI assistance.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.KHIKCLmYn6fLW1mOULIion5LC1r872i8T1LR7WosTQb4E9OsJqRPh7aN1aU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->