### PR TITLE
fix(react-generative-ui): handle prototype-named component types

### DIFF
--- a/.changeset/calm-maps-render.md
+++ b/.changeset/calm-maps-render.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: treat inherited library properties as unknown component names

--- a/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
+++ b/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
@@ -114,6 +114,32 @@ describe("renderGenerativeUI", () => {
     expect(html).toBe("");
   });
 
+  it.each(["toString", "constructor"])(
+    "treats inherited %s as an unknown component",
+    (type) => {
+      const html = renderToStaticMarkup(
+        <>{renderGenerativeUI({ $type: type }, library)}</>,
+      );
+      expect(html).toBe("");
+    },
+  );
+
+  it("renders an explicitly registered prototype-named component", () => {
+    const prototypeNamedLibrary: GenerativeUILibrary = {
+      ...library,
+      toString: {
+        description: "An explicitly registered component.",
+        properties: z.object({}),
+        render: () => <span>registered</span>,
+      },
+    };
+
+    const html = renderToStaticMarkup(
+      <>{renderGenerativeUI({ $type: "toString" }, prototypeNamedLibrary)}</>,
+    );
+    expect(html).toBe("<span>registered</span>");
+  });
+
   it("holds back a node whose `$type` is still streaming", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     try {

--- a/packages/react-generative-ui/src/renderGenerativeUI.tsx
+++ b/packages/react-generative-ui/src/renderGenerativeUI.tsx
@@ -61,7 +61,9 @@ function renderElement(
   library: GenerativeUILibrary,
   context: GenerativeUIRenderContext,
 ): ReactNode {
-  const entry = library[element.type];
+  const entry = Object.hasOwn(library, element.type)
+    ? library[element.type]
+    : undefined;
   if (!entry) {
     reportUnknownComponent(element.type, Object.keys(library));
     return null;


### PR DESCRIPTION
## Problem

A model-emitted component type such as `toString` or `constructor` resolves through `Object.prototype` when it is not registered in the Generative UI library. The renderer then treats that inherited function as a component entry and crashes with `TypeError: render is not a function` instead of ignoring the unknown component.

## Root cause

`renderGenerativeUI()` indexed the library directly without checking whether the component name was an own property.

## Change

Require an own library property before rendering an entry. Explicitly registered prototype-named components remain supported.

## Verification

- Confirmed `{ $type: "toString" }` crashes before the fix and renders nothing after it.
- Added coverage for inherited `toString` and `constructor` names.
- Added coverage proving an explicitly registered `toString` component still renders.
- `pnpm --filter @assistant-ui/react-generative-ui test` (637 tests)
- `pnpm --filter @assistant-ui/react-generative-ui build`
- `pnpm changesets:check`
- `pnpm lint`

## Public surface

`@assistant-ui/react-generative-ui` receives a patch changeset. No exports or API types change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5ArdYnzhyts3G8haLc_8HvWxJ-efutH_rWyuAhUSp4TlIL0eZbPin79gkmc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->