### PR TITLE
fix(react-generative-ui): tolerate malformed collection props

### DIFF
--- a/.changeset/calm-tables-render.md
+++ b/.changeset/calm-tables-render.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: tolerate malformed Select and Table collection props

--- a/.changeset/calm-tables-render.md
+++ b/.changeset/calm-tables-render.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-generative-ui": patch
 ---
 
-fix: tolerate malformed Select and Table collection props
+fix: tolerate malformed Select and Table collection props while ignoring invalid entries

--- a/packages/react-generative-ui/src/vocabulary/data.test.tsx
+++ b/packages/react-generative-ui/src/vocabulary/data.test.tsx
@@ -37,10 +37,14 @@ describe("dataVocabulary", () => {
       render({
         $type: "Table",
         columns: "not-an-array",
-        rows: [["kept"], null],
+        rows: [["kept", null, {}, false], null],
       }),
     ).toBe(
-      '<table data-aui="table"><tbody><tr><td>kept</td></tr></tbody></table>',
+      '<table data-aui="table"><tbody><tr><td>kept</td><td>false</td></tr></tbody></table>',
+    );
+
+    expect(render({ $type: "Table", columns: [null], rows: [null] })).toBe(
+      '<table data-aui="table"></table>',
     );
 
     expect(

--- a/packages/react-generative-ui/src/vocabulary/data.test.tsx
+++ b/packages/react-generative-ui/src/vocabulary/data.test.tsx
@@ -32,6 +32,28 @@ describe("dataVocabulary", () => {
     expect(html).toContain("<td>only</td>");
   });
 
+  it("Table ignores malformed collections instead of throwing", () => {
+    expect(
+      render({
+        $type: "Table",
+        columns: "not-an-array",
+        rows: [["kept"], null],
+      }),
+    ).toBe(
+      '<table data-aui="table"><tbody><tr><td>kept</td></tr></tbody></table>',
+    );
+
+    expect(
+      render({
+        $type: "Table",
+        columns: [null, { label: "Name" }],
+        rows: "not-an-array",
+      }),
+    ).toBe(
+      '<table data-aui="table"><thead><tr><th data-aui="table-col">Name</th></tr></thead></table>',
+    );
+  });
+
   it("Markdown renders the value in a div", () => {
     expect(render({ $type: "Markdown", value: "# hi" })).toBe(
       '<div data-aui="markdown"># hi</div>',

--- a/packages/react-generative-ui/src/vocabulary/data.test.tsx
+++ b/packages/react-generative-ui/src/vocabulary/data.test.tsx
@@ -40,7 +40,7 @@ describe("dataVocabulary", () => {
         rows: [["kept", null, {}, false], null],
       }),
     ).toBe(
-      '<table data-aui="table"><tbody><tr><td>kept</td><td>false</td></tr></tbody></table>',
+      '<table data-aui="table"><tbody><tr><td>kept</td><td></td><td></td><td>false</td></tr></tbody></table>',
     );
 
     expect(render({ $type: "Table", columns: [null], rows: [null] })).toBe(
@@ -54,7 +54,7 @@ describe("dataVocabulary", () => {
         rows: "not-an-array",
       }),
     ).toBe(
-      '<table data-aui="table"><thead><tr><th data-aui="table-col">Name</th></tr></thead></table>',
+      '<table data-aui="table"><thead><tr><th data-aui="table-col"></th><th data-aui="table-col">Name</th></tr></thead></table>',
     );
   });
 

--- a/packages/react-generative-ui/src/vocabulary/data.tsx
+++ b/packages/react-generative-ui/src/vocabulary/data.tsx
@@ -284,26 +284,30 @@ export const dataVocabulary = {
     }),
     render: ({ columns, rows, children }) => (
       <table data-aui="table">
-        {columns?.length ? (
+        {Array.isArray(columns) && columns.length ? (
           <thead>
             <tr>
-              {columns.map((c: { label: string }, i: number) => (
-                <th key={i} data-aui="table-col">
-                  {c.label}
-                </th>
-              ))}
+              {columns.map((column, i) =>
+                column && typeof column.label === "string" ? (
+                  <th key={i} data-aui="table-col">
+                    {column.label}
+                  </th>
+                ) : null,
+              )}
             </tr>
           </thead>
         ) : null}
-        {rows?.length ? (
+        {Array.isArray(rows) && rows.length ? (
           <tbody>
-            {rows.map((row: (string | number | boolean)[], r: number) => (
-              <tr key={r}>
-                {row.map((cell: string | number | boolean, c: number) => (
-                  <td key={c}>{String(cell)}</td>
-                ))}
-              </tr>
-            ))}
+            {rows.map((row, r) =>
+              Array.isArray(row) ? (
+                <tr key={r}>
+                  {row.map((cell, c) => (
+                    <td key={c}>{String(cell)}</td>
+                  ))}
+                </tr>
+              ) : null,
+            )}
           </tbody>
         ) : null}
         {children}

--- a/packages/react-generative-ui/src/vocabulary/data.tsx
+++ b/packages/react-generative-ui/src/vocabulary/data.tsx
@@ -297,19 +297,18 @@ export const dataVocabulary = {
       rows: z.array(z.array(cellSchema)).optional().describe("Rows of cells."),
     }),
     render: ({ columns, rows, children }) => {
-      const safeColumns = Array.isArray(columns)
-        ? columns.filter(isTableColumn)
-        : [];
+      const safeColumns = Array.isArray(columns) ? columns : [];
+      const hasColumns = safeColumns.some(isTableColumn);
       const safeRows = Array.isArray(rows) ? rows.filter(Array.isArray) : [];
 
       return (
         <table data-aui="table">
-          {safeColumns.length ? (
+          {hasColumns ? (
             <thead>
               <tr>
                 {safeColumns.map((column, i) => (
                   <th key={i} data-aui="table-col">
-                    {column.label}
+                    {isTableColumn(column) ? column.label : ""}
                   </th>
                 ))}
               </tr>
@@ -319,9 +318,9 @@ export const dataVocabulary = {
             <tbody>
               {safeRows.map((row, r) => (
                 <tr key={r}>
-                  {row.map((cell, c) =>
-                    isTableCell(cell) ? <td key={c}>{String(cell)}</td> : null,
-                  )}
+                  {row.map((cell, c) => (
+                    <td key={c}>{isTableCell(cell) ? String(cell) : ""}</td>
+                  ))}
                 </tr>
               ))}
             </tbody>

--- a/packages/react-generative-ui/src/vocabulary/data.tsx
+++ b/packages/react-generative-ui/src/vocabulary/data.tsx
@@ -9,6 +9,20 @@ const cellSchema = z
   .union([z.string(), z.number(), z.boolean()])
   .describe("A cell value.");
 
+type TableColumn = { label: string };
+type TableCell = string | number | boolean;
+
+const isTableColumn = (column: unknown): column is TableColumn =>
+  column !== null &&
+  typeof column === "object" &&
+  "label" in column &&
+  typeof column.label === "string";
+
+const isTableCell = (cell: unknown): cell is TableCell =>
+  typeof cell === "string" ||
+  typeof cell === "number" ||
+  typeof cell === "boolean";
+
 const CHART_HEIGHT = 40;
 const CHART_WIDTH = 100;
 
@@ -282,37 +296,40 @@ export const dataVocabulary = {
       columns: z.array(columnSchema).optional().describe("Column definitions."),
       rows: z.array(z.array(cellSchema)).optional().describe("Rows of cells."),
     }),
-    render: ({ columns, rows, children }) => (
-      <table data-aui="table">
-        {Array.isArray(columns) && columns.length ? (
-          <thead>
-            <tr>
-              {columns.map((column, i) =>
-                column && typeof column.label === "string" ? (
+    render: ({ columns, rows, children }) => {
+      const safeColumns = Array.isArray(columns)
+        ? columns.filter(isTableColumn)
+        : [];
+      const safeRows = Array.isArray(rows) ? rows.filter(Array.isArray) : [];
+
+      return (
+        <table data-aui="table">
+          {safeColumns.length ? (
+            <thead>
+              <tr>
+                {safeColumns.map((column, i) => (
                   <th key={i} data-aui="table-col">
                     {column.label}
                   </th>
-                ) : null,
-              )}
-            </tr>
-          </thead>
-        ) : null}
-        {Array.isArray(rows) && rows.length ? (
-          <tbody>
-            {rows.map((row, r) =>
-              Array.isArray(row) ? (
+                ))}
+              </tr>
+            </thead>
+          ) : null}
+          {safeRows.length ? (
+            <tbody>
+              {safeRows.map((row, r) => (
                 <tr key={r}>
-                  {row.map((cell, c) => (
-                    <td key={c}>{String(cell)}</td>
-                  ))}
+                  {row.map((cell, c) =>
+                    isTableCell(cell) ? <td key={c}>{String(cell)}</td> : null,
+                  )}
                 </tr>
-              ) : null,
-            )}
-          </tbody>
-        ) : null}
-        {children}
-      </table>
-    ),
+              ))}
+            </tbody>
+          ) : null}
+          {children}
+        </table>
+      );
+    },
   },
   Markdown: {
     description:

--- a/packages/react-generative-ui/src/vocabulary/interactive.test.tsx
+++ b/packages/react-generative-ui/src/vocabulary/interactive.test.tsx
@@ -103,6 +103,18 @@ describe("interactiveVocabulary", () => {
     expect(html).toContain('<option value="b">B</option>');
   });
 
+  it("Select ignores malformed options instead of throwing", () => {
+    expect(render({ $type: "Select" })).toBe(
+      '<select data-aui="select"></select>',
+    );
+    expect(
+      render({
+        $type: "Select",
+        options: [null, { label: "Missing value" }, { label: "A", value: "a" }],
+      }),
+    ).toBe('<select data-aui="select"><option value="a">A</option></select>');
+  });
+
   it("Input renders a single-line input by default", () => {
     expect(render({ $type: "Input", placeholder: "type here" })).toBe(
       '<input data-aui="input" placeholder="type here"/>',

--- a/packages/react-generative-ui/src/vocabulary/interactive.test.tsx
+++ b/packages/react-generative-ui/src/vocabulary/interactive.test.tsx
@@ -107,10 +107,18 @@ describe("interactiveVocabulary", () => {
     expect(render({ $type: "Select" })).toBe(
       '<select data-aui="select"></select>',
     );
+    expect(render({ $type: "Select", options: "not-an-array" })).toBe(
+      '<select data-aui="select"></select>',
+    );
     expect(
       render({
         $type: "Select",
-        options: [null, { label: "Missing value" }, { label: "A", value: "a" }],
+        options: [
+          null,
+          { label: "Missing value" },
+          { value: "Missing label" },
+          { label: "A", value: "a" },
+        ],
       }),
     ).toBe('<select data-aui="select"><option value="a">A</option></select>');
   });

--- a/packages/react-generative-ui/src/vocabulary/interactive.tsx
+++ b/packages/react-generative-ui/src/vocabulary/interactive.tsx
@@ -39,25 +39,27 @@ function RadioGroupRender({
 }: RadioGroupRenderProps) {
   const generatedName = useId();
   const fieldName = name ?? generatedName;
-  const safeOptions = Array.isArray(options) ? options.filter(isOption) : [];
+  const safeOptions = Array.isArray(options) ? options : [];
   return (
     <fieldset
       data-aui="radiogroup"
       data-aui-action={actionAttr($action)}
       aria-label={label}
     >
-      {safeOptions.map((option, i) => (
-        <label key={i} data-aui="radiogroup-option">
-          <input
-            type="radio"
-            name={fieldName}
-            value={option.value}
-            defaultChecked={defaultValue === option.value}
-            onChange={() => fire($action, $dispatch, option.value)}
-          />
-          {option.label}
-        </label>
-      ))}
+      {safeOptions.map((option, i) =>
+        isOption(option) ? (
+          <label key={i} data-aui="radiogroup-option">
+            <input
+              type="radio"
+              name={fieldName}
+              value={option.value}
+              defaultChecked={defaultValue === option.value}
+              onChange={() => fire($action, $dispatch, option.value)}
+            />
+            {option.label}
+          </label>
+        ) : null,
+      )}
     </fieldset>
   );
 }
@@ -140,12 +142,12 @@ export const interactiveVocabulary = {
             {placeholder}
           </option>
         ) : null}
-        {(Array.isArray(options) ? options.filter(isOption) : []).map(
-          (option, i) => (
+        {(Array.isArray(options) ? options : []).map((option, i) =>
+          isOption(option) ? (
             <option key={i} value={option.value}>
               {option.label}
             </option>
-          ),
+          ) : null,
         )}
         {children}
       </select>

--- a/packages/react-generative-ui/src/vocabulary/interactive.tsx
+++ b/packages/react-generative-ui/src/vocabulary/interactive.tsx
@@ -10,8 +10,18 @@ const optionSchema = z.object({
   value: z.string(),
 });
 
+type Option = { label: string; value: string };
+
+const isOption = (option: unknown): option is Option =>
+  option !== null &&
+  typeof option === "object" &&
+  "label" in option &&
+  typeof option.label === "string" &&
+  "value" in option &&
+  typeof option.value === "string";
+
 type RadioGroupRenderProps = {
-  options: { label: string; value: string }[];
+  options: Option[];
   name?: string;
   label?: string;
   defaultValue?: string;
@@ -29,29 +39,25 @@ function RadioGroupRender({
 }: RadioGroupRenderProps) {
   const generatedName = useId();
   const fieldName = name ?? generatedName;
-  const safeOptions = Array.isArray(options) ? options : [];
+  const safeOptions = Array.isArray(options) ? options.filter(isOption) : [];
   return (
     <fieldset
       data-aui="radiogroup"
       data-aui-action={actionAttr($action)}
       aria-label={label}
     >
-      {safeOptions.map((option, i) =>
-        option &&
-        typeof option.label === "string" &&
-        typeof option.value === "string" ? (
-          <label key={i} data-aui="radiogroup-option">
-            <input
-              type="radio"
-              name={fieldName}
-              value={option.value}
-              defaultChecked={defaultValue === option.value}
-              onChange={() => fire($action, $dispatch, option.value)}
-            />
-            {option.label}
-          </label>
-        ) : null,
-      )}
+      {safeOptions.map((option, i) => (
+        <label key={i} data-aui="radiogroup-option">
+          <input
+            type="radio"
+            name={fieldName}
+            value={option.value}
+            defaultChecked={defaultValue === option.value}
+            onChange={() => fire($action, $dispatch, option.value)}
+          />
+          {option.label}
+        </label>
+      ))}
     </fieldset>
   );
 }
@@ -134,14 +140,12 @@ export const interactiveVocabulary = {
             {placeholder}
           </option>
         ) : null}
-        {(Array.isArray(options) ? options : []).map((option, i) =>
-          option &&
-          typeof option.label === "string" &&
-          typeof option.value === "string" ? (
+        {(Array.isArray(options) ? options.filter(isOption) : []).map(
+          (option, i) => (
             <option key={i} value={option.value}>
               {option.label}
             </option>
-          ) : null,
+          ),
         )}
         {children}
       </select>

--- a/packages/react-generative-ui/src/vocabulary/interactive.tsx
+++ b/packages/react-generative-ui/src/vocabulary/interactive.tsx
@@ -134,11 +134,15 @@ export const interactiveVocabulary = {
             {placeholder}
           </option>
         ) : null}
-        {options.map((o: { label: string; value: string }, i: number) => (
-          <option key={i} value={o.value}>
-            {o.label}
-          </option>
-        ))}
+        {(Array.isArray(options) ? options : []).map((option, i) =>
+          option &&
+          typeof option.label === "string" &&
+          typeof option.value === "string" ? (
+            <option key={i} value={option.value}>
+              {option.label}
+            </option>
+          ) : null,
+        )}
         {children}
       </select>
     ),


### PR DESCRIPTION
## Problem

In `@assistant-ui/react-generative-ui` 0.0.17, built-in collection components can crash an entire generated UI when streamed or malformed model output does not match the schema. For example, rendering `{ $type: "Select" }` throws while reading `options.map`, and a `Table` with non-array `columns` or a non-array row throws in the same way.

## Root cause

The built-in `Select` and `Table` renderers trusted collection props at runtime even though generated content can be partial or invalid. Nearby `RadioGroup` handling already guards this boundary.

## Change

Guard `Select` options and `Table` columns, rows, and row entries before iterating them. Valid entries render unchanged; malformed collections or entries are ignored so the rest of the generated UI remains usable.

## Verification

- Added focused renderer tests for missing and malformed Select options.
- Added focused renderer tests for malformed Table columns and rows.
- `pnpm --filter @assistant-ui/react-generative-ui test` (29 files, 636 tests)
- `pnpm --filter @assistant-ui/react-generative-ui build`
- `pnpm changesets:check`
- `pnpm lint`

The focused reproductions throw on `main` and render safely with this change.

## Public surface

Affected package: `@assistant-ui/react-generative-ui` (patch changeset). No exports, API reference, docs, or templates change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4IuP1e37yWiaA1tEPJIvFIvPJUs2vu7YGgB3QByBW9jTmkmvDNIzLAUQsKg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->