### PR TITLE
fix(assistant-stream-py): cancel sibling streams after substream failures

### DIFF
--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -273,8 +273,16 @@ async def create_run(
             for dispose in controller._dispose_callbacks:
                 dispose()
             try:
-                for task in controller._stream_tasks:
-                    await task
+                try:
+                    await asyncio.gather(*controller._stream_tasks)
+                except BaseException:
+                    for task in controller._stream_tasks:
+                        if not task.done():
+                            task.cancel()
+                    await asyncio.gather(
+                        *controller._stream_tasks, return_exceptions=True
+                    )
+                    raise
             finally:
                 enqueue_threadsafe(asyncio.get_running_loop(), queue, None)
 

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -112,8 +112,8 @@ class RunController:
         stream, controller = await create_tool_call(tool_name, tool_call_id, self._parent_id)
         self._dispose_callbacks.append(controller.close)
 
-        self.add_stream(stream)
-        self._stream_tasks_to_drain.append(self._stream_tasks[-1])
+        task = self._add_stream_task(stream)
+        self._stream_tasks_to_drain.append(task)
         return controller
 
     def add_tool_result(self, tool_call_id: str, result: Any) -> None:
@@ -126,6 +126,11 @@ class RunController:
 
     def add_stream(self, stream: AsyncGenerator[AssistantStreamChunk, None]) -> None:
         """Append a substream to the main stream."""
+        self._add_stream_task(stream)
+
+    def _add_stream_task(
+        self, stream: AsyncGenerator[AssistantStreamChunk, None]
+    ) -> asyncio.Task[None]:
 
         async def reader():
             async for chunk in stream:
@@ -133,6 +138,7 @@ class RunController:
 
         task = asyncio.create_task(reader())
         self._stream_tasks.append(task)
+        return task
 
     def add_data(self, data: Any) -> None:
         """Emit an event to the main stream."""
@@ -308,10 +314,21 @@ async def create_run(
                     task_index += len(tasks)
                 drain_dispose_callbacks()
 
+            async def finish_stream_task_cancellation():
+                cleanup_task = asyncio.create_task(cancel_stream_tasks())
+                while True:
+                    try:
+                        await asyncio.shield(cleanup_task)
+                        return
+                    except asyncio.CancelledError:
+                        if cleanup_task.done():
+                            cleanup_task.result()
+                            return
+
             drain_dispose_callbacks()
             try:
                 if callback_failed:
-                    await cancel_stream_tasks()
+                    await finish_stream_task_cancellation()
                 else:
                     try:
                         task_index = 0
@@ -321,7 +338,7 @@ async def create_run(
                             task_index += len(tasks)
                             drain_dispose_callbacks()
                     except BaseException:
-                        await cancel_stream_tasks()
+                        await finish_stream_task_cancellation()
                         raise
             finally:
                 enqueue_threadsafe(asyncio.get_running_loop(), queue, None)

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -274,14 +274,20 @@ async def create_run(
                 dispose()
             try:
                 try:
-                    await asyncio.gather(*controller._stream_tasks)
+                    task_index = 0
+                    while task_index < len(controller._stream_tasks):
+                        tasks = controller._stream_tasks[task_index:]
+                        await asyncio.gather(*tasks)
+                        task_index += len(tasks)
                 except BaseException:
-                    for task in controller._stream_tasks:
-                        if not task.done():
-                            task.cancel()
-                    await asyncio.gather(
-                        *controller._stream_tasks, return_exceptions=True
-                    )
+                    task_index = 0
+                    while task_index < len(controller._stream_tasks):
+                        tasks = controller._stream_tasks[task_index:]
+                        for task in tasks:
+                            if not task.done():
+                                task.cancel()
+                        await asyncio.gather(*tasks, return_exceptions=True)
+                        task_index += len(tasks)
                     raise
             finally:
                 enqueue_threadsafe(asyncio.get_running_loop(), queue, None)

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -27,6 +27,18 @@ from assistant_stream.state_manager import StateManager
 logger = logging.getLogger(__name__)
 
 
+def _log_detached_task_error(task: asyncio.Task[None]) -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.warning(
+            "Suppressed callback exception after interrupted early-close cleanup",
+            exc_info=True,
+        )
+
+
 class ReadOnlyCancellationSignal:
     """Read-only view over an asyncio.Event used for cancellation."""
 
@@ -321,6 +333,7 @@ async def create_run(
                         await asyncio.shield(cleanup_task)
                         return
                     except asyncio.CancelledError:
+                        # Cleanup remains uncancellable so nested readers cannot be orphaned.
                         if cleanup_task.done():
                             cleanup_task.result()
                             return
@@ -389,6 +402,7 @@ async def create_run(
                     pass
                 else:
                     # Preserve caller-initiated cancellation (e.g. wait_for timeout).
+                    task.add_done_callback(_log_detached_task_error)
                     raise
             except Exception:
                 # The stream consumer already disconnected, so suppress callback errors

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -383,6 +383,9 @@ async def create_run(
                 except asyncio.TimeoutError:
                     # Timeout means cooperative shutdown did not finish in time.
                     pass
+                except asyncio.CancelledError:
+                    task.add_done_callback(_log_detached_task_error)
+                    raise
                 except Exception:
                     # The stream consumer already disconnected, so suppress callback errors
                     # but keep a log signal for postmortem debugging.

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -261,10 +261,13 @@ async def create_run(
     controller = RunController(queue, state_data=state)
 
     async def background_task():
+        callback_failed = False
         try:
             await callback(controller)
-        except Exception as e:
-            controller.add_error(str(e))
+        except BaseException as e:
+            callback_failed = True
+            if isinstance(e, Exception):
+                controller.add_error(str(e))
             raise
         finally:
             # Flush any pending state updates before disposing
@@ -279,27 +282,33 @@ async def create_run(
                     dispose_index += 1
                     dispose()
 
+            async def cancel_stream_tasks():
+                task_index = 0
+                while task_index < len(controller._stream_tasks):
+                    drain_dispose_callbacks()
+                    tasks = controller._stream_tasks[task_index:]
+                    for task in tasks:
+                        if not task.done():
+                            task.cancel()
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                    task_index += len(tasks)
+                drain_dispose_callbacks()
+
             drain_dispose_callbacks()
             try:
-                try:
-                    task_index = 0
-                    while task_index < len(controller._stream_tasks):
-                        tasks = controller._stream_tasks[task_index:]
-                        await asyncio.gather(*tasks)
-                        task_index += len(tasks)
-                        drain_dispose_callbacks()
-                except BaseException:
-                    task_index = 0
-                    while task_index < len(controller._stream_tasks):
-                        drain_dispose_callbacks()
-                        tasks = controller._stream_tasks[task_index:]
-                        for task in tasks:
-                            if not task.done():
-                                task.cancel()
-                        await asyncio.gather(*tasks, return_exceptions=True)
-                        task_index += len(tasks)
-                    drain_dispose_callbacks()
-                    raise
+                if callback_failed:
+                    await cancel_stream_tasks()
+                else:
+                    try:
+                        task_index = 0
+                        while task_index < len(controller._stream_tasks):
+                            tasks = controller._stream_tasks[task_index:]
+                            await asyncio.gather(*tasks)
+                            task_index += len(tasks)
+                            drain_dispose_callbacks()
+                    except BaseException:
+                        await cancel_stream_tasks()
+                        raise
             finally:
                 enqueue_threadsafe(asyncio.get_running_loop(), queue, None)
 

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -31,7 +31,7 @@ def _log_detached_task_error(task: asyncio.Task[None]) -> None:
     try:
         task.result()
     except asyncio.CancelledError:
-        pass
+        return
     except Exception:
         logger.warning(
             "Suppressed callback exception after interrupted early-close cleanup",

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -46,6 +46,7 @@ class RunController:
         self._loop = asyncio.get_running_loop()
         self._dispose_callbacks = []
         self._stream_tasks = []
+        self._stream_tasks_to_drain = []
         self._state_manager = StateManager(self._put_chunk_nowait, state_data)
         self._parent_id = parent_id
         self._cancelled_event = asyncio.Event()
@@ -63,6 +64,7 @@ class RunController:
         controller._loop = self._loop
         controller._dispose_callbacks = self._dispose_callbacks
         controller._stream_tasks = self._stream_tasks
+        controller._stream_tasks_to_drain = self._stream_tasks_to_drain
         controller._state_manager = self._state_manager
         controller._parent_id = parent_id
         controller._cancelled_event = self._cancelled_event
@@ -111,6 +113,7 @@ class RunController:
         self._dispose_callbacks.append(controller.close)
 
         self.add_stream(stream)
+        self._stream_tasks_to_drain.append(self._stream_tasks[-1])
         return controller
 
     def add_tool_result(self, tool_call_id: str, result: Any) -> None:
@@ -284,8 +287,19 @@ async def create_run(
 
             async def cancel_stream_tasks():
                 task_index = 0
-                while task_index < len(controller._stream_tasks):
+                drain_index = 0
+                while True:
                     drain_dispose_callbacks()
+
+                    tasks_to_drain = controller._stream_tasks_to_drain[drain_index:]
+                    if tasks_to_drain:
+                        await asyncio.gather(*tasks_to_drain, return_exceptions=True)
+                        drain_index += len(tasks_to_drain)
+                        continue
+
+                    if task_index >= len(controller._stream_tasks):
+                        break
+
                     tasks = controller._stream_tasks[task_index:]
                     for task in tasks:
                         if not task.done():

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -39,6 +39,11 @@ def _log_detached_task_error(task: asyncio.Task[None]) -> None:
         )
 
 
+def _cancel_detached_task(task: asyncio.Task[None]) -> None:
+    task.add_done_callback(_log_detached_task_error)
+    task.cancel()
+
+
 class ReadOnlyCancellationSignal:
     """Read-only view over an asyncio.Event used for cancellation."""
 
@@ -372,7 +377,11 @@ async def create_run(
         else:
             controller._mark_cancelled()
             # Yield to the event loop to allow the cancel signal to propagate.
-            await asyncio.sleep(0)
+            try:
+                await asyncio.sleep(0)
+            except asyncio.CancelledError:
+                _cancel_detached_task(task)
+                raise
             if not task.done():
                 # Give callbacks a brief chance to observe `is_cancelled`
                 # and exit cooperatively before forcing cancellation.
@@ -384,7 +393,7 @@ async def create_run(
                     # Timeout means cooperative shutdown did not finish in time.
                     pass
                 except asyncio.CancelledError:
-                    task.add_done_callback(_log_detached_task_error)
+                    _cancel_detached_task(task)
                     raise
                 except Exception:
                     # The stream consumer already disconnected, so suppress callback errors
@@ -405,7 +414,7 @@ async def create_run(
                     pass
                 else:
                     # Preserve caller-initiated cancellation (e.g. wait_for timeout).
-                    task.add_done_callback(_log_detached_task_error)
+                    _cancel_detached_task(task)
                     raise
             except Exception:
                 # The stream consumer already disconnected, so suppress callback errors

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -270,8 +270,16 @@ async def create_run(
             # Flush any pending state updates before disposing
             controller._state_manager.flush()
 
-            for dispose in controller._dispose_callbacks:
-                dispose()
+            dispose_index = 0
+
+            def drain_dispose_callbacks():
+                nonlocal dispose_index
+                while dispose_index < len(controller._dispose_callbacks):
+                    dispose = controller._dispose_callbacks[dispose_index]
+                    dispose_index += 1
+                    dispose()
+
+            drain_dispose_callbacks()
             try:
                 try:
                     task_index = 0
@@ -279,15 +287,18 @@ async def create_run(
                         tasks = controller._stream_tasks[task_index:]
                         await asyncio.gather(*tasks)
                         task_index += len(tasks)
+                        drain_dispose_callbacks()
                 except BaseException:
                     task_index = 0
                     while task_index < len(controller._stream_tasks):
+                        drain_dispose_callbacks()
                         tasks = controller._stream_tasks[task_index:]
                         for task in tasks:
                             if not task.done():
                                 task.cancel()
                         await asyncio.gather(*tasks, return_exceptions=True)
                         task_index += len(tasks)
+                    drain_dispose_callbacks()
                     raise
             finally:
                 enqueue_threadsafe(asyncio.get_running_loop(), queue, None)

--- a/python/assistant-stream/tests/test_cancellation.py
+++ b/python/assistant-stream/tests/test_cancellation.py
@@ -187,6 +187,39 @@ async def test_early_stream_close_forces_background_task_cancellation():
 
 
 @pytest.mark.anyio
+async def test_early_stream_close_cancels_and_awaits_substreams():
+    substream_started = asyncio.Event()
+    substream_cancelled = asyncio.Event()
+    substream_finished = asyncio.Event()
+
+    async def blocking_stream():
+        substream_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            substream_cancelled.set()
+            raise
+        finally:
+            substream_finished.set()
+        yield
+
+    async def run_callback(controller: RunController):
+        controller.add_stream(blocking_stream())
+        controller.append_text("start")
+        await substream_started.wait()
+        await asyncio.Event().wait()
+
+    stream = create_run(run_callback)
+    first_chunk = await anext(stream)
+    assert first_chunk.type == "text-delta"
+
+    await asyncio.wait_for(stream.aclose(), timeout=1)
+
+    assert substream_cancelled.is_set()
+    assert substream_finished.is_set()
+
+
+@pytest.mark.anyio
 async def test_early_stream_close_does_not_raise_callback_exception():
     async def run_callback(controller: RunController):
         controller.append_text("start")

--- a/python/assistant-stream/tests/test_cancellation.py
+++ b/python/assistant-stream/tests/test_cancellation.py
@@ -161,6 +161,27 @@ async def test_closes_tool_streams_registered_by_substreams():
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("with_result", [False, True])
+async def test_callback_failure_drains_tool_streams(with_result: bool):
+    async def run_callback(controller: RunController):
+        tool_call = await controller.add_tool_call("lookup", "tool-1")
+        if with_result:
+            tool_call.set_response("found")
+        raise RuntimeError("boom")
+
+    chunks = []
+    with pytest.raises(RuntimeError, match="boom"):
+        async for chunk in create_run(run_callback):
+            chunks.append(chunk)
+
+    chunk_types = [chunk.type for chunk in chunks]
+    assert chunk_types[-1] == "tool-call-args-text-finish"
+    if with_result:
+        tool_result = next(chunk for chunk in chunks if chunk.type == "tool-result")
+        assert tool_result.result == "found"
+
+
+@pytest.mark.anyio
 async def test_early_stream_close_forces_background_task_cancellation():
     callback_cancelled = asyncio.Event()
     callback_finished = asyncio.Event()

--- a/python/assistant-stream/tests/test_cancellation.py
+++ b/python/assistant-stream/tests/test_cancellation.py
@@ -140,20 +140,9 @@ async def test_substream_failure_cancels_and_awaits_sibling_streams():
 
 
 @pytest.mark.anyio
-async def test_waits_for_substreams_registered_by_substreams():
-    nested_started = asyncio.Event()
-    release_nested = asyncio.Event()
-    completion_order: list[str] = []
-
-    async def nested_stream():
-        nested_started.set()
-        await release_nested.wait()
-        completion_order.append("nested")
-        if False:
-            yield
-
+async def test_closes_tool_streams_registered_by_substreams():
     async def parent_stream(controller: RunController):
-        controller.add_stream(nested_stream())
+        await controller.add_tool_call("lookup", "tool-1")
         if False:
             yield
 
@@ -161,16 +150,14 @@ async def test_waits_for_substreams_registered_by_substreams():
         controller.add_stream(parent_stream(controller))
 
     async def consume():
-        async for _ in create_run(run_callback):
-            pass
-        completion_order.append("run")
+        return [chunk async for chunk in create_run(run_callback)]
 
-    consume_task = asyncio.create_task(consume())
-    await asyncio.wait_for(nested_started.wait(), timeout=1)
-    release_nested.set()
-    await asyncio.wait_for(consume_task, timeout=1)
+    chunks = await asyncio.wait_for(consume(), timeout=1)
 
-    assert completion_order == ["nested", "run"]
+    assert [chunk.type for chunk in chunks] == [
+        "tool-call-begin",
+        "tool-call-args-text-finish",
+    ]
 
 
 @pytest.mark.anyio

--- a/python/assistant-stream/tests/test_cancellation.py
+++ b/python/assistant-stream/tests/test_cancellation.py
@@ -363,6 +363,7 @@ async def test_early_stream_close_does_not_raise_callback_exception():
 
 @pytest.mark.anyio
 async def test_early_stream_close_does_not_swallow_close_task_cancellation():
+    callback_cancelled = asyncio.Event()
     callback_finished = asyncio.Event()
     loop = asyncio.get_running_loop()
 
@@ -374,6 +375,7 @@ async def test_early_stream_close_does_not_swallow_close_task_cancellation():
                 try:
                     await asyncio.sleep(0.01)
                 except asyncio.CancelledError:
+                    callback_cancelled.set()
                     # Simulate non-cooperative callback behavior: ignore cancellation.
                     continue
         finally:
@@ -393,5 +395,6 @@ async def test_early_stream_close_does_not_swallow_close_task_cancellation():
         assert close_task.cancelled()
     finally:
         await asyncio.wait_for(callback_finished.wait(), timeout=2)
+        assert callback_cancelled.is_set()
         if not close_task.done():
             await asyncio.wait({close_task}, timeout=1)

--- a/python/assistant-stream/tests/test_cancellation.py
+++ b/python/assistant-stream/tests/test_cancellation.py
@@ -327,15 +327,17 @@ async def test_cancelled_close_retrieves_late_callback_failure(
     stream = create_run(run_callback)
     first_chunk = await anext(stream)
     assert first_chunk.type == "text-delta"
-    await cleanup_started.wait()
+    await asyncio.wait_for(cleanup_started.wait(), timeout=1)
 
     close_task = asyncio.create_task(stream.aclose())
-    await asyncio.sleep(cancel_delay)
-    close_task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await close_task
+    try:
+        await asyncio.sleep(cancel_delay)
+        close_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(close_task, timeout=1)
+    finally:
+        release_cleanup.set()
 
-    release_cleanup.set()
     await asyncio.wait_for(reader_finished.wait(), timeout=1)
     for _ in range(20):
         if "interrupted early-close cleanup" in caplog.text:

--- a/python/assistant-stream/tests/test_cancellation.py
+++ b/python/assistant-stream/tests/test_cancellation.py
@@ -241,6 +241,62 @@ async def test_early_stream_close_cancels_and_awaits_substreams():
 
 
 @pytest.mark.anyio
+async def test_early_close_during_callback_failure_finishes_reader_cleanup():
+    parent_started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    nested_started = asyncio.Event()
+    nested_cancelled = asyncio.Event()
+    nested_finished = asyncio.Event()
+
+    async def nested_stream():
+        nested_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            nested_cancelled.set()
+            raise
+        finally:
+            nested_finished.set()
+        yield
+
+    async def parent_stream(controller: RunController):
+        parent_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            controller.add_stream(nested_stream())
+            await nested_started.wait()
+            cleanup_started.set()
+            await release_cleanup.wait()
+            raise
+        yield
+
+    async def run_callback(controller: RunController):
+        controller.add_stream(parent_stream(controller))
+        controller.append_text("start")
+        await parent_started.wait()
+        raise RuntimeError("boom")
+
+    stream = create_run(run_callback)
+    first_chunk = await anext(stream)
+    assert first_chunk.type == "text-delta"
+    await cleanup_started.wait()
+
+    close_task = asyncio.create_task(stream.aclose())
+    try:
+        await asyncio.sleep(0.1)
+        assert not close_task.done()
+        assert not nested_cancelled.is_set()
+    finally:
+        release_cleanup.set()
+        await asyncio.wait_for(close_task, timeout=1)
+
+    assert nested_cancelled.is_set()
+    assert nested_finished.is_set()
+
+
+@pytest.mark.anyio
 async def test_early_stream_close_does_not_raise_callback_exception():
     async def run_callback(controller: RunController):
         controller.append_text("start")

--- a/python/assistant-stream/tests/test_cancellation.py
+++ b/python/assistant-stream/tests/test_cancellation.py
@@ -297,6 +297,52 @@ async def test_early_close_during_callback_failure_finishes_reader_cleanup():
 
 
 @pytest.mark.anyio
+async def test_cancelled_close_retrieves_late_callback_failure(caplog):
+    reader_started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    reader_finished = asyncio.Event()
+
+    async def blocking_stream():
+        reader_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            await release_cleanup.wait()
+            raise
+        finally:
+            reader_finished.set()
+        yield
+
+    async def run_callback(controller: RunController):
+        controller.add_stream(blocking_stream())
+        controller.append_text("start")
+        await reader_started.wait()
+        raise RuntimeError("boom")
+
+    stream = create_run(run_callback)
+    first_chunk = await anext(stream)
+    assert first_chunk.type == "text-delta"
+    await cleanup_started.wait()
+
+    close_task = asyncio.create_task(stream.aclose())
+    await asyncio.sleep(0.1)
+    close_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await close_task
+
+    release_cleanup.set()
+    await asyncio.wait_for(reader_finished.wait(), timeout=1)
+    for _ in range(20):
+        if "interrupted early-close cleanup" in caplog.text:
+            break
+        await asyncio.sleep(0.01)
+
+    assert "interrupted early-close cleanup" in caplog.text
+
+
+@pytest.mark.anyio
 async def test_early_stream_close_does_not_raise_callback_exception():
     async def run_callback(controller: RunController):
         controller.append_text("start")

--- a/python/assistant-stream/tests/test_cancellation.py
+++ b/python/assistant-stream/tests/test_cancellation.py
@@ -297,7 +297,10 @@ async def test_early_close_during_callback_failure_finishes_reader_cleanup():
 
 
 @pytest.mark.anyio
-async def test_cancelled_close_retrieves_late_callback_failure(caplog):
+@pytest.mark.parametrize("cancel_delay", [0.01, 0.1])
+async def test_cancelled_close_retrieves_late_callback_failure(
+    caplog, cancel_delay
+):
     reader_started = asyncio.Event()
     cleanup_started = asyncio.Event()
     release_cleanup = asyncio.Event()
@@ -327,7 +330,7 @@ async def test_cancelled_close_retrieves_late_callback_failure(caplog):
     await cleanup_started.wait()
 
     close_task = asyncio.create_task(stream.aclose())
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(cancel_delay)
     close_task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await close_task

--- a/python/assistant-stream/tests/test_cancellation.py
+++ b/python/assistant-stream/tests/test_cancellation.py
@@ -140,6 +140,40 @@ async def test_substream_failure_cancels_and_awaits_sibling_streams():
 
 
 @pytest.mark.anyio
+async def test_waits_for_substreams_registered_by_substreams():
+    nested_started = asyncio.Event()
+    release_nested = asyncio.Event()
+    completion_order: list[str] = []
+
+    async def nested_stream():
+        nested_started.set()
+        await release_nested.wait()
+        completion_order.append("nested")
+        if False:
+            yield
+
+    async def parent_stream(controller: RunController):
+        controller.add_stream(nested_stream())
+        if False:
+            yield
+
+    async def run_callback(controller: RunController):
+        controller.add_stream(parent_stream(controller))
+
+    async def consume():
+        async for _ in create_run(run_callback):
+            pass
+        completion_order.append("run")
+
+    consume_task = asyncio.create_task(consume())
+    await asyncio.wait_for(nested_started.wait(), timeout=1)
+    release_nested.set()
+    await asyncio.wait_for(consume_task, timeout=1)
+
+    assert completion_order == ["nested", "run"]
+
+
+@pytest.mark.anyio
 async def test_early_stream_close_forces_background_task_cancellation():
     callback_cancelled = asyncio.Event()
     callback_finished = asyncio.Event()

--- a/python/assistant-stream/tests/test_cancellation.py
+++ b/python/assistant-stream/tests/test_cancellation.py
@@ -103,6 +103,43 @@ async def test_normal_completion_surfaces_callback_exception():
 
 
 @pytest.mark.anyio
+async def test_substream_failure_cancels_and_awaits_sibling_streams():
+    sibling_started = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+    sibling_finished = asyncio.Event()
+
+    async def blocking_stream():
+        sibling_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+        finally:
+            sibling_finished.set()
+        yield
+
+    async def failing_stream():
+        await sibling_started.wait()
+        raise RuntimeError("substream failed")
+        yield
+
+    async def run_callback(controller: RunController):
+        controller.add_stream(blocking_stream())
+        controller.add_stream(failing_stream())
+
+    async def consume():
+        with pytest.raises(RuntimeError, match="substream failed"):
+            async for _ in create_run(run_callback):
+                pass
+
+    await asyncio.wait_for(consume(), timeout=1)
+
+    assert sibling_cancelled.is_set()
+    assert sibling_finished.is_set()
+
+
+@pytest.mark.anyio
 async def test_early_stream_close_forces_background_task_cancellation():
     callback_cancelled = asyncio.Event()
     callback_finished = asyncio.Event()

--- a/python/assistant-stream/tests/test_with_parent_id.py
+++ b/python/assistant-stream/tests/test_with_parent_id.py
@@ -23,6 +23,9 @@ async def test_with_parent_id_shares_everything_but_the_parent_id():
             derived._dispose_callbacks is controller._dispose_callbacks
         )
         observed["tasks_shared"] = derived._stream_tasks is controller._stream_tasks
+        observed["drained_tasks_shared"] = (
+            derived._stream_tasks_to_drain is controller._stream_tasks_to_drain
+        )
         derived.append_text("nested")
 
     chunks = [chunk async for chunk in create_run(run_callback)]
@@ -33,6 +36,7 @@ async def test_with_parent_id_shares_everything_but_the_parent_id():
         "cancel_shared": True,
         "dispose_shared": True,
         "tasks_shared": True,
+        "drained_tasks_shared": True,
     }
     assert len(chunks) == 1
     assert chunks[0].type == "text-delta"


### PR DESCRIPTION
## Problem

`RunController.add_stream()` starts each substream reader concurrently, but `create_run()` waits for those tasks in registration order. If a later reader fails while an earlier reader is still pending, the failure is never observed, the run does not finish, and sibling model/network work can remain active.

Minimal reproduction on current `main`: register a blocking substream first and a substream that raises second. Consuming `create_run()` times out instead of receiving the failure, and the blocking substream is not cancelled.

## Root cause

The background cleanup loop awaits each reader task sequentially. It cannot observe a failure from a later task until every earlier task has completed, and it has no sibling cancellation path when a task fails.

## Change

Wait for each batch of registered substream readers concurrently and continue draining readers registered by nested substreams. If the callback exits exceptionally, a reader fails, or the join is cancelled, first drain streams closed by disposal so queued terminal frames are forwarded, then cancel every reader that remains unfinished. Await all cleanup including newly registered tasks before re-raising the original exception. A later consumer cancellation cannot interrupt that cleanup; abandoning close cancels the background task and still retrieves any eventual callback error.

Failure and cancellation cleanup deliberately wait for substreams to unwind before propagating the failure or closing the run. A custom substream that suppresses cancellation can therefore delay failure propagation or close; this matches the existing treatment of non-cooperative cleanup callbacks and avoids orphaning model or network work.

## Verification

- Added `test_substream_failure_cancels_and_awaits_sibling_streams`; it times out on `main` and passes with this change.
- Added `test_closes_tool_streams_registered_by_substreams` to prove nested tool streams are disposed and drained.
- Added `test_early_stream_close_cancels_and_awaits_substreams` to cover cancellation while the callback is still active.
- Added `test_callback_failure_drains_tool_streams` to preserve tool-finish and result frames before live readers are cancelled.
- Added `test_early_close_during_callback_failure_finishes_reader_cleanup` to cover readers registered while cancellation is already in progress.
- Added `test_cancelled_close_retrieves_late_callback_failure` to prove detached protected cleanup retrieves a later callback error during both the cooperative grace wait and forced-cleanup wait.
- Python 3.10 cancellation suite: 16 passed.
- Python 3.12 cancellation suite: 16 passed.
- Full Python 3.12 package suite: 202 passed, 7 skipped.

## Public surface

Python `assistant-stream` behavior only. No API changes and no npm changeset.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.pMhtB4Z9U8VuW4cQAQ8Z53Yar3YhI2RRc4Jx_uZDnBTRXaCcQ17Qgks0pNo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->