### PR TITLE
fix(assistant-stream): reuse raw enqueue channels

### DIFF
--- a/.changeset/reuse-raw-enqueue-channel.md
+++ b/.changeset/reuse-raw-enqueue-channel.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+perf: reuse the raw AssistantStream enqueue channel

--- a/packages/assistant-stream/src/core/utils/stream/merge.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.test.ts
@@ -1,7 +1,82 @@
 import { describe, expect, it, vi } from "vitest";
+import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
 import { createMergeStream } from "./merge";
 
+const textDelta = (textDelta: string): AssistantStreamChunk => ({
+  type: "text-delta",
+  path: [0],
+  textDelta,
+});
+
 describe("createMergeStream", () => {
+  it("reuses one reader for ordered raw chunks", async () => {
+    const getReader = vi.spyOn(ReadableStream.prototype, "getReader");
+    const merger = createMergeStream();
+    const received: AssistantStreamChunk[] = [];
+
+    merger.enqueue(textDelta("a"));
+    merger.enqueue(textDelta("b"));
+    merger.enqueue(textDelta("c"));
+
+    expect(getReader).toHaveBeenCalledOnce();
+    getReader.mockRestore();
+
+    merger.seal();
+    await merger.readable.pipeTo(
+      new WritableStream({
+        write(chunk) {
+          received.push(chunk);
+        },
+      }),
+    );
+
+    expect(received).toEqual([textDelta("a"), textDelta("b"), textDelta("c")]);
+  });
+
+  it("preserves raw chunk order around a merged stream", async () => {
+    const merger = createMergeStream();
+    const received: AssistantStreamChunk[] = [];
+
+    merger.enqueue(textDelta("before"));
+    merger.addStream(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(textDelta("child"));
+          controller.close();
+        },
+      }),
+    );
+    merger.enqueue(textDelta("after"));
+    merger.seal();
+
+    await merger.readable.pipeTo(
+      new WritableStream({
+        write(chunk) {
+          received.push(chunk);
+        },
+      }),
+    );
+
+    expect(received).toEqual([
+      textDelta("before"),
+      textDelta("child"),
+      textDelta("after"),
+    ]);
+  });
+
+  it("discards raw chunks after cancellation", async () => {
+    const getReader = vi.spyOn(ReadableStream.prototype, "getReader");
+    const merger = createMergeStream();
+
+    merger.enqueue(textDelta("before"));
+    await merger.readable.cancel();
+    merger.enqueue(textDelta("after"));
+
+    expect(merger.isCancelled()).toBe(true);
+    expect(getReader).toHaveBeenCalledOnce();
+    getReader.mockRestore();
+  });
+
   it("releases child readers after successful completion", async () => {
     const child = new ReadableStream<never>({
       start(controller) {

--- a/packages/assistant-stream/src/core/utils/stream/merge.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.ts
@@ -13,6 +13,9 @@ export const createMergeStream = () => {
   let cancelled = false;
   let errored = false;
   let controller: ReadableStreamDefaultController<AssistantStreamChunk>;
+  let rawChunkController:
+    | ReadableStreamDefaultController<AssistantStreamChunk>
+    | undefined;
   let currentPull: ReturnType<typeof promiseWithResolvers<void>> | undefined;
   let cleanupPromise: Promise<void> | undefined;
 
@@ -93,6 +96,39 @@ export const createMergeStream = () => {
     },
   });
 
+  const closeRawChunkStream = () => {
+    rawChunkController?.close();
+    rawChunkController = undefined;
+  };
+
+  const addStreamItem = (
+    stream: ReadableStream<AssistantStreamChunk>,
+    pipeTask?: Promise<unknown>,
+  ) => {
+    const item = { reader: stream.getReader(), pipeTask };
+    list.push(item);
+    handlePull(item);
+  };
+
+  const addStream = (
+    stream: ReadableStream<AssistantStreamChunk>,
+    pipeTask?: Promise<unknown>,
+  ) => {
+    const handledPipeTask = pipeTask?.catch(() => undefined);
+    if (cancelled || errored) {
+      void stream.cancel().catch(() => undefined);
+      return;
+    }
+
+    if (sealed) {
+      void stream.cancel().catch(() => undefined);
+      throw new Error("Cannot add streams after the run callback has settled.");
+    }
+
+    closeRawChunkStream();
+    addStreamItem(stream, handledPipeTask);
+  };
+
   return {
     readable,
     isSealed() {
@@ -107,38 +143,32 @@ export const createMergeStream = () => {
     seal() {
       if (sealed || cancelled || errored) return;
       sealed = true;
+      closeRawChunkStream();
       if (list.length === 0) controller.close();
     },
-    addStream(
-      stream: ReadableStream<AssistantStreamChunk>,
-      pipeTask?: Promise<unknown>,
-    ) {
-      const handledPipeTask = pipeTask?.catch(() => undefined);
-      if (cancelled || errored) {
-        void stream.cancel().catch(() => undefined);
-        return;
-      }
-
+    addStream,
+    enqueue(chunk: AssistantStreamChunk) {
+      if (cancelled || errored) return;
       if (sealed) {
-        void stream.cancel().catch(() => undefined);
         throw new Error(
           "Cannot add streams after the run callback has settled.",
         );
       }
 
-      const item = { reader: stream.getReader(), pipeTask: handledPipeTask };
-      list.push(item);
-      handlePull(item);
-    },
-    enqueue(chunk: AssistantStreamChunk) {
-      this.addStream(
-        new ReadableStream({
-          start(c) {
-            c.enqueue(chunk);
-            c.close();
-          },
-        }),
-      );
+      if (!rawChunkController) {
+        addStreamItem(
+          new ReadableStream({
+            start(c) {
+              rawChunkController = c;
+            },
+            cancel() {
+              rawChunkController = undefined;
+            },
+          }),
+        );
+      }
+
+      rawChunkController?.enqueue(chunk);
     },
   };
 };

--- a/packages/x-performance/bench/accumulator.bench.ts
+++ b/packages/x-performance/bench/accumulator.bench.ts
@@ -1,6 +1,7 @@
 import { bench, describe } from "vitest";
 import {
   AssistantMessageStream,
+  createAssistantStream,
   type AssistantStreamChunk,
 } from "assistant-stream";
 
@@ -38,6 +39,14 @@ const drainRaw = async (chunks: AssistantStreamChunk[]) => {
   while (!(await reader.read()).done);
 };
 
+const drainRawEnqueue = async (chunks: AssistantStreamChunk[]) => {
+  const source = createAssistantStream((controller) => {
+    for (const chunk of chunks) controller.enqueue(chunk);
+  });
+  const reader = source.getReader();
+  while (!(await reader.read()).done);
+};
+
 describe("assistant-stream: stream + accumulator per-delta cost (16-char deltas)", () => {
   for (const n of [100, 1000, 4000]) {
     const chunks = makeChunks(n, 16);
@@ -54,6 +63,18 @@ describe("assistant-stream: stream round trip baseline, no accumulator", () => {
       await drainRaw(chunks);
     });
   }
+});
+
+describe("assistant-stream: raw controller enqueue overhead", () => {
+  const chunks = makeChunks(10_000, 1);
+
+  bench("10,000 controller.enqueue calls", async () => {
+    await drainRawEnqueue(chunks);
+  });
+
+  bench("10,000 chunks from one source stream", async () => {
+    await drainRaw(chunks);
+  });
 });
 
 describe("assistant-stream: same 4000-char text, chunk size A/B", () => {


### PR DESCRIPTION
## Problem

Low-level protocol adapters can emit raw `AssistantStreamChunk` values through `AssistantStreamController.enqueue()`. Each call currently creates a one-chunk `ReadableStream`, acquires a reader, and adds it to the merger.

For 10,000 consecutive raw chunks, that means 10,000 streams and readers.

Closes #7139.

## Root cause

`createMergeStream().enqueue()` implements a raw chunk by delegating to `addStream()` with a newly allocated one-chunk stream.

## Change

Reuse one lazily-created raw chunk stream for consecutive `enqueue()` calls. Adding a child stream closes the current raw channel before inserting the child, so raw and child stream ordering remains unchanged.

The focused benchmark measures 10,000 raw enqueues at about 6.5 ms after the change. The same local median probe measured approximately 82 ms on `origin/main`.

## Verification

- `pnpm --filter assistant-stream test` (536 passed, 22 skipped)
- `pnpm --filter assistant-stream build`
- `pnpm -C packages/x-performance exec vitest bench --run bench/accumulator.bench.ts`
- `node scripts/check-changesets.mjs`
- Focused tests cover reader reuse, raw ordering, child-stream interleaving, sealing, and cancellation.

## Public surface

- `assistant-stream`: internal performance change, no API changes
- Added a patch changeset
- Added an `@assistant-ui/x-performance` benchmark

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

