### PR TITLE
fix(react): cancel WebMCP tools during async validation

### DIFF
--- a/.changeset/soft-dodos-listen.md
+++ b/.changeset/soft-dodos-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: cancel WebMCP tools while asynchronous validation is pending

--- a/packages/react/src/unstable/webmcp/convertTools.test.ts
+++ b/packages/react/src/unstable/webmcp/convertTools.test.ts
@@ -268,6 +268,37 @@ describe("toWebMcpTool cancellation", () => {
   });
 
   it.for(["caller", "lifecycle"] as const)(
+    "settles while async validation is pending when the %s signal aborts",
+    async (abortedSignal) => {
+      const lifecycle = new AbortController();
+      const caller = new AbortController();
+      let finishValidation!: (result: { issues?: readonly unknown[] }) => void;
+      const schema = z.object({ city: z.string() });
+      (schema as any)["~standard"] = {
+        ...schema["~standard"],
+        validate: () =>
+          new Promise<{ issues?: readonly unknown[] }>((resolve) => {
+            finishValidation = resolve;
+          }),
+      };
+      const execute = vi.fn(async () => "never");
+      const pending = descriptorFor(
+        { execute, parameters: schema },
+        lifecycle.signal,
+      ).execute({ city: "Paris" }, { signal: caller.signal });
+
+      (abortedSignal === "caller" ? caller : lifecycle).abort();
+
+      await expect(pending).resolves.toEqual({
+        isError: true,
+        content: [text("Tool execution was cancelled.")],
+      });
+      expect(execute).not.toHaveBeenCalled();
+      finishValidation({});
+    },
+  );
+
+  it.for(["caller", "lifecycle"] as const)(
     "merges signals without AbortSignal.any when the %s signal aborts",
     async (abortedSignal) => {
       const lifecycle = new AbortController();

--- a/packages/react/src/unstable/webmcp/convertTools.test.ts
+++ b/packages/react/src/unstable/webmcp/convertTools.test.ts
@@ -298,6 +298,34 @@ describe("toWebMcpTool cancellation", () => {
     },
   );
 
+  it("consumes a validator rejection after cancellation", async () => {
+    const caller = new AbortController();
+    let failValidation!: (error: unknown) => void;
+    const schema = z.object({ city: z.string() });
+    (schema as any)["~standard"] = {
+      ...schema["~standard"],
+      validate: () =>
+        new Promise((_resolve, reject) => {
+          failValidation = reject;
+        }),
+    };
+    const execute = vi.fn(async () => "never");
+    const pending = descriptorFor({ execute, parameters: schema }).execute(
+      { city: "Paris" },
+      { signal: caller.signal },
+    );
+
+    caller.abort();
+
+    await expect(pending).resolves.toEqual({
+      isError: true,
+      content: [text("Tool execution was cancelled.")],
+    });
+    failValidation(new Error("late validation failure"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it("does not execute when cancellation follows validation", async () => {
     const caller = new AbortController();
     const removeEventListener = caller.signal.removeEventListener.bind(

--- a/packages/react/src/unstable/webmcp/convertTools.test.ts
+++ b/packages/react/src/unstable/webmcp/convertTools.test.ts
@@ -326,21 +326,41 @@ describe("toWebMcpTool cancellation", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
-  it("does not execute when cancellation follows validation", async () => {
+  it("prefers cancellation when validation aborts before rejecting", async () => {
     const caller = new AbortController();
-    const removeEventListener = caller.signal.removeEventListener.bind(
-      caller.signal,
-    );
-    vi.spyOn(caller.signal, "removeEventListener").mockImplementation(
-      (...args) => {
-        removeEventListener(...args);
-        caller.abort();
-      },
-    );
     const schema = z.object({ city: z.string() });
     (schema as any)["~standard"] = {
       ...schema["~standard"],
-      validate: async () => ({}),
+      validate: () => {
+        caller.abort();
+        return Promise.reject(new Error("validation failed"));
+      },
+    };
+    const execute = vi.fn(async () => "never");
+
+    const result = await descriptorFor({ execute, parameters: schema }).execute(
+      { city: "Paris" },
+      { signal: caller.signal },
+    );
+
+    expect(result).toEqual({
+      isError: true,
+      content: [text("Tool execution was cancelled.")],
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("does not execute when cancellation follows validation", async () => {
+    const caller = new AbortController();
+    const schema = z.object({ city: z.string() });
+    (schema as any)["~standard"] = {
+      ...schema["~standard"],
+      validate: () => ({
+        then: (resolve: (value: { issues?: readonly unknown[] }) => void) => {
+          resolve({});
+          caller.abort();
+        },
+      }),
     };
     const execute = vi.fn(async () => "never");
 

--- a/packages/react/src/unstable/webmcp/convertTools.test.ts
+++ b/packages/react/src/unstable/webmcp/convertTools.test.ts
@@ -298,6 +298,36 @@ describe("toWebMcpTool cancellation", () => {
     },
   );
 
+  it("does not execute when cancellation follows validation", async () => {
+    const caller = new AbortController();
+    const removeEventListener = caller.signal.removeEventListener.bind(
+      caller.signal,
+    );
+    vi.spyOn(caller.signal, "removeEventListener").mockImplementation(
+      (...args) => {
+        removeEventListener(...args);
+        caller.abort();
+      },
+    );
+    const schema = z.object({ city: z.string() });
+    (schema as any)["~standard"] = {
+      ...schema["~standard"],
+      validate: async () => ({}),
+    };
+    const execute = vi.fn(async () => "never");
+
+    const result = await descriptorFor({ execute, parameters: schema }).execute(
+      { city: "Paris" },
+      { signal: caller.signal },
+    );
+
+    expect(result).toEqual({
+      isError: true,
+      content: [text("Tool execution was cancelled.")],
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it.for(["caller", "lifecycle"] as const)(
     "merges signals without AbortSignal.any when the %s signal aborts",
     async (abortedSignal) => {

--- a/packages/react/src/unstable/webmcp/convertTools.ts
+++ b/packages/react/src/unstable/webmcp/convertTools.ts
@@ -138,6 +138,7 @@ const raceWithAbort = async <T>(
   });
 
   try {
+    // Cancellation wins when validation aborts and rejects synchronously.
     return await Promise.race([abortPromise, value]);
   } finally {
     abortSignal.removeEventListener("abort", onAbort);

--- a/packages/react/src/unstable/webmcp/convertTools.ts
+++ b/packages/react/src/unstable/webmcp/convertTools.ts
@@ -138,7 +138,7 @@ const raceWithAbort = async <T>(
   });
 
   try {
-    return await Promise.race([value, abortPromise]);
+    return await Promise.race([abortPromise, value]);
   } finally {
     abortSignal.removeEventListener("abort", onAbort);
   }

--- a/packages/react/src/unstable/webmcp/convertTools.ts
+++ b/packages/react/src/unstable/webmcp/convertTools.ts
@@ -118,31 +118,30 @@ const isStandardSchema = (schema: unknown): schema is StandardSchemaLike =>
   "~standard" in schema &&
   (schema as StandardSchemaLike)["~standard"].version === 1;
 
-const awaitWithAbort = async <T>(
-  value: T | PromiseLike<T>,
-  signal: AbortSignal | undefined,
-): Promise<T> => {
-  if (!signal) return await value;
-  if (signal.aborted) throw new Error("Tool execution was cancelled.");
+const TOOL_ABORTED = Symbol("assistant-ui.webmcp-tool-aborted");
 
-  return await new Promise<T>((resolve, reject) => {
-    const onAbort = () => {
-      signal.removeEventListener("abort", onAbort);
-      reject(new Error("Tool execution was cancelled."));
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
+const isThenable = <T>(value: T | PromiseLike<T>): value is PromiseLike<T> =>
+  typeof (value as PromiseLike<T> | null | undefined)?.then === "function";
 
-    Promise.resolve(value).then(
-      (result) => {
-        signal.removeEventListener("abort", onAbort);
-        resolve(result);
-      },
-      (error: unknown) => {
-        signal.removeEventListener("abort", onAbort);
-        reject(error);
-      },
-    );
+const raceWithAbort = async <T>(
+  value: PromiseLike<T>,
+  abortSignal: AbortSignal,
+): Promise<T | typeof TOOL_ABORTED> => {
+  let onAbort!: () => void;
+  const abortPromise = new Promise<typeof TOOL_ABORTED>((resolve) => {
+    onAbort = () => resolve(TOOL_ABORTED);
+    if (abortSignal.aborted) {
+      onAbort();
+    } else {
+      abortSignal.addEventListener("abort", onAbort, { once: true });
+    }
   });
+
+  try {
+    return await Promise.race([value, abortPromise]);
+  } finally {
+    abortSignal.removeEventListener("abort", onAbort);
+  }
 };
 
 // AbortSignal.any sits above the browserslist floor and rejects any input that
@@ -213,8 +212,15 @@ export const toWebMcpTool = (
 
       let executeFn = tool.execute;
       if (isStandardSchema(tool.parameters)) {
-        let validation = tool.parameters["~standard"].validate(args);
-        validation = await awaitWithAbort(validation, abortSignal);
+        const result = tool.parameters["~standard"].validate(args);
+        const validation = isThenable(result)
+          ? abortSignal
+            ? await raceWithAbort(result, abortSignal)
+            : await result
+          : result;
+        if (validation === TOOL_ABORTED) {
+          return errorResult("Tool execution was cancelled.");
+        }
         if (validation.issues) {
           const issues = validation.issues;
           executeFn =
@@ -225,6 +231,10 @@ export const toWebMcpTool = (
               );
             });
         }
+      }
+
+      if (abortSignal?.aborted) {
+        return errorResult("Tool execution was cancelled.");
       }
 
       if (!executeFn) {

--- a/packages/react/src/unstable/webmcp/convertTools.ts
+++ b/packages/react/src/unstable/webmcp/convertTools.ts
@@ -118,6 +118,33 @@ const isStandardSchema = (schema: unknown): schema is StandardSchemaLike =>
   "~standard" in schema &&
   (schema as StandardSchemaLike)["~standard"].version === 1;
 
+const awaitWithAbort = async <T>(
+  value: T | PromiseLike<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> => {
+  if (!signal) return await value;
+  if (signal.aborted) throw new Error("Tool execution was cancelled.");
+
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(new Error("Tool execution was cancelled."));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    Promise.resolve(value).then(
+      (result) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(result);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+};
+
 // AbortSignal.any sits above the browserslist floor and rejects any input that
 // is not a native AbortSignal, which a navigator.modelContext polyfill's signal
 // is not. The merged signal tracks its inputs only until cleanup runs, where
@@ -179,10 +206,15 @@ export const toWebMcpTool = (
       } else {
         abortSignal = callerSignal ?? lifecycleSignal;
       }
+
+      if (abortSignal?.aborted) {
+        return errorResult("Tool execution was cancelled.");
+      }
+
       let executeFn = tool.execute;
       if (isStandardSchema(tool.parameters)) {
         let validation = tool.parameters["~standard"].validate(args);
-        validation = await validation;
+        validation = await awaitWithAbort(validation, abortSignal);
         if (validation.issues) {
           const issues = validation.issues;
           executeFn =
@@ -193,10 +225,6 @@ export const toWebMcpTool = (
               );
             });
         }
-      }
-
-      if (abortSignal?.aborted) {
-        return errorResult("Tool execution was cancelled.");
       }
 
       if (!executeFn) {

--- a/packages/react/src/unstable/webmcp/convertTools.ts
+++ b/packages/react/src/unstable/webmcp/convertTools.ts
@@ -138,7 +138,7 @@ const raceWithAbort = async <T>(
   });
 
   try {
-    // Cancellation wins when validation aborts and rejects synchronously.
+    // Unlike assistant-stream's helper, cancellation wins when validation aborts and rejects synchronously.
     return await Promise.race([abortPromise, value]);
   } finally {
     abortSignal.removeEventListener("abort", onAbort);


### PR DESCRIPTION
## Problem

WebMCP tool execution can remain pending after cancellation when a Standard Schema validator returns a slow or unresolved promise. In the focused reproduction, aborting either the caller signal or the provider lifecycle signal did not settle the tool call, and the tool implementation never ran.

## Root cause

Cancellation was checked only after asynchronous schema validation completed. An unresolved validator therefore prevented the execution path from reaching the cancellation check.

## Change

Race only thenable validation results against the active cancellation signal, using the same sentinel-based shape as the primary tool-execution path in assistant-stream. Synchronous validators remain synchronous, and checks before and after validation close the cancellation windows around the race.

The helper remains local because the assistant-stream implementation is package-private; exporting it would broaden another package's surface for one internal WebMCP caller.

## Verification

- `cd packages/react && node_modules/.bin/vitest run src/unstable/webmcp/convertTools.test.ts`
- `cd packages/react && node_modules/.bin/vitest run`
- `cd packages/react && node_modules/.bin/aui-build`
- `node scripts/check-changesets.mjs`
- Confirmed the regression test stays pending without the fix and passes with it for caller and lifecycle cancellation.
- Confirmed cancellation after validation settles still prevents tool execution.

## Public surface

`@assistant-ui/react` behavior only. No exports, documentation, templates, or API-reference output changed. Includes a patch changeset.