### PR TITLE
perf(docs): cache design markdown via UI flavor

### DIFF
--- a/apps/docs/app/(home)/llms.mdx/design/[[...slug]]/route.test.ts
+++ b/apps/docs/app/(home)/llms.mdx/design/[[...slug]]/route.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import "@/test/mock-fumadocs-collections";
+
+const { getDesignMarkdown } = vi.hoisted(() => ({
+  getDesignMarkdown: vi.fn(async () => "# Base design"),
+}));
+
+vi.mock("@/lib/design-markdown", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/design-markdown")>()),
+  getDesignMarkdown,
+}));
+
+import { GET } from "./route";
+
+describe("GET", () => {
+  it("returns cache validators with Base UI design markdown", async () => {
+    const response = await GET(new Request("https://example.com/design.md"), {
+      params: Promise.resolve({}),
+    });
+
+    expect(await response.text()).toBe("# Base design");
+    expect(getDesignMarkdown).toHaveBeenCalledWith(undefined, "base");
+    expect(response.headers.get("Cache-Control")).toBe(
+      "no-cache, must-revalidate",
+    );
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(response.headers.get("ETag")).toMatch(
+      /^"sha256-[a-f0-9]{64}"$/,
+    );
+    expect(response.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+});

--- a/apps/docs/app/(home)/radix-llms.mdx/design/[[...slug]]/route.test.ts
+++ b/apps/docs/app/(home)/radix-llms.mdx/design/[[...slug]]/route.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import "@/test/mock-fumadocs-collections";
+
+const { getDesignMarkdown } = vi.hoisted(() => ({
+  getDesignMarkdown: vi.fn(async () => "# Radix design"),
+}));
+
+vi.mock("@/lib/design-markdown", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/design-markdown")>()),
+  getDesignMarkdown,
+}));
+
+import { GET } from "./route";
+
+describe("GET", () => {
+  it("returns cache validators with Radix design markdown", async () => {
+    const response = await GET(new Request("https://example.com/design.md"), {
+      params: Promise.resolve({}),
+    });
+
+    expect(await response.text()).toBe("# Radix design");
+    expect(getDesignMarkdown).toHaveBeenCalledWith(undefined, "radix");
+    expect(response.headers.get("Cache-Control")).toBe(
+      "no-cache, must-revalidate",
+    );
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(response.headers.get("ETag")).toMatch(
+      /^"sha256-[a-f0-9]{64}"$/,
+    );
+    expect(response.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+});

--- a/apps/docs/app/(home)/radix-llms.mdx/design/[[...slug]]/route.ts
+++ b/apps/docs/app/(home)/radix-llms.mdx/design/[[...slug]]/route.ts
@@ -11,7 +11,7 @@ export async function GET(
   { params }: { params: Promise<{ slug?: string[] }> },
 ) {
   const { slug } = await params;
-  return createMarkdownResponse(await getDesignMarkdown(slug, "base"));
+  return createMarkdownResponse(await getDesignMarkdown(slug, "radix"));
 }
 
 export function generateStaticParams() {

--- a/apps/docs/lib/design-markdown.ts
+++ b/apps/docs/lib/design-markdown.ts
@@ -1,0 +1,34 @@
+import { getLLMText, type LLMRenderContext } from "@/lib/get-llm-text";
+import { design } from "@/lib/source";
+import { notFound } from "next/navigation";
+
+export async function getDesignMarkdown(
+  slug: string[] | undefined,
+  flavor: LLMRenderContext["flavor"],
+) {
+  if (!slug || slug.length === 0) {
+    return [
+      "# Design",
+      "",
+      "The design system: actions, inputs, display, overlays, and navigation.",
+      "",
+      ...design.getPages().map((page) => {
+        const description = page.data.description
+          ? `: ${page.data.description}`
+          : "";
+        return `- [${page.data.title}](${page.url})${description}`;
+      }),
+    ].join("\n");
+  }
+
+  const page = design.getPage(slug);
+  if (!page) notFound();
+
+  return getLLMText(page, { flavor });
+}
+
+export function getDesignMarkdownStaticParams() {
+  return design.getPages().map((page) => ({
+    slug: page.slugs,
+  }));
+}

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -428,7 +428,17 @@ const config: NextConfig = {
       },
       {
         source: "/design/:path+.md",
+        has: [{ type: "query", key: "view", value: "radix-ui" }],
+        destination: "/radix-llms.mdx/design/:path*",
+      },
+      {
+        source: "/design/:path+.md",
         destination: "/llms.mdx/design/:path*",
+      },
+      {
+        source: "/design/:path+.mdx",
+        has: [{ type: "query", key: "view", value: "radix-ui" }],
+        destination: "/radix-llms.mdx/design/:path*",
       },
       {
         source: "/design/:path+.mdx",
@@ -489,6 +499,14 @@ const config: NextConfig = {
           { type: "header", key: "accept", value: "(?:.*text/markdown.*)" },
         ],
         destination: "/llms.mdx/examples/:path*",
+      },
+      {
+        source: "/design/:path*",
+        has: [
+          { type: "header", key: "accept", value: "(?:.*text/markdown.*)" },
+          { type: "query", key: "view", value: "radix-ui" },
+        ],
+        destination: "/radix-llms.mdx/design/:path*",
       },
       {
         source: "/design/:path*",


### PR DESCRIPTION
## Problem

Design Markdown varies between Base UI and Radix UI through `?view=radix-ui`. The route reads that query parameter at request time, so every request repeats the MDX-to-Markdown render.

This is the UI-flavor part of #6742 and follows #7127.

## Root cause

Both flavors share one `force-dynamic` route. Next.js cannot prerender or reuse either response while the flavor is resolved from the request inside the handler.

## Change

Route the Radix query variant to a dedicated internal static handler and keep the existing handler as the static Base UI variant. Both handlers share the same renderer, but each flavor now has its own deterministic cache target. Public `.md`, legacy `.mdx`, and `Accept: text/markdown` URLs stay unchanged.

## Verification

- `pnpm -C apps/docs build`
  - Both `/llms.mdx/design/[[...slug]]` and `/radix-llms.mdx/design/[[...slug]]` are emitted as SSG routes.
- Started the production build locally and requested `/design/components/button.md` in both flavors.
  - Both responses reported `x-nextjs-cache: HIT`.
  - Base output contained `@base-ui/react`; Radix output contained `radix-ui`.
- `pnpm lint`

## Public surface

None. Public URLs and Markdown content are preserved; only their internal cache targets change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ytbpBEm5NwSeMn9OG4hR_ff8DUzwzFIOMhW2JpPYuCoDp-Q21Qaqr3R04wk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->