### PR TITLE
perf(docs): cache markdown via selected platforms

### DIFF
--- a/apps/docs/app/(home)/llms.mdx/[[...slug]]/route.test.ts
+++ b/apps/docs/app/(home)/llms.mdx/[[...slug]]/route.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import "@/test/mock-fumadocs-collections";
+
+const { getDocsMarkdown } = vi.hoisted(() => ({
+  getDocsMarkdown: vi.fn(async () => "# React documentation"),
+}));
+
+vi.mock("@/lib/docs-markdown", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/docs-markdown")>()),
+  getDocsMarkdown,
+}));
+
+import { GET } from "./route";
+
+describe("GET", () => {
+  it("returns cache validators with default React markdown", async () => {
+    const response = await GET(new Request("https://example.com/docs.md"), {
+      params: Promise.resolve({}),
+    });
+
+    expect(await response.text()).toBe("# React documentation");
+    expect(getDocsMarkdown).toHaveBeenCalledWith(undefined, {
+      flavor: "base",
+      platform: "react",
+    });
+    expect(response.headers.get("Cache-Control")).toBe(
+      "no-cache, must-revalidate",
+    );
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(response.headers.get("ETag")).toMatch(
+      /^"sha256-[a-f0-9]{64}"$/,
+    );
+    expect(response.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+});

--- a/apps/docs/app/(home)/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/(home)/llms.mdx/[[...slug]]/route.ts
@@ -1,32 +1,14 @@
-import { type NextRequest, NextResponse } from "next/server";
-import { getLLMText } from "@/lib/get-llm-text";
-import { source } from "@/lib/source";
-import { notFound } from "next/navigation";
-import { resolveDocsPlatform } from "@/lib/docs-platform";
+import { getDocsMarkdown } from "@/lib/docs-markdown";
+import { createMarkdownResponse } from "@/lib/markdown-response";
 
-// The flavor and platform query parameters vary the response, so this route
-// renders per request instead of being prerendered.
-export const dynamic = "force-dynamic";
+export const dynamic = "force-static";
 
 export async function GET(
-  req: NextRequest,
+  _req: Request,
   { params }: { params: Promise<{ slug?: string[] }> },
 ) {
   const { slug } = await params;
-  const page = source.getPage(slug);
-  if (!page) notFound();
-
-  const flavor =
-    req.nextUrl.searchParams.get("view") === "radix-ui" ? "radix" : "base";
-  const platform = resolveDocsPlatform(
-    req.nextUrl.searchParams.get("platform"),
+  return createMarkdownResponse(
+    await getDocsMarkdown(slug, { flavor: "base", platform: "react" }),
   );
-
-  return new NextResponse(await getLLMText(page, { flavor, platform }), {
-    headers: {
-      "Cache-Control": "no-cache, must-revalidate",
-      "Content-Type": "text/markdown; charset=utf-8",
-      "X-Robots-Tag": "noindex, follow",
-    },
-  });
 }

--- a/apps/docs/app/(home)/platform-llms.mdx/[platform]/[flavor]/[[...slug]]/route.test.ts
+++ b/apps/docs/app/(home)/platform-llms.mdx/[platform]/[flavor]/[[...slug]]/route.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/test/mock-fumadocs-collections";
+import { PLATFORMS } from "@/lib/constants";
 
 const { getDocsMarkdown } = vi.hoisted(() => ({
   getDocsMarkdown: vi.fn(async () => "# React Native documentation"),
@@ -12,29 +13,50 @@ vi.mock("@/lib/docs-markdown", async (importOriginal) => ({
 
 import { GET } from "./route";
 
-describe("GET", () => {
-  it("returns cache validators with platform markdown", async () => {
-    const response = await GET(new Request("https://example.com/docs.md"), {
-      params: Promise.resolve({
-        platform: "rn",
-        flavor: "base",
-      }),
-    });
+const variants = PLATFORMS.flatMap((platform) =>
+  (["base", "radix"] as const).map((flavor) => [platform, flavor] as const),
+);
 
-    expect(await response.text()).toBe("# React Native documentation");
-    expect(getDocsMarkdown).toHaveBeenCalledWith(undefined, {
-      flavor: "base",
-      platform: "rn",
-    });
-    expect(response.headers.get("Cache-Control")).toBe(
-      "no-cache, must-revalidate",
-    );
-    expect(response.headers.get("Content-Type")).toBe(
-      "text/markdown; charset=utf-8",
-    );
-    expect(response.headers.get("ETag")).toMatch(
-      /^"sha256-[a-f0-9]{64}"$/,
-    );
-    expect(response.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+beforeEach(() => {
+  getDocsMarkdown.mockClear();
+});
+
+describe("GET", () => {
+  it.each(variants)(
+    "returns cache validators for %s and %s",
+    async (platform, flavor) => {
+      const response = await GET(new Request("https://example.com/docs.md"), {
+        params: Promise.resolve({
+          platform,
+          flavor,
+        }),
+      });
+
+      expect(await response.text()).toBe("# React Native documentation");
+      expect(getDocsMarkdown).toHaveBeenCalledWith(undefined, {
+        flavor,
+        platform,
+      });
+      expect(response.headers.get("Cache-Control")).toBe(
+        "no-cache, must-revalidate",
+      );
+      expect(response.headers.get("Content-Type")).toBe(
+        "text/markdown; charset=utf-8",
+      );
+      expect(response.headers.get("ETag")).toMatch(/^"sha256-[a-f0-9]{64}"$/);
+      expect(response.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+    },
+  );
+
+  it.each([
+    ["unknown", "base"],
+    ["react", "unknown"],
+  ])("rejects invalid platform or flavor %s/%s", async (platform, flavor) => {
+    await expect(
+      GET(new Request("https://example.com/docs.md"), {
+        params: Promise.resolve({ platform, flavor }),
+      }),
+    ).rejects.toMatchObject({ digest: "NEXT_HTTP_ERROR_FALLBACK;404" });
+    expect(getDocsMarkdown).not.toHaveBeenCalled();
   });
 });

--- a/apps/docs/app/(home)/platform-llms.mdx/[platform]/[flavor]/[[...slug]]/route.test.ts
+++ b/apps/docs/app/(home)/platform-llms.mdx/[platform]/[flavor]/[[...slug]]/route.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import "@/test/mock-fumadocs-collections";
+
+const { getDocsMarkdown } = vi.hoisted(() => ({
+  getDocsMarkdown: vi.fn(async () => "# React Native documentation"),
+}));
+
+vi.mock("@/lib/docs-markdown", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/docs-markdown")>()),
+  getDocsMarkdown,
+}));
+
+import { GET } from "./route";
+
+describe("GET", () => {
+  it("returns cache validators with platform markdown", async () => {
+    const response = await GET(new Request("https://example.com/docs.md"), {
+      params: Promise.resolve({
+        platform: "rn",
+        flavor: "base",
+      }),
+    });
+
+    expect(await response.text()).toBe("# React Native documentation");
+    expect(getDocsMarkdown).toHaveBeenCalledWith(undefined, {
+      flavor: "base",
+      platform: "rn",
+    });
+    expect(response.headers.get("Cache-Control")).toBe(
+      "no-cache, must-revalidate",
+    );
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(response.headers.get("ETag")).toMatch(
+      /^"sha256-[a-f0-9]{64}"$/,
+    );
+    expect(response.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+});

--- a/apps/docs/app/(home)/platform-llms.mdx/[platform]/[flavor]/[[...slug]]/route.ts
+++ b/apps/docs/app/(home)/platform-llms.mdx/[platform]/[flavor]/[[...slug]]/route.ts
@@ -1,0 +1,34 @@
+import { notFound } from "next/navigation";
+import { isPlatform } from "@/lib/docs-platform";
+import { getDocsMarkdown } from "@/lib/docs-markdown";
+import { createMarkdownResponse } from "@/lib/markdown-response";
+
+export const dynamic = "force-static";
+
+export async function GET(
+  _req: Request,
+  {
+    params,
+  }: {
+    params: Promise<{
+      platform: string;
+      flavor: string;
+      slug?: string[];
+    }>;
+  },
+) {
+  const { platform, flavor, slug } = await params;
+  if (
+    !isPlatform(platform) ||
+    (flavor !== "base" && flavor !== "radix")
+  ) {
+    notFound();
+  }
+
+  return createMarkdownResponse(
+    await getDocsMarkdown(slug, {
+      platform,
+      flavor,
+    }),
+  );
+}

--- a/apps/docs/lib/docs-markdown.ts
+++ b/apps/docs/lib/docs-markdown.ts
@@ -1,0 +1,13 @@
+import { getLLMText, type LLMRenderContext } from "@/lib/get-llm-text";
+import { source } from "@/lib/source";
+import { notFound } from "next/navigation";
+
+export async function getDocsMarkdown(
+  slug: string[] | undefined,
+  options: LLMRenderContext,
+) {
+  const page = source.getPage(slug);
+  if (!page) notFound();
+
+  return getLLMText(page, options);
+}

--- a/apps/docs/lib/markdown-rewrites.test.ts
+++ b/apps/docs/lib/markdown-rewrites.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { PLATFORMS } from "./constants";
 import {
   docsMarkdownAcceptRewrites,
   docsMarkdownFileRewrites,
@@ -18,7 +19,9 @@ type Rewrite = {
 };
 
 const resolveVariant = (query: Record<string, string | undefined>) => {
-  const rewrites = docsMarkdownVariantRewrites("/docs.md", "") as Rewrite[];
+  const rewrites = docsMarkdownFileRewrites().filter(
+    (rewrite) => rewrite.source === "/docs.md",
+  ) as Rewrite[];
   const matches = (condition: RewriteCondition) => {
     const value = query[condition.key];
     return (
@@ -35,11 +38,13 @@ const resolveVariant = (query: Record<string, string | undefined>) => {
       ),
   );
 
-  return (
-    rewrite?.destination.replace(":docsPlatform", query.platform ?? "") ??
-    "/llms.mdx"
-  );
+  return rewrite?.destination.replace(":docsPlatform", query.platform ?? "");
 };
+
+const variantCases = PLATFORMS.flatMap((platform) => [
+  [platform, undefined, `/platform-llms.mdx/${platform}/base`] as const,
+  [platform, "radix-ui", `/platform-llms.mdx/${platform}/radix`] as const,
+]);
 
 describe("docsMarkdownVariantRewrites", () => {
   it("maps platform and flavor to stable internal paths", () => {
@@ -54,10 +59,11 @@ describe("docsMarkdownVariantRewrites", () => {
       {
         type: "query",
         key: "platform",
-        value: "(?<docsPlatform>react|rn|ink)",
+        value: `(?<docsPlatform>${PLATFORMS.join("|")})`,
       },
       { type: "query", key: "view", value: "radix-ui" },
     ]);
+    expect(rewrites[1]?.missing).toEqual([{ type: "query", key: "view" }]);
     expect(rewrites[2]?.missing).toEqual([{ type: "query", key: "platform" }]);
   });
 
@@ -77,22 +83,21 @@ describe("docsMarkdownVariantRewrites", () => {
     }
   });
 
-  it.each([
-    ["react", undefined, "/platform-llms.mdx/react/base"],
-    ["react", "radix-ui", "/platform-llms.mdx/react/radix"],
-    ["rn", undefined, "/platform-llms.mdx/rn/base"],
-    ["rn", "radix-ui", "/platform-llms.mdx/rn/radix"],
-    ["ink", undefined, "/platform-llms.mdx/ink/base"],
-    ["ink", "radix-ui", "/platform-llms.mdx/ink/radix"],
-  ])("maps platform %s and view %s", (platform, view, expected) => {
-    expect(resolveVariant({ noise: "1", platform, view })).toBe(expected);
-  });
+  it.each(variantCases)(
+    "maps platform %s and view %s",
+    (platform, view, expected) => {
+      expect(resolveVariant({ noise: "1", platform, view })).toBe(expected);
+    },
+  );
 
   it("uses the default only for invalid selections", () => {
     expect(resolveVariant({ platform: "unknown", view: "radix-ui" })).toBe(
       "/llms.mdx",
     );
     expect(resolveVariant({ platform: "unknown" })).toBe("/llms.mdx");
+    expect(resolveVariant({ platform: "rn", view: "compact" })).toBe(
+      "/llms.mdx",
+    );
     expect(resolveVariant({ view: "radix-ui" })).toBe(
       "/platform-llms.mdx/react/radix",
     );

--- a/apps/docs/lib/markdown-rewrites.test.ts
+++ b/apps/docs/lib/markdown-rewrites.test.ts
@@ -63,7 +63,6 @@ describe("docsMarkdownVariantRewrites", () => {
       },
       { type: "query", key: "view", value: "radix-ui" },
     ]);
-    expect(rewrites[1]?.missing).toEqual([{ type: "query", key: "view" }]);
     expect(rewrites[2]?.missing).toEqual([{ type: "query", key: "platform" }]);
   });
 
@@ -90,13 +89,16 @@ describe("docsMarkdownVariantRewrites", () => {
     },
   );
 
-  it("uses the default only for invalid selections", () => {
+  it("falls back without losing a supported platform", () => {
     expect(resolveVariant({ platform: "unknown", view: "radix-ui" })).toBe(
       "/llms.mdx",
     );
     expect(resolveVariant({ platform: "unknown" })).toBe("/llms.mdx");
+    expect(resolveVariant({ platform: "rn", view: "base-ui" })).toBe(
+      "/platform-llms.mdx/rn/base",
+    );
     expect(resolveVariant({ platform: "rn", view: "compact" })).toBe(
-      "/llms.mdx",
+      "/platform-llms.mdx/rn/base",
     );
     expect(resolveVariant({ view: "radix-ui" })).toBe(
       "/platform-llms.mdx/react/radix",

--- a/apps/docs/lib/markdown-rewrites.test.ts
+++ b/apps/docs/lib/markdown-rewrites.test.ts
@@ -63,7 +63,6 @@ describe("docsMarkdownVariantRewrites", () => {
       },
       { type: "query", key: "view", value: "radix-ui" },
     ]);
-    expect(rewrites[2]?.missing).toEqual([{ type: "query", key: "platform" }]);
   });
 
   it("keeps content negotiation on every variant rewrite", () => {
@@ -91,7 +90,7 @@ describe("docsMarkdownVariantRewrites", () => {
 
   it("falls back without losing a supported platform", () => {
     expect(resolveVariant({ platform: "unknown", view: "radix-ui" })).toBe(
-      "/llms.mdx",
+      "/platform-llms.mdx/react/radix",
     );
     expect(resolveVariant({ platform: "unknown" })).toBe("/llms.mdx");
     expect(resolveVariant({ platform: "rn", view: "base-ui" })).toBe(

--- a/apps/docs/lib/markdown-rewrites.test.ts
+++ b/apps/docs/lib/markdown-rewrites.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  docsMarkdownAcceptRewrites,
+  docsMarkdownFileRewrites,
+  docsMarkdownVariantRewrites,
+} from "./markdown-rewrites";
+
+type RewriteCondition = {
+  type: "header" | "query";
+  key: string;
+  value?: string;
+};
+
+type Rewrite = {
+  destination: string;
+  has?: RewriteCondition[];
+  missing?: RewriteCondition[];
+};
+
+const resolveVariant = (query: Record<string, string | undefined>) => {
+  const rewrites = docsMarkdownVariantRewrites("/docs.md", "") as Rewrite[];
+  const matches = (condition: RewriteCondition) => {
+    const value = query[condition.key];
+    return (
+      value !== undefined &&
+      new RegExp(`^(?:${condition.value ?? ".*"})$`).test(value)
+    );
+  };
+
+  const rewrite = rewrites.find(
+    (candidate) =>
+      (candidate.has ?? []).every(matches) &&
+      (candidate.missing ?? []).every(
+        (condition) => query[condition.key] === undefined,
+      ),
+  );
+
+  return (
+    rewrite?.destination.replace(":docsPlatform", query.platform ?? "") ??
+    "/llms.mdx"
+  );
+};
+
+describe("docsMarkdownVariantRewrites", () => {
+  it("maps platform and flavor to stable internal paths", () => {
+    const rewrites = docsMarkdownVariantRewrites("/docs/:path*.md", "/:path*");
+
+    expect(rewrites.map((rewrite) => rewrite.destination)).toEqual([
+      "/platform-llms.mdx/:docsPlatform/radix/:path*",
+      "/platform-llms.mdx/:docsPlatform/base/:path*",
+      "/platform-llms.mdx/react/radix/:path*",
+    ]);
+    expect(rewrites[0]?.has).toEqual([
+      {
+        type: "query",
+        key: "platform",
+        value: "(?<docsPlatform>react|rn|ink)",
+      },
+      { type: "query", key: "view", value: "radix-ui" },
+    ]);
+    expect(rewrites[2]?.missing).toEqual([{ type: "query", key: "platform" }]);
+  });
+
+  it("keeps content negotiation on every variant rewrite", () => {
+    const rewrites = docsMarkdownVariantRewrites(
+      "/docs/:path*",
+      "/:path*",
+      true,
+    );
+
+    for (const rewrite of rewrites) {
+      expect(rewrite.has[0]).toEqual({
+        type: "header",
+        key: "accept",
+        value: "(?:.*text/markdown.*)",
+      });
+    }
+  });
+
+  it.each([
+    ["react", undefined, "/platform-llms.mdx/react/base"],
+    ["react", "radix-ui", "/platform-llms.mdx/react/radix"],
+    ["rn", undefined, "/platform-llms.mdx/rn/base"],
+    ["rn", "radix-ui", "/platform-llms.mdx/rn/radix"],
+    ["ink", undefined, "/platform-llms.mdx/ink/base"],
+    ["ink", "radix-ui", "/platform-llms.mdx/ink/radix"],
+  ])("maps platform %s and view %s", (platform, view, expected) => {
+    expect(resolveVariant({ noise: "1", platform, view })).toBe(expected);
+  });
+
+  it("uses the default only for invalid selections", () => {
+    expect(resolveVariant({ platform: "unknown", view: "radix-ui" })).toBe(
+      "/llms.mdx",
+    );
+    expect(resolveVariant({ platform: "unknown" })).toBe("/llms.mdx");
+    expect(resolveVariant({ view: "radix-ui" })).toBe(
+      "/platform-llms.mdx/react/radix",
+    );
+  });
+
+  it("registers every file and content-negotiated entry point", () => {
+    const fileRewrites = docsMarkdownFileRewrites();
+    const sources = [
+      "/docs.md",
+      "/docs.mdx",
+      "/docs/:path*.md",
+      "/docs/:path*.mdx",
+    ];
+
+    for (const source of sources) {
+      expect(
+        fileRewrites.filter((rewrite) => rewrite.source === source),
+      ).toHaveLength(4);
+    }
+
+    const acceptRewrites = docsMarkdownAcceptRewrites();
+    expect(acceptRewrites).toHaveLength(4);
+    expect(
+      acceptRewrites.every((rewrite) => rewrite.source === "/docs/:path*"),
+    ).toBe(true);
+    expect(
+      acceptRewrites.every((rewrite) => rewrite.has[0]?.key === "accept"),
+    ).toBe(true);
+  });
+});

--- a/apps/docs/lib/markdown-rewrites.ts
+++ b/apps/docs/lib/markdown-rewrites.ts
@@ -1,3 +1,7 @@
+import { PLATFORMS } from "./constants";
+
+const docsPlatformPattern = `(?<docsPlatform>${PLATFORMS.join("|")})`;
+
 export const docsMarkdownVariantRewrites = (
   source: string,
   destinationSuffix: string,
@@ -21,7 +25,7 @@ export const docsMarkdownVariantRewrites = (
         {
           type: "query" as const,
           key: "platform",
-          value: "(?<docsPlatform>react|rn|ink)",
+          value: docsPlatformPattern,
         },
         { type: "query" as const, key: "view", value: "radix-ui" },
       ],
@@ -34,9 +38,10 @@ export const docsMarkdownVariantRewrites = (
         {
           type: "query" as const,
           key: "platform",
-          value: "(?<docsPlatform>react|rn|ink)",
+          value: docsPlatformPattern,
         },
       ],
+      missing: [{ type: "query" as const, key: "view" }],
       destination: `/platform-llms.mdx/:docsPlatform/base${destinationSuffix}`,
     },
     {

--- a/apps/docs/lib/markdown-rewrites.ts
+++ b/apps/docs/lib/markdown-rewrites.ts
@@ -49,7 +49,6 @@ export const docsMarkdownVariantRewrites = (
         ...required,
         { type: "query" as const, key: "view", value: "radix-ui" },
       ],
-      missing: [{ type: "query" as const, key: "platform" }],
       destination: `/platform-llms.mdx/react/radix${destinationSuffix}`,
     },
   ];

--- a/apps/docs/lib/markdown-rewrites.ts
+++ b/apps/docs/lib/markdown-rewrites.ts
@@ -1,0 +1,84 @@
+export const docsMarkdownVariantRewrites = (
+  source: string,
+  destinationSuffix: string,
+  requireMarkdownAccept = false,
+) => {
+  const required = requireMarkdownAccept
+    ? [
+        {
+          type: "header" as const,
+          key: "accept",
+          value: "(?:.*text/markdown.*)",
+        },
+      ]
+    : [];
+
+  return [
+    {
+      source,
+      has: [
+        ...required,
+        {
+          type: "query" as const,
+          key: "platform",
+          value: "(?<docsPlatform>react|rn|ink)",
+        },
+        { type: "query" as const, key: "view", value: "radix-ui" },
+      ],
+      destination: `/platform-llms.mdx/:docsPlatform/radix${destinationSuffix}`,
+    },
+    {
+      source,
+      has: [
+        ...required,
+        {
+          type: "query" as const,
+          key: "platform",
+          value: "(?<docsPlatform>react|rn|ink)",
+        },
+      ],
+      destination: `/platform-llms.mdx/:docsPlatform/base${destinationSuffix}`,
+    },
+    {
+      source,
+      has: [
+        ...required,
+        { type: "query" as const, key: "view", value: "radix-ui" },
+      ],
+      missing: [{ type: "query" as const, key: "platform" }],
+      destination: `/platform-llms.mdx/react/radix${destinationSuffix}`,
+    },
+  ];
+};
+
+export const docsMarkdownFileRewrites = () => {
+  const entries = [
+    ["/docs.md", ""],
+    ["/docs.mdx", ""],
+    ["/docs/:path*.md", "/:path*"],
+    ["/docs/:path*.mdx", "/:path*"],
+  ] as const;
+
+  return entries.flatMap(([source, destinationSuffix]) => [
+    ...docsMarkdownVariantRewrites(source, destinationSuffix),
+    {
+      source,
+      destination: `/llms.mdx${destinationSuffix}`,
+    },
+  ]);
+};
+
+export const docsMarkdownAcceptRewrites = () => [
+  ...docsMarkdownVariantRewrites("/docs/:path*", "/:path*", true),
+  {
+    source: "/docs/:path*",
+    has: [
+      {
+        type: "header" as const,
+        key: "accept",
+        value: "(?:.*text/markdown.*)",
+      },
+    ],
+    destination: "/llms.mdx/:path*",
+  },
+];

--- a/apps/docs/lib/markdown-rewrites.ts
+++ b/apps/docs/lib/markdown-rewrites.ts
@@ -41,7 +41,6 @@ export const docsMarkdownVariantRewrites = (
           value: docsPlatformPattern,
         },
       ],
-      missing: [{ type: "query" as const, key: "view" }],
       destination: `/platform-llms.mdx/:docsPlatform/base${destinationSuffix}`,
     },
     {

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -6,6 +6,10 @@ import {
   API_CATALOG_LINK_HEADER,
 } from "./lib/agent-discovery-routes";
 import { isWebMcpEnabled } from "./lib/feature-flags";
+import {
+  docsMarkdownAcceptRewrites,
+  docsMarkdownFileRewrites,
+} from "./lib/markdown-rewrites";
 
 const isDev = process.env.NODE_ENV === "development";
 
@@ -394,22 +398,7 @@ const config: NextConfig = {
         source: "/docs/.well-known/mcp",
         destination: "/api/mcp",
       },
-      {
-        source: "/docs.md",
-        destination: "/llms.mdx",
-      },
-      {
-        source: "/docs.mdx",
-        destination: "/llms.mdx",
-      },
-      {
-        source: "/docs/:path*.md",
-        destination: "/llms.mdx/:path*",
-      },
-      {
-        source: "/docs/:path*.mdx",
-        destination: "/llms.mdx/:path*",
-      },
+      ...docsMarkdownFileRewrites(),
       {
         source: "/examples.md",
         destination: "/llms.mdx/examples",
@@ -486,13 +475,7 @@ const config: NextConfig = {
         source: "/pricing.mdx",
         destination: "/pricing.md",
       },
-      {
-        source: "/docs/:path*",
-        has: [
-          { type: "header", key: "accept", value: "(?:.*text/markdown.*)" },
-        ],
-        destination: "/llms.mdx/:path*",
-      },
+      ...docsMarkdownAcceptRewrites(),
       {
         source: "/examples/:path*",
         has: [


### PR DESCRIPTION
## Problem

The main docs Markdown now follows the selected React, React Native, or React Ink platform as well as the Base UI or Radix UI flavor. Reading both query parameters inside one `force-dynamic` handler causes every request to rebuild the MDX, including repeated requests for the same page and selection.

This is the platform-aware part of #6742 and follows #7128.

## Root cause

The six possible `platform + flavor` combinations had no stable route identity for Next.js to cache. The request-time handler also allowed irrelevant query parameters to keep reaching the expensive renderer.

## Change

Map the supported query combinations to one internal static route keyed by platform, flavor, and page slug. Keep the existing internal route as the static React + Base default. Unsupported platform values fall back to React, while non-Radix view values use Base and preserve a supported platform. Unrelated query parameters reuse the normalized static target.

The public `.md`, legacy `.mdx`, and `Accept: text/markdown` entry points remain unchanged.

The platform route fills its cache on demand instead of using `generateStaticParams`, because eagerly prerendering every page would multiply the docs render set by all six platform and flavor combinations. `dynamic = "force-static"` also makes the handler independent of request query data, so unrelated query parameters reuse the same route cache entry. The smaller design routes can use build-time generation without that sixfold cost.

## Verification

- `apps/docs/node_modules/.bin/vitest run apps/docs/lib/markdown-rewrites.test.ts apps/docs/lib/markdown-response.test.ts`
- `pnpm lint`
- `pnpm -C apps/docs exec next build`
  - `/llms.mdx/[[...slug]]` and `/platform-llms.mdx/[platform]/[flavor]/[[...slug]]` are emitted as static routes.
- Started the production build locally and exercised all six React/React Native/React Ink and Base/Radix combinations.
  - First request: `x-nextjs-cache: MISS`
  - Repeated request: `x-nextjs-cache: HIT`
  - React, React Native, and React Ink returned distinct platform output.
  - Random ignored query parameters still hit the normalized cached route.
- Confirmed `.md`, `.mdx`, and `Accept: text/markdown` requests return Markdown with the cache policy.

## Public surface

None. Route URLs and the platform-aware Markdown behavior are preserved.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.lQeVBi_Agie9gkoGvEQEGGRe7_evt5Lox7ooggjL-CVELvdzsfi9DtmHqjg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

