### PR TITLE
feat(docs): keep page markdown on the selected platform

### DIFF
--- a/apps/docs/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/(docs)/docs/[[...slug]]/page.tsx
@@ -63,6 +63,7 @@ export default async function Page(props: {
           items={toc}
           githubEditUrl={githubEditUrl}
           markdownUrl={markdownUrl}
+          platformAwareMarkdown
         />
       }
     >
@@ -76,6 +77,7 @@ export default async function Page(props: {
               {...(footerPrevious && { previous: { url: footerPrevious.url } })}
               {...(footerNext && { next: { url: footerNext.url } })}
               markdownUrl={markdownUrl}
+              platformAwareMarkdown
             />
           </div>
           {page.data.description && (

--- a/apps/docs/app/(home)/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/(home)/llms.mdx/[[...slug]]/route.ts
@@ -2,9 +2,10 @@ import { type NextRequest, NextResponse } from "next/server";
 import { getLLMText } from "@/lib/get-llm-text";
 import { source } from "@/lib/source";
 import { notFound } from "next/navigation";
+import { resolveDocsPlatform } from "@/lib/docs-platform";
 
-// The flavor query parameter varies the response, so this route renders per
-// request instead of being prerendered.
+// The flavor and platform query parameters vary the response, so this route
+// renders per request instead of being prerendered.
 export const dynamic = "force-dynamic";
 
 export async function GET(
@@ -17,8 +18,11 @@ export async function GET(
 
   const flavor =
     req.nextUrl.searchParams.get("view") === "radix-ui" ? "radix" : "base";
+  const platform = resolveDocsPlatform(
+    req.nextUrl.searchParams.get("platform"),
+  );
 
-  return new NextResponse(await getLLMText(page, { flavor }), {
+  return new NextResponse(await getLLMText(page, { flavor, platform }), {
     headers: {
       "Cache-Control": "no-cache, must-revalidate",
       "Content-Type": "text/markdown; charset=utf-8",

--- a/apps/docs/components/pages/docs/layout/docs-pager.tsx
+++ b/apps/docs/components/pages/docs/layout/docs-pager.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { BASE_URL } from "@/lib/constants";
 import { useMarkdownCopy } from "@/hooks/use-markdown-copy";
+import { usePlatformMarkdownUrl } from "@/hooks/use-platform-markdown-url";
 
 type PagerItem = {
   url: string;
@@ -25,10 +26,20 @@ type DocsPagerProps = {
   previous?: PagerItem;
   next?: PagerItem;
   markdownUrl?: string;
+  platformAwareMarkdown?: boolean;
 };
 
-export function DocsPager({ previous, next, markdownUrl }: DocsPagerProps) {
-  const { copy, prefetch, isLoading } = useMarkdownCopy(markdownUrl);
+export function DocsPager({
+  previous,
+  next,
+  markdownUrl,
+  platformAwareMarkdown = false,
+}: DocsPagerProps) {
+  const resolvedMarkdownUrl = usePlatformMarkdownUrl(
+    markdownUrl,
+    platformAwareMarkdown,
+  );
+  const { copy, prefetch, isLoading } = useMarkdownCopy(resolvedMarkdownUrl);
 
   const buttonClass =
     "flex size-7 items-center justify-center rounded-md bg-muted/50 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground sm:size-8";
@@ -68,7 +79,7 @@ export function DocsPager({ previous, next, markdownUrl }: DocsPagerProps) {
             <DropdownMenuItem
               render={
                 <a
-                  href={`${BASE_URL}${markdownUrl}`}
+                  href={`${BASE_URL}${resolvedMarkdownUrl}`}
                   target="_blank"
                   rel="noreferrer noopener"
                 />

--- a/apps/docs/components/pages/docs/layout/table-of-contents.tsx
+++ b/apps/docs/components/pages/docs/layout/table-of-contents.tsx
@@ -8,6 +8,7 @@ import { useMarkdownCopy } from "@/hooks/use-markdown-copy";
 import { useAssistantPanel } from "@/components/pages/docs/assistant/context";
 import { useCurrentPage } from "@/components/pages/docs/contexts/current-page";
 import { analytics } from "@/lib/analytics";
+import { usePlatformMarkdownUrl } from "@/hooks/use-platform-markdown-url";
 
 type TOCItem = {
   title: ReactNode;
@@ -19,16 +20,23 @@ type TableOfContentsProps = {
   items: TOCItem[];
   githubEditUrl?: string;
   markdownUrl?: string;
+  platformAwareMarkdown?: boolean;
 };
 
 function TOCActions({
   markdownUrl,
   githubEditUrl,
+  platformAwareMarkdown,
 }: {
   markdownUrl: string | undefined;
   githubEditUrl: string | undefined;
+  platformAwareMarkdown: boolean;
 }) {
-  const { copy, prefetch, isLoading } = useMarkdownCopy(markdownUrl);
+  const resolvedMarkdownUrl = usePlatformMarkdownUrl(
+    markdownUrl,
+    platformAwareMarkdown,
+  );
+  const { copy, prefetch, isLoading } = useMarkdownCopy(resolvedMarkdownUrl);
   const { askAI } = useAssistantPanel();
   const currentPage = useCurrentPage();
 
@@ -77,7 +85,7 @@ function TOCActions({
             {isLoading ? "Loading..." : "Copy page"}
           </button>
           <a
-            href={`${BASE_URL}${markdownUrl}`}
+            href={`${BASE_URL}${resolvedMarkdownUrl}`}
             target="_blank"
             rel="noreferrer noopener"
             className={linkClass}
@@ -112,6 +120,7 @@ export function TableOfContents({
   items,
   githubEditUrl,
   markdownUrl,
+  platformAwareMarkdown = false,
 }: TableOfContentsProps) {
   const [activeId, setActiveId] = useState<string | null>(null);
   const listRef = useRef<HTMLUListElement>(null);
@@ -196,7 +205,11 @@ export function TableOfContents({
           })}
         </ul>
         <div className="mt-6 shrink-0">
-          <TOCActions markdownUrl={markdownUrl} githubEditUrl={githubEditUrl} />
+          <TOCActions
+            markdownUrl={markdownUrl}
+            githubEditUrl={githubEditUrl}
+            platformAwareMarkdown={platformAwareMarkdown}
+          />
         </div>
       </div>
     </div>

--- a/apps/docs/components/pages/docs/platform/context.tsx
+++ b/apps/docs/components/pages/docs/platform/context.tsx
@@ -14,12 +14,19 @@ import {
   PLATFORMS,
   type Platform,
 } from "@/lib/constants";
+import { isPlatform } from "@/lib/docs-platform";
 import {
   createPersistedPreference,
   usePersistedPreference,
 } from "@/lib/persisted-preference";
 
-export { DEFAULT_PLATFORM, PLATFORM_LABELS, PLATFORMS, type Platform };
+export {
+  DEFAULT_PLATFORM,
+  isPlatform,
+  PLATFORM_LABELS,
+  PLATFORMS,
+  type Platform,
+};
 
 export const PLATFORM_DOC_BASE_PATHS: Record<Platform, string> = {
   react: "/docs",
@@ -29,12 +36,6 @@ export const PLATFORM_DOC_BASE_PATHS: Record<Platform, string> = {
 
 const STORAGE_KEY = "assistant-ui::docs:platform";
 const URL_PARAM = "platform";
-
-export function isPlatform(
-  value: string | null | undefined,
-): value is Platform {
-  return value != null && (PLATFORMS as readonly string[]).includes(value);
-}
 
 const platformPreference = createPersistedPreference<Platform>({
   key: STORAGE_KEY,

--- a/apps/docs/components/pages/docs/platform/mdx.llm.test.tsx
+++ b/apps/docs/components/pages/docs/platform/mdx.llm.test.tsx
@@ -45,6 +45,19 @@ describe("platform markdown components", () => {
     expect(html).not.toContain("Native instructions");
   });
 
+  it("omits a platform group when the requested tab is missing", () => {
+    const html = renderToStaticMarkup(
+      PlatformTabsLLM(
+        {
+          children: createElement(Tab, { value: "React" }, "Web instructions"),
+        },
+        { flavor: "base", platform: "ink" },
+      ),
+    );
+
+    expect(html).toBe("");
+  });
+
   it("filters platform-only content against the requested platform", () => {
     const props = {
       children: "Native-only details",

--- a/apps/docs/components/pages/docs/platform/mdx.llm.test.tsx
+++ b/apps/docs/components/pages/docs/platform/mdx.llm.test.tsx
@@ -1,0 +1,65 @@
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { PlatformOnlyLLM, PlatformTabsLLM } from "./mdx.llm";
+
+function Tab({ children }: { value: string; children: ReactNode }) {
+  return <>{children}</>;
+}
+
+const platformTabs = [
+  createElement(Tab, { value: "React", key: "react" }, "Web instructions"),
+  createElement(
+    Tab,
+    { value: "React Native", key: "rn" },
+    "Native instructions",
+  ),
+  createElement(
+    Tab,
+    { value: "React Ink", key: "ink" },
+    "Terminal instructions",
+  ),
+];
+
+describe("platform markdown components", () => {
+  it("renders the requested platform tab", () => {
+    const html = renderToStaticMarkup(
+      PlatformTabsLLM(
+        { children: platformTabs },
+        { flavor: "base", platform: "rn" },
+      ),
+    );
+
+    expect(html).toContain("React Native");
+    expect(html).toContain("Native instructions");
+    expect(html).not.toContain("Web instructions");
+    expect(html).not.toContain("Terminal instructions");
+  });
+
+  it("keeps React as the default platform", () => {
+    const html = renderToStaticMarkup(
+      PlatformTabsLLM({ children: platformTabs }),
+    );
+
+    expect(html).toContain("Web instructions");
+    expect(html).not.toContain("Native instructions");
+  });
+
+  it("filters platform-only content against the requested platform", () => {
+    const props = {
+      children: "Native-only details",
+      platforms: ["rn"] as const,
+    };
+
+    expect(
+      renderToStaticMarkup(
+        PlatformOnlyLLM(props, { flavor: "base", platform: "rn" }),
+      ),
+    ).toContain("Native-only details");
+    expect(
+      renderToStaticMarkup(
+        PlatformOnlyLLM(props, { flavor: "base", platform: "react" }),
+      ),
+    ).toBe("");
+  });
+});

--- a/apps/docs/components/pages/docs/platform/mdx.llm.tsx
+++ b/apps/docs/components/pages/docs/platform/mdx.llm.tsx
@@ -5,46 +5,49 @@ import {
   PLATFORMS,
   type Platform,
 } from "@/lib/constants";
+import type { LLMRenderContext } from "@/lib/get-llm-text";
 import type { PlatformTabsProps } from "./mdx";
 
-// Emit only the React (default) tab — other platforms duplicate content and have
-// their own doc trees (/docs/react-native, /docs/ink). Label it so the code isn't
-// read as universal.
-export function PlatformTabsLLM({ children }: PlatformTabsProps): ReactNode {
+// Emit only the requested platform tab so the text does not read like every
+// platform-specific instruction applies at once.
+export function PlatformTabsLLM(
+  { children }: PlatformTabsProps,
+  ctx?: LLMRenderContext,
+): ReactNode {
+  const platform = ctx?.platform ?? DEFAULT_PLATFORM;
   const tabs = Children.toArray(children).filter(isValidElement);
-  const reactTab =
+  const selectedTab =
     tabs.find(
       (child) =>
-        (child.props as { value?: string }).value ===
-        PLATFORM_LABELS[DEFAULT_PLATFORM],
+        (child.props as { value?: string }).value === PLATFORM_LABELS[platform],
     ) ?? tabs[0];
-  if (!reactTab) return null;
+  if (!selectedTab) return null;
 
   return (
     <>
       <p>
-        <strong>{PLATFORM_LABELS[DEFAULT_PLATFORM]}</strong>
+        <strong>{PLATFORM_LABELS[platform]}</strong>
       </p>
-      {reactTab}
+      {selectedTab}
     </>
   );
 }
 
-export function PlatformOnlyLLM({
-  children,
-  except,
-  platforms,
-}: {
-  children: ReactNode;
-  except?: readonly Platform[];
-  platforms?: readonly Platform[];
-}): ReactNode {
-  if (except?.includes(DEFAULT_PLATFORM)) return null;
-  if (
-    platforms &&
-    platforms.length > 0 &&
-    !platforms.includes(DEFAULT_PLATFORM)
-  )
+export function PlatformOnlyLLM(
+  {
+    children,
+    except,
+    platforms,
+  }: {
+    children: ReactNode;
+    except?: readonly Platform[];
+    platforms?: readonly Platform[];
+  },
+  ctx?: LLMRenderContext,
+): ReactNode {
+  const platform = ctx?.platform ?? DEFAULT_PLATFORM;
+  if (except?.includes(platform)) return null;
+  if (platforms && platforms.length > 0 && !platforms.includes(platform))
     return null;
 
   const applicable = PLATFORMS.filter(

--- a/apps/docs/components/pages/docs/platform/mdx.llm.tsx
+++ b/apps/docs/components/pages/docs/platform/mdx.llm.tsx
@@ -16,11 +16,10 @@ export function PlatformTabsLLM(
 ): ReactNode {
   const platform = ctx?.platform ?? DEFAULT_PLATFORM;
   const tabs = Children.toArray(children).filter(isValidElement);
-  const selectedTab =
-    tabs.find(
-      (child) =>
-        (child.props as { value?: string }).value === PLATFORM_LABELS[platform],
-    ) ?? tabs[0];
+  const selectedTab = tabs.find(
+    (child) =>
+      (child.props as { value?: string }).value === PLATFORM_LABELS[platform],
+  );
   if (!selectedTab) return null;
 
   return (

--- a/apps/docs/components/pages/docs/platform/mdx.tsx
+++ b/apps/docs/components/pages/docs/platform/mdx.tsx
@@ -1,14 +1,6 @@
 "use client";
 
-import {
-  Children,
-  cloneElement,
-  isValidElement,
-  useCallback,
-  useMemo,
-  useState,
-  type ReactNode,
-} from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import {
   PlatformScope,
   isVisibleForPlatform,
@@ -22,6 +14,7 @@ import {
   escapeValue,
   type TabsProps,
 } from "@/components/pages/docs/fumadocs/tabs";
+import { rewritePlatformPackages } from "./rewrite";
 
 const ITEMS = PLATFORMS.map((p) => PLATFORM_LABELS[p]);
 const VALUE_TO_PLATFORM: Record<string, Platform> = Object.fromEntries(
@@ -82,37 +75,11 @@ export function PlatformOnly({
   return <>{children}</>;
 }
 
-// Negative lookahead avoids matching siblings like `@assistant-ui/react-langgraph`.
-const PACKAGE_PATTERN = /@assistant-ui\/react(?![-\w])/g;
-
-const PLATFORM_PACKAGE: Record<Platform, string> = {
-  react: "@assistant-ui/react",
-  rn: "@assistant-ui/react-native",
-  ink: "@assistant-ui/react-ink",
-};
-
-function rewrite(node: ReactNode, replacement: string): ReactNode {
-  if (typeof node === "string") {
-    return node.replace(PACKAGE_PATTERN, replacement);
-  }
-  if (Array.isArray(node)) {
-    // Children.map auto-keys the siblings; bare Array.map would warn on Shiki spans.
-    return Children.map(node, (child) => rewrite(child, replacement));
-  }
-  if (isValidElement<{ children?: ReactNode }>(node)) {
-    const { children } = node.props;
-    if (children === undefined) return node;
-    return cloneElement(node, { children: rewrite(children, replacement) });
-  }
-  return node;
-}
-
 export function PlatformAwareCode({ children }: { children: ReactNode }) {
   const platform = usePlatformOrDefault();
-  const replacement = PLATFORM_PACKAGE[platform];
   const rewritten = useMemo(
-    () => (platform === "react" ? children : rewrite(children, replacement)),
-    [children, platform, replacement],
+    () => rewritePlatformPackages(children, platform),
+    [children, platform],
   );
   return <>{rewritten}</>;
 }

--- a/apps/docs/components/pages/docs/platform/rewrite.test.tsx
+++ b/apps/docs/components/pages/docs/platform/rewrite.test.tsx
@@ -1,0 +1,34 @@
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+import { rewritePlatformPackages } from "./rewrite";
+
+describe("rewritePlatformPackages", () => {
+  it("rewrites the web package without changing adapter package names", () => {
+    expect(
+      rewritePlatformPackages(
+        "@assistant-ui/react @assistant-ui/react-ai-sdk",
+        "rn",
+      ),
+    ).toBe("@assistant-ui/react-native @assistant-ui/react-ai-sdk");
+  });
+
+  it("rewrites package names inside nested code nodes", () => {
+    const node = createElement(
+      "code",
+      null,
+      'import { Thread } from "@assistant-ui/react";',
+    );
+    const rewritten = rewritePlatformPackages(node, "ink");
+
+    expect(rewritten).toMatchObject({
+      props: {
+        children: 'import { Thread } from "@assistant-ui/react-ink";',
+      },
+    });
+  });
+
+  it("preserves React content by reference", () => {
+    const node = createElement("code", null, "@assistant-ui/react");
+    expect(rewritePlatformPackages(node, "react")).toBe(node);
+  });
+});

--- a/apps/docs/components/pages/docs/platform/rewrite.ts
+++ b/apps/docs/components/pages/docs/platform/rewrite.ts
@@ -1,6 +1,7 @@
 import { Children, cloneElement, isValidElement, type ReactNode } from "react";
 import type { Platform } from "@/lib/constants";
 
+// Negative lookahead avoids matching siblings like `@assistant-ui/react-langgraph`.
 const PACKAGE_PATTERN = /@assistant-ui\/react(?![-\w])/g;
 
 const PLATFORM_PACKAGE: Record<Platform, string> = {
@@ -19,6 +20,7 @@ export function rewritePlatformPackages(
     return node.replace(PACKAGE_PATTERN, PLATFORM_PACKAGE[platform]);
   }
   if (Array.isArray(node)) {
+    // Children.map auto-keys the siblings; bare Array.map would warn on Shiki spans.
     return Children.map(node, (child) =>
       rewritePlatformPackages(child, platform),
     );

--- a/apps/docs/components/pages/docs/platform/rewrite.ts
+++ b/apps/docs/components/pages/docs/platform/rewrite.ts
@@ -1,0 +1,34 @@
+import { Children, cloneElement, isValidElement, type ReactNode } from "react";
+import type { Platform } from "@/lib/constants";
+
+const PACKAGE_PATTERN = /@assistant-ui\/react(?![-\w])/g;
+
+const PLATFORM_PACKAGE: Record<Platform, string> = {
+  react: "@assistant-ui/react",
+  rn: "@assistant-ui/react-native",
+  ink: "@assistant-ui/react-ink",
+};
+
+export function rewritePlatformPackages(
+  node: ReactNode,
+  platform: Platform,
+): ReactNode {
+  if (platform === "react") return node;
+
+  if (typeof node === "string") {
+    return node.replace(PACKAGE_PATTERN, PLATFORM_PACKAGE[platform]);
+  }
+  if (Array.isArray(node)) {
+    return Children.map(node, (child) =>
+      rewritePlatformPackages(child, platform),
+    );
+  }
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    const { children } = node.props;
+    if (children === undefined) return node;
+    return cloneElement(node, {
+      children: rewritePlatformPackages(children, platform),
+    });
+  }
+  return node;
+}

--- a/apps/docs/components/pages/docs/preview-code.server.test.tsx
+++ b/apps/docs/components/pages/docs/preview-code.server.test.tsx
@@ -1,6 +1,8 @@
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import { PreviewCode } from "./preview-code.server";
+import type { LLMRenderContext } from "@/lib/get-llm-text";
 
 const PreviewCodeClient = vi.hoisted(() => () => null);
 
@@ -12,6 +14,15 @@ type PreviewCodeElement = ReactElement<{
   code: string;
   baseCode?: string;
 }>;
+
+const PreviewCodeLLM = (
+  PreviewCode as typeof PreviewCode & {
+    llm: (
+      props: Parameters<typeof PreviewCode>[0],
+      ctx?: LLMRenderContext,
+    ) => ReactNode;
+  }
+).llm;
 
 async function getPreviewCode(
   file: string,
@@ -73,4 +84,26 @@ describe("PreviewCode", () => {
     );
     expect(code).not.toContain("AssistantRuntime");
   });
+
+  it.each([
+    ["rn", "@assistant-ui/react-native"],
+    ["ink", "@assistant-ui/react-ink"],
+  ] as const)(
+    "rewrites LLM preview imports for %s",
+    (platform, packageName) => {
+      const markup = renderToStaticMarkup(
+        PreviewCodeLLM(
+          {
+            file: "components/pages/docs/samples/tool-ui/custom-renderer",
+            name: "WeatherToolUI",
+            children: null,
+          },
+          { flavor: "base", platform },
+        ),
+      );
+
+      expect(markup).toContain(packageName);
+      expect(markup).not.toContain("@assistant-ui/react&quot;");
+    },
+  );
 });

--- a/apps/docs/components/pages/docs/preview-code.server.tsx
+++ b/apps/docs/components/pages/docs/preview-code.server.tsx
@@ -11,6 +11,8 @@ import {
   filterRelevantImports,
 } from "./preview-code-extract";
 import type { LLMRenderContext } from "@/lib/get-llm-text";
+import { DEFAULT_PLATFORM } from "@/lib/constants";
+import { rewritePlatformPackages } from "./platform/rewrite";
 
 type PreviewCodeProps = {
   /** Path relative to apps/docs, e.g. "components/pages/docs/samples/select" */
@@ -98,7 +100,10 @@ export async function PreviewCode({
       <p>{`Code for ${name} preview:`}</p>
       <pre>
         <code className="language-tsx">
-          {buildPreviewCode(sourceFile, name)}
+          {rewritePlatformPackages(
+            buildPreviewCode(sourceFile, name),
+            ctx?.platform ?? DEFAULT_PLATFORM,
+          )}
         </code>
       </pre>
     </>

--- a/apps/docs/hooks/use-markdown-copy.test.tsx
+++ b/apps/docs/hooks/use-markdown-copy.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useMarkdownCopy } from "./use-markdown-copy";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("useMarkdownCopy", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches again when the platform-specific URL changes", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => ({
+      ok: true,
+      text: async () => `Content for ${String(input)}`,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, rerender } = renderHook(({ url }) => useMarkdownCopy(url), {
+      initialProps: { url: "/docs/example.md" },
+    });
+
+    act(() => result.current.prefetch());
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith("/docs/example.md"),
+    );
+
+    rerender({ url: "/docs/example.md?platform=rn" });
+    act(() => result.current.prefetch());
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith("/docs/example.md?platform=rn"),
+    );
+  });
+});

--- a/apps/docs/hooks/use-markdown-copy.ts
+++ b/apps/docs/hooks/use-markdown-copy.ts
@@ -4,34 +4,55 @@ import { useRef, useState, useCallback } from "react";
 import { toast } from "sonner";
 
 export function useMarkdownCopy(markdownUrl: string | undefined) {
-  const [content, setContent] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const hasFetched = useRef(false);
+  const [loaded, setLoaded] = useState<{
+    url: string;
+    content: string;
+  } | null>(null);
+  const [loadingUrl, setLoadingUrl] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+  const pendingUrlRef = useRef<string | null>(null);
 
   const prefetch = useCallback(() => {
-    if (!markdownUrl || hasFetched.current) return;
-    hasFetched.current = true;
-    setIsLoading(true);
+    if (
+      !markdownUrl ||
+      loaded?.url === markdownUrl ||
+      pendingUrlRef.current === markdownUrl
+    )
+      return;
+
+    const requestId = ++requestIdRef.current;
+    pendingUrlRef.current = markdownUrl;
+    setLoadingUrl(markdownUrl);
     fetch(markdownUrl)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.text();
       })
-      .then(setContent)
-      .catch(() => setContent(null))
-      .finally(() => setIsLoading(false));
-  }, [markdownUrl]);
+      .then((content) => {
+        if (requestId === requestIdRef.current) {
+          setLoaded({ url: markdownUrl, content });
+        }
+      })
+      .catch(() => {
+        if (requestId === requestIdRef.current) setLoaded(null);
+      })
+      .finally(() => {
+        if (requestId !== requestIdRef.current) return;
+        pendingUrlRef.current = null;
+        setLoadingUrl(null);
+      });
+  }, [loaded?.url, markdownUrl]);
 
   const copy = useCallback(() => {
-    if (!content) {
+    if (!loaded || loaded.url !== markdownUrl) {
       toast.error("Content not loaded yet");
       return;
     }
     navigator.clipboard
-      .writeText(content)
+      .writeText(loaded.content)
       .then(() => toast.success("Copied to clipboard"))
       .catch(() => toast.error("Failed to copy"));
-  }, [content]);
+  }, [loaded, markdownUrl]);
 
-  return { copy, prefetch, isLoading };
+  return { copy, prefetch, isLoading: loadingUrl === markdownUrl };
 }

--- a/apps/docs/hooks/use-platform-markdown-url.ts
+++ b/apps/docs/hooks/use-platform-markdown-url.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePlatformOrDefault } from "@/components/pages/docs/platform/context";
+import { getPlatformMarkdownUrl } from "@/lib/docs-platform";
+
+export function usePlatformMarkdownUrl(
+  markdownUrl: string | undefined,
+  platformAware: boolean,
+): string | undefined {
+  const platform = usePlatformOrDefault();
+
+  return useMemo(() => {
+    if (!markdownUrl || !platformAware) return markdownUrl;
+    return getPlatformMarkdownUrl(markdownUrl, platform);
+  }, [markdownUrl, platform, platformAware]);
+}

--- a/apps/docs/lib/docs-platform.test.ts
+++ b/apps/docs/lib/docs-platform.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPlatformMarkdownUrl,
+  isPlatform,
+  resolveDocsPlatform,
+} from "./docs-platform";
+
+describe("docs platform", () => {
+  it("recognizes supported platforms", () => {
+    expect(isPlatform("react")).toBe(true);
+    expect(isPlatform("rn")).toBe(true);
+    expect(isPlatform("ink")).toBe(true);
+    expect(isPlatform("vue")).toBe(false);
+  });
+
+  it("falls back to React for missing or invalid platform parameters", () => {
+    expect(resolveDocsPlatform(null)).toBe("react");
+    expect(resolveDocsPlatform("vue")).toBe("react");
+  });
+
+  it("adds the selected platform without dropping other parameters", () => {
+    expect(
+      getPlatformMarkdownUrl("/docs/runtimes/ai-sdk/v7.md?view=radix-ui", "rn"),
+    ).toBe("/docs/runtimes/ai-sdk/v7.md?view=radix-ui&platform=rn");
+  });
+
+  it("keeps React markdown URLs canonical", () => {
+    expect(
+      getPlatformMarkdownUrl(
+        "/docs/runtimes/ai-sdk/v7.md?platform=ink",
+        "react",
+      ),
+    ).toBe("/docs/runtimes/ai-sdk/v7.md");
+  });
+});

--- a/apps/docs/lib/docs-platform.ts
+++ b/apps/docs/lib/docs-platform.ts
@@ -1,0 +1,33 @@
+import {
+  BASE_URL,
+  DEFAULT_PLATFORM,
+  PLATFORMS,
+  type Platform,
+} from "./constants";
+
+export function isPlatform(
+  value: string | null | undefined,
+): value is Platform {
+  return value != null && (PLATFORMS as readonly string[]).includes(value);
+}
+
+export function resolveDocsPlatform(
+  value: string | null | undefined,
+): Platform {
+  return isPlatform(value) ? value : DEFAULT_PLATFORM;
+}
+
+export function getPlatformMarkdownUrl(
+  markdownUrl: string,
+  platform: Platform,
+): string {
+  const url = new URL(markdownUrl, BASE_URL);
+
+  if (platform === DEFAULT_PLATFORM) {
+    url.searchParams.delete("platform");
+  } else {
+    url.searchParams.set("platform", platform);
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/apps/docs/lib/get-llm-text.tsx
+++ b/apps/docs/lib/get-llm-text.tsx
@@ -12,6 +12,7 @@ import remarkStringify from "remark-stringify";
 import { unified } from "unified";
 import { AGENT_DOCS_DIRECTIVE_MARKDOWN } from "@/lib/agent-docs-directive";
 import { LLM_COMPONENTS } from "@/lib/llm-components";
+import { DEFAULT_PLATFORM, type Platform } from "@/lib/constants";
 import type {
   design,
   elementsDocs,
@@ -52,9 +53,15 @@ const OMITTED_STATIC_PROP_NAMES = new Set([
   "priority",
 ]);
 
-export type LLMRenderContext = { flavor: "radix" | "base" };
+export type LLMRenderContext = {
+  flavor: "radix" | "base";
+  platform: Platform;
+};
 
-const DEFAULT_LLM_CONTEXT: LLMRenderContext = { flavor: "base" };
+const DEFAULT_LLM_CONTEXT: LLMRenderContext = {
+  flavor: "base",
+  platform: DEFAULT_PLATFORM,
+};
 
 type StaticFunctionComponent = (
   props: Record<string, unknown>,
@@ -348,13 +355,11 @@ type LLMPage =
 
 export async function getLLMText(
   page: LLMPage,
-  ctx: LLMRenderContext = DEFAULT_LLM_CONTEXT,
+  options: Partial<LLMRenderContext> = {},
 ) {
   const { body: Body } = await page.data.load();
+  const ctx: LLMRenderContext = { ...DEFAULT_LLM_CONTEXT, ...options };
 
-  // TODO: Platform-scoped MDX currently renders with the server default
-  // platform ("react"). If llms output should include React Native or Ink
-  // variants, render once per platform or provide an explicit platform scope.
   const staticBody = await resolveStaticReactNode(
     <Body components={LLM_COMPONENTS} />,
     ctx,

--- a/apps/docs/lib/llm-components.tsx
+++ b/apps/docs/lib/llm-components.tsx
@@ -7,6 +7,9 @@ import {
   PlatformTabsLLM,
 } from "@/components/pages/docs/platform/mdx.llm";
 import type { CalloutProps } from "@/components/ui/callout";
+import { DEFAULT_PLATFORM } from "@/lib/constants";
+import { rewritePlatformPackages } from "@/components/pages/docs/platform/rewrite";
+import type { LLMRenderContext } from "@/lib/get-llm-text";
 import { CardLLM, CardsLLM } from "@/components/pages/docs/fumadocs/card";
 import { InstallCommandLLM } from "@/components/pages/docs/fumadocs/install/install-command";
 import { ParametersTableLLM } from "@/components/pages/docs/parameters-table";
@@ -72,7 +75,11 @@ export const LLM_COMPONENTS: MDXComponents = {
   h4: Heading("h4"),
   h5: Heading("h5"),
   h6: Heading("h6"),
-  pre: ({ children }: ComponentProps<"pre">) => <pre>{children}</pre>,
+  pre: ({ children }: ComponentProps<"pre">, ctx?: LLMRenderContext) => (
+    <pre>
+      {rewritePlatformPackages(children, ctx?.platform ?? DEFAULT_PLATFORM)}
+    </pre>
+  ),
   // Static markdown images render via next/image (client), whose fallback drops
   // src and leaks alt. A host <img> survives as `![alt](src)`; src may be a
   // string or a StaticImageData object.


### PR DESCRIPTION
## Problem

On pages with platform-specific instructions:

1. Select React Native or React Ink.
2. Open the page actions.
3. Use Copy page or View as Markdown.

The generated Markdown still contains the React tab and React package imports instead of the selected platform. This affects the current docs deployment.

## Root cause

The selected platform lives in client-side docs state, but the page actions linked to a platform-neutral Markdown URL. The Markdown route and static MDX components also always rendered the React default. The copy hook cached its first request without accounting for a later platform URL change.

## Change

- Carry React Native and Ink selections into page Markdown URLs while keeping React URLs canonical.
- Parse and validate the platform in the Markdown route.
- Render the matching PlatformTabs and PlatformOnly content.
- Rewrite exact @assistant-ui/react references in fenced code for React Native and Ink.
- Key copied Markdown content by URL so switching platforms fetches the correct page.
- Keep non-platform docs surfaces and default MCP/LLM output on React.

## Verification

- pnpm -C apps/docs exec vitest run lib/docs-platform.test.ts components/pages/docs/platform/rewrite.test.tsx components/pages/docs/platform/mdx.llm.test.tsx hooks/use-markdown-copy.test.tsx
- pnpm -C apps/docs test
- pnpm -C apps/docs exec tsc --noEmit
- pnpm lint
- pnpm -C apps/docs build
- Started the production build locally and confirmed:
  - /docs/runtimes/custom/local-runtime.md returns React instructions.
  - ?platform=rn returns React Native and Expo instructions.
  - ?platform=ink returns React Ink and terminal instructions.

The reproduction returns React before this change and the selected platform after it.

## Public surface

None. This changes only the private docs application, so no changeset is required.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.XfraXVAnI5JmR-MAZ8HZqWe7gm7PvtcGKgP8IOJ7DxRxEvM8JUBRu28yals?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->