### PR TITLE
fix(safe-content-frame): clear completed load timers

### DIFF
--- a/.changeset/calm-frames-rest.md
+++ b/.changeset/calm-frames-rest.md
@@ -1,0 +1,5 @@
+---
+"safe-content-frame": patch
+---
+
+fix: clear load timeout timers after SafeContentFrame settles

--- a/packages/safe-content-frame/src/index.test.ts
+++ b/packages/safe-content-frame/src/index.test.ts
@@ -271,11 +271,17 @@ describe("SafeContentFrame", () => {
     iframe.dispatchEvent(new Event("load"));
     const frame = await framePromise;
 
-    const fullyLoaded = frame.fullyLoadedPromiseWithTimeout(100);
-    MockMessageChannel.instances[0]!.port1.emit({ type: "msg" });
+    vi.useFakeTimers();
+    try {
+      const fullyLoaded = frame.fullyLoadedPromiseWithTimeout(100);
+      MockMessageChannel.instances[0]!.port1.emit({ type: "msg" });
 
-    await expect(fullyLoaded).resolves.toBeUndefined();
-    frame.dispose();
+      await expect(fullyLoaded).resolves.toBeUndefined();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+      frame.dispose();
+    }
   });
 
   it("keeps render completion compatible without a readiness message", async () => {

--- a/packages/safe-content-frame/src/index.ts
+++ b/packages/safe-content-frame/src/index.ts
@@ -270,24 +270,30 @@ export class SafeContentFrame {
           origin: iframeOrigin,
           sendMessage: (data, transfer) =>
             iframe.contentWindow?.postMessage(data, iframeOrigin, transfer),
-          fullyLoadedPromiseWithTimeout: (ms) =>
-            Promise.race([
-              loaded,
-              new Promise<void>((_, rej) =>
-                setTimeout(
-                  () =>
-                    rej(
-                      shimReady
-                        ? shimLoadError("render-timeout", "Timeout")
-                        : shimLoadError(
-                            "shim-unavailable",
-                            `Failed to load shim: ${shimUrl}`,
-                          ),
-                    ),
-                  ms,
-                ),
-              ),
-            ]),
+          fullyLoadedPromiseWithTimeout: async (ms) => {
+            let timeout: ReturnType<typeof setTimeout> | undefined;
+            try {
+              await Promise.race([
+                loaded,
+                new Promise<void>((_, reject) => {
+                  timeout = setTimeout(
+                    () =>
+                      reject(
+                        shimReady
+                          ? shimLoadError("render-timeout", "Timeout")
+                          : shimLoadError(
+                              "shim-unavailable",
+                              `Failed to load shim: ${shimUrl}`,
+                            ),
+                      ),
+                    ms,
+                  );
+                }),
+              ]);
+            } finally {
+              if (timeout !== undefined) clearTimeout(timeout);
+            }
+          },
           dispose: cleanup,
         });
       };


### PR DESCRIPTION
## Problem

A successful SafeContentFrame load leaves the timeout created by fullyLoadedPromiseWithTimeout scheduled until the full deadline. Repeated renders retain unnecessary timers and their closures after the frame has already settled.

## Root cause

Promise.race settled the returned promise but did not cancel the losing timeout branch.

## Change

Track the timeout handle and clear it in a finally block after the load promise either resolves or rejects. Timeout behavior and existing error codes remain unchanged.

## Verification

- `cd packages/safe-content-frame && node_modules/.bin/vitest run src/index.test.ts`
- `cd packages/safe-content-frame && node_modules/.bin/vitest run`
- `cd packages/safe-content-frame && node_modules/.bin/aui-build`
- `node scripts/check-changesets.mjs`
- Confirmed successful completion leaves one timer without the fix and zero timers with it.

## Public surface

`safe-content-frame` behavior only. No exports, documentation, templates, or API-reference output changed. Includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-YDLQL6KdiKHOdUNJU1zSBFkJ5MZBC1KwSC3K3F7hAP1r5DbLc2LbqY2j5Y?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->