### PR TITLE
fix(core): handle assistant frame result serialization failures

### DIFF
--- a/.changeset/quiet-frames-report.md
+++ b/.changeset/quiet-frames-report.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: report AssistantFrame tool results that cannot cross the frame boundary

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -147,6 +147,9 @@ describe("AssistantFrameProvider", () => {
   });
 
   it("reports tool results that cannot cross the frame boundary", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     const execute = vi.fn(async () => () => undefined);
     vi.mocked(parentWindow.postMessage).mockImplementation((data) => {
       structuredClone(data);
@@ -160,6 +163,10 @@ describe("AssistantFrameProvider", () => {
     dispatchToolCall(window.location.origin);
 
     await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui] AssistantFrame tool result could not be sent.",
+        expect.objectContaining({ name: "DataCloneError" }),
+      );
       expect(parentWindow.postMessage).toHaveBeenCalledWith(
         {
           channel: FRAME_MESSAGE_CHANNEL,

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -149,13 +149,7 @@ describe("AssistantFrameProvider", () => {
   it("reports tool results that cannot cross the frame boundary", async () => {
     const execute = vi.fn(async () => () => undefined);
     vi.mocked(parentWindow.postMessage).mockImplementation((data) => {
-      const message = (data as { message?: Record<string, unknown> }).message;
-      if (message?.["type"] === "tool-result" && "result" in message) {
-        throw new DOMException(
-          "The object could not be cloned.",
-          "DataCloneError",
-        );
-      }
+      structuredClone(data);
     });
     AssistantFrameProvider.addModelContextProvider({
       getModelContext: () => ({

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -146,6 +146,40 @@ describe("AssistantFrameProvider", () => {
     });
   });
 
+  it("reports tool results that cannot cross the frame boundary", async () => {
+    const execute = vi.fn(async () => () => undefined);
+    vi.mocked(parentWindow.postMessage).mockImplementation((data) => {
+      const message = (data as { message?: Record<string, unknown> }).message;
+      if (message?.["type"] === "tool-result" && "result" in message) {
+        throw new DOMException(
+          "The object could not be cloned.",
+          "DataCloneError",
+        );
+      }
+    });
+    AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({
+        tools: { sensitiveTool: { execute } },
+      }),
+    });
+
+    dispatchToolCall(window.location.origin);
+
+    await vi.waitFor(() => {
+      expect(parentWindow.postMessage).toHaveBeenCalledWith(
+        {
+          channel: FRAME_MESSAGE_CHANNEL,
+          message: {
+            type: "tool-result",
+            id: "tool-call-1",
+            error: "Tool result could not be sent across the frame boundary",
+          },
+        },
+        { targetOrigin: window.location.origin },
+      );
+    });
+  });
+
   it("aborts in-flight tool calls when the parent cancels them", async () => {
     let toolSignal: AbortSignal | undefined;
     const execute = vi.fn(

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -170,6 +170,10 @@ export class AssistantFrameProvider {
     } catch (sendError) {
       if (error !== undefined) throw sendError;
 
+      console.error(
+        "[assistant-ui] AssistantFrame tool result could not be sent.",
+        sendError,
+      );
       this.sendMessage(event, {
         type: "tool-result",
         id: message.id,

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -108,7 +108,7 @@ export class AssistantFrameProvider {
       case "tool-call":
         void this.handleToolCall(message, event).catch((error: unknown) => {
           console.error(
-            "[assistant-ui] Failed to send AssistantFrame tool result.",
+            "[assistant-ui] AssistantFrame tool call failed.",
             error,
           );
         });

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -106,7 +106,12 @@ export class AssistantFrameProvider {
         break;
 
       case "tool-call":
-        this.handleToolCall(message, event);
+        void this.handleToolCall(message, event).catch((error: unknown) => {
+          console.error(
+            "[assistant-ui] Failed to send AssistantFrame tool result.",
+            error,
+          );
+        });
         break;
 
       case "tool-cancel":
@@ -156,11 +161,21 @@ export class AssistantFrameProvider {
     if (this._activeToolCalls.get(message.id) !== activeCall) return;
     this._activeToolCalls.delete(message.id);
 
-    this.sendMessage(event, {
-      type: "tool-result",
-      id: message.id,
-      ...(error !== undefined ? { error } : { result }),
-    });
+    try {
+      this.sendMessage(event, {
+        type: "tool-result",
+        id: message.id,
+        ...(error !== undefined ? { error } : { result }),
+      });
+    } catch (sendError) {
+      if (error !== undefined) throw sendError;
+
+      this.sendMessage(event, {
+        type: "tool-result",
+        id: message.id,
+        error: "Tool result could not be sent across the frame boundary",
+      });
+    }
   }
 
   private cancelToolCall(id: string) {


### PR DESCRIPTION
## Problem

An AssistantFrame tool can complete with a valid JavaScript value that cannot be structured-cloned, such as a function. In the focused reproduction, posting that result threw DataCloneError, no tool result reached the host, and the host could wait until its request timeout.

## Root cause

The provider converted tool execution failures into tool-result errors, but the result postMessage call itself was outside that protection. Synchronous serialization failures therefore escaped the asynchronous message handler.

## Change

If posting a successful tool result fails, send a clone-safe tool-result error for the same call. The message handler also contains a failure from the fallback transport so it cannot become an unhandled rejection.

## Verification

- `cd packages/core && node_modules/.bin/vitest run src/model-context/frame/provider.test.ts`
- `cd packages/core && node_modules/.bin/aui-build`
- `node scripts/check-changesets.mjs`
- Confirmed the regression throws DataCloneError and sends no reply without the fix, then sends the structured fallback error with the fix.

## Public surface

`@assistant-ui/core` behavior only. No exports, documentation, templates, or API-reference output changed. Includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.eqxeZYseeyzAz4XqiCOrSa8M339jFdVSbEs1khdsUDqCm9G1KoSBCZwLwqY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->