### PR TITLE
perf(assistant-stream): lazy tools arguments parsing 

### DIFF
--- a/.changeset/lazy-tool-argument-parsing.md
+++ b/.changeset/lazy-tool-argument-parsing.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+perf: skip partial tool argument parsing without active readers

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.test.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.test.ts
@@ -1,5 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ToolCallReaderImpl } from "./ToolCallReader";
+
+const parsePartialJsonObjectCalls = vi.hoisted(() => vi.fn());
+
+vi.mock(
+  "../../utils/json/parse-partial-json-object",
+  async (importOriginal) => {
+    const original =
+      await importOriginal<
+        typeof import("../../utils/json/parse-partial-json-object")
+      >();
+    return {
+      ...original,
+      parsePartialJsonObject: (
+        ...args: Parameters<typeof original.parsePartialJsonObject>
+      ) => {
+        parsePartialJsonObjectCalls(...args);
+        return original.parsePartialJsonObject(...args);
+      },
+    };
+  },
+);
 
 type Args = {
   required: string;
@@ -8,6 +29,92 @@ type Args = {
 };
 
 const createReader = () => new ToolCallReaderImpl<Args, string>();
+
+describe("ToolCallArgsReader parsing", () => {
+  it("does not parse streamed arguments without an active reader", async () => {
+    parsePartialJsonObjectCalls.mockClear();
+    const reader = createReader();
+
+    await reader.appendArgsTextDelta('{"required":"');
+    await reader.appendArgsTextDelta("hello");
+    await reader.appendArgsTextDelta('"}');
+    await reader.finishArgsText();
+
+    expect(parsePartialJsonObjectCalls).not.toHaveBeenCalled();
+  });
+
+  it("parses accumulated arguments when a reader starts", async () => {
+    parsePartialJsonObjectCalls.mockClear();
+    const reader = createReader();
+
+    await reader.appendArgsTextDelta('{"required":"hel');
+    expect(parsePartialJsonObjectCalls).not.toHaveBeenCalled();
+
+    const stream = reader.args.streamText("required");
+    expect(parsePartialJsonObjectCalls).toHaveBeenCalledOnce();
+
+    await reader.appendArgsTextDelta('lo"}');
+    await reader.finishArgsText();
+
+    let value = "";
+    for await (const delta of stream) value += delta;
+    expect(value).toBe("hello");
+  });
+
+  it("stops parsing after the last reader settles", async () => {
+    parsePartialJsonObjectCalls.mockClear();
+    const reader = createReader();
+    const required = reader.args.get("required");
+
+    await reader.appendArgsTextDelta('{"required":"hello",');
+    expect(await required).toBe("hello");
+    expect(parsePartialJsonObjectCalls).toHaveBeenCalledTimes(2);
+
+    await reader.appendArgsTextDelta('"optional":"later"}');
+    await reader.finishArgsText();
+    expect(parsePartialJsonObjectCalls).toHaveBeenCalledTimes(2);
+  });
+
+  it("parses completed arguments for a late reader", async () => {
+    parsePartialJsonObjectCalls.mockClear();
+    const reader = createReader();
+
+    await reader.appendArgsTextDelta('{"required":"hello"}');
+    await reader.finishArgsText();
+    expect(parsePartialJsonObjectCalls).not.toHaveBeenCalled();
+
+    await expect(reader.args.get("required")).resolves.toBe("hello");
+    expect(parsePartialJsonObjectCalls).toHaveBeenCalledOnce();
+  });
+
+  it("stops parsing after a reader is cancelled", async () => {
+    parsePartialJsonObjectCalls.mockClear();
+    const reader = createReader();
+
+    await reader.appendArgsTextDelta('{"required":"hel');
+    const streamReader = reader.args.streamText("required").getReader();
+    expect(parsePartialJsonObjectCalls).toHaveBeenCalledOnce();
+
+    await streamReader.cancel();
+    parsePartialJsonObjectCalls.mockClear();
+    await reader.appendArgsTextDelta('lo"}');
+    await reader.finishArgsText();
+    expect(parsePartialJsonObjectCalls).not.toHaveBeenCalled();
+  });
+
+  it("does not emit stale values for an unparseable delta", async () => {
+    const reader = createReader();
+    const stream = reader.args.streamValues("required");
+
+    await reader.appendArgsTextDelta('{"required":"hi');
+    await reader.appendArgsTextDelta("\\uZZ");
+    await reader.finishArgsText();
+
+    const values: string[] = [];
+    for await (const value of stream) values.push(value ?? "");
+    expect(values).toEqual(["hi"]);
+  });
+});
 
 describe("ToolCallArgsReader.get", () => {
   it("waits for all digits of a positive exponent", async () => {

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.ts
@@ -31,6 +31,7 @@ function getField<T>(obj: T, fieldPath: (string | number)[]): unknown {
 }
 
 interface Handle {
+  readonly isDisposed: boolean;
   update(args: unknown): void;
   end(args: unknown): void;
   dispose(): void;
@@ -41,6 +42,10 @@ class GetHandle<T, TValue> implements Handle {
   private reject: (reason: unknown) => void;
   private disposed = false;
   private fieldPath: (string | number)[];
+
+  get isDisposed() {
+    return this.disposed;
+  }
 
   constructor(
     resolve: (value: TValue) => void,
@@ -98,6 +103,10 @@ class StreamValuesHandle<T> implements Handle {
   private disposed = false;
   private fieldPath: (string | number)[];
 
+  get isDisposed() {
+    return this.disposed;
+  }
+
   constructor(
     controller: ReadableStreamDefaultController<unknown>,
     fieldPath: (string | number)[],
@@ -148,6 +157,10 @@ class StreamTextHandle<T> implements Handle {
   private disposed = false;
   private fieldPath: (string | number)[];
   private lastValue: string | undefined = undefined;
+
+  get isDisposed() {
+    return this.disposed;
+  }
 
   constructor(
     controller: ReadableStreamDefaultController<unknown>,
@@ -201,6 +214,10 @@ class ForEachHandle<T> implements Handle {
   private disposed = false;
   private fieldPath: (string | number)[];
   private processedIndexes = new Set<number>();
+
+  get isDisposed() {
+    return this.disposed;
+  }
 
   constructor(
     controller: ReadableStreamDefaultController<unknown>,
@@ -269,7 +286,9 @@ export class ToolCallArgsReaderImpl<
 > implements ToolCallArgsReader<T> {
   private argTextDeltas: ReadableStream<string>;
   private handles: Set<Handle> = new Set();
-  private args: unknown = parsePartialJsonObject("");
+  private accumulatedText = "";
+  private parsedTextLength = -1;
+  private args: unknown = undefined;
   private finished = false;
 
   constructor(argTextDeltas: ReadableStream<string>) {
@@ -279,23 +298,16 @@ export class ToolCallArgsReaderImpl<
 
   private async processStream(): Promise<void> {
     try {
-      let accumulatedText = "";
       const reader = this.argTextDeltas.getReader();
 
       while (true) {
         const { value, done } = await reader.read();
         if (done) break;
 
-        accumulatedText += value;
-        const parsedArgs = parsePartialJsonObject(accumulatedText);
+        this.accumulatedText += value;
+        if (this.handles.size === 0) continue;
 
-        if (parsedArgs !== undefined) {
-          this.args = parsedArgs;
-          // Notify all handles of the updated args
-          for (const handle of this.handles) {
-            handle.update(parsedArgs);
-          }
-        }
+        if (this.parseCurrentArgs()) this.updateHandles();
       }
     } catch (error) {
       console.error("Error processing argument stream:", error);
@@ -308,6 +320,40 @@ export class ToolCallArgsReaderImpl<
     }
   }
 
+  private parseCurrentArgs(): boolean {
+    if (this.parsedTextLength === this.accumulatedText.length) return false;
+
+    const parsedArgs = parsePartialJsonObject(this.accumulatedText);
+    this.parsedTextLength = this.accumulatedText.length;
+    if (parsedArgs === undefined) {
+      this.args ??= parsePartialJsonObject("");
+      return false;
+    }
+
+    this.args = parsedArgs;
+    return true;
+  }
+
+  private updateHandles(): void {
+    for (const handle of this.handles) {
+      handle.update(this.args);
+      if (handle.isDisposed) this.handles.delete(handle);
+    }
+  }
+
+  private activateHandle(handle: Handle): void {
+    this.parseCurrentArgs();
+    handle.update(this.args);
+    if (handle.isDisposed) return;
+
+    if (this.finished) {
+      handle.end(this.args);
+      return;
+    }
+
+    this.handles.add(handle);
+  }
+
   get<PathT extends TypePath<T>>(
     ...fieldPath: PathT
   ): Promise<TypeAtPath<T, PathT>> {
@@ -317,29 +363,7 @@ export class ToolCallArgsReaderImpl<
         reject,
         fieldPath,
       );
-
-      // Check if the field is already complete in current args
-      if (
-        this.args &&
-        getPartialJsonObjectFieldState(
-          this.args as Record<string, unknown>,
-          fieldPath,
-        ) === "complete"
-      ) {
-        const value = getField(this.args as T, fieldPath);
-        if (value !== undefined) {
-          resolve(value as TypeAtPath<T, PathT>);
-          return;
-        }
-      }
-
-      if (this.finished) {
-        handle.end(this.args);
-        return;
-      }
-
-      this.handles.add(handle);
-      handle.update(this.args);
+      this.activateHandle(handle);
     });
   }
 
@@ -353,12 +377,7 @@ export class ToolCallArgsReaderImpl<
     const stream = new ReadableStream<DeepPartial<TypeAtPath<T, PathT>>>({
       start: (controller) => {
         handle = new StreamValuesHandle<T>(controller, simplePath);
-        if (!this.finished) this.handles.add(handle);
-
-        // Check current args immediately
-        handle.update(this.args);
-
-        if (this.finished) handle.end();
+        this.activateHandle(handle);
       },
       cancel: () => {
         // Dispose this stream's own handle (captured above) — scanning for the
@@ -385,12 +404,7 @@ export class ToolCallArgsReaderImpl<
     const stream = new ReadableStream<unknown>({
       start: (controller) => {
         handle = new StreamTextHandle<T>(controller, simplePath);
-        if (!this.finished) this.handles.add(handle);
-
-        // Check current args immediately
-        handle.update(this.args);
-
-        if (this.finished) handle.end();
+        this.activateHandle(handle);
       },
       cancel: () => {
         // Dispose this stream's own handle (captured above) — scanning for the
@@ -417,12 +431,7 @@ export class ToolCallArgsReaderImpl<
     const stream = new ReadableStream<unknown>({
       start: (controller) => {
         handle = new ForEachHandle<T>(controller, simplePath);
-        if (!this.finished) this.handles.add(handle);
-
-        // Check current args immediately
-        handle.update(this.args);
-
-        if (this.finished) handle.end();
+        this.activateHandle(handle);
       },
       cancel: () => {
         // Dispose this stream's own handle (captured above) — scanning for the

--- a/packages/x-performance/bench/tool-args.bench.ts
+++ b/packages/x-performance/bench/tool-args.bench.ts
@@ -1,0 +1,68 @@
+import { bench, describe } from "vitest";
+import {
+  unstable_toolResultStream,
+  type AssistantStreamChunk,
+} from "assistant-stream";
+
+const makeChunks = (
+  size: number,
+  chunkSize: number,
+): AssistantStreamChunk[] => {
+  const argsText = JSON.stringify({ value: "x".repeat(size) });
+  return [
+    {
+      type: "part-start",
+      path: [],
+      part: {
+        type: "tool-call",
+        toolCallId: "tool-call",
+        toolName: "noop",
+      },
+    },
+    ...Array.from(
+      { length: Math.ceil(argsText.length / chunkSize) },
+      (_, index): AssistantStreamChunk => ({
+        type: "text-delta",
+        path: [0],
+        textDelta: argsText.slice(index * chunkSize, (index + 1) * chunkSize),
+      }),
+    ),
+    { type: "tool-call-args-text-finish", path: [0] },
+    { type: "part-finish", path: [0] },
+  ];
+};
+
+const chunkSource = (chunks: AssistantStreamChunk[]) =>
+  new ReadableStream<AssistantStreamChunk>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+
+const drain = async (readable: ReadableStream<unknown>) => {
+  const reader = readable.getReader();
+  while (!(await reader.read()).done);
+};
+
+describe("assistant-stream: execute-only tool arguments (16-char deltas)", () => {
+  for (const size of [1000, 5000, 10000]) {
+    const chunks = makeChunks(size, 16);
+    bench(`${size} bytes`, async () => {
+      await drain(
+        chunkSource(chunks).pipeThrough(
+          unstable_toolResultStream(
+            {
+              noop: {
+                parameters: { type: "object" },
+                execute: () => null,
+              },
+            },
+            new AbortController().signal,
+            async () => {},
+          ),
+        ),
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Problem

`ToolCallArgsReaderImpl` reparses the full accumulated argument prefix after every text delta, including execute-only tools that never read partial arguments. The final execution path parses the completed JSON separately, so this repeated partial parsing adds work without producing an observable value.

With a 10 KB argument streamed in 16-character chunks, the public tool-result path took about 34 ms locally before this change. The cost grew faster than the argument size because every delta reparsed a larger prefix.

Fixes #7133.

## Root cause

The argument stream started processing immediately and called `parsePartialJsonObject` unconditionally for every delta. Reader handles that had already resolved also remained registered until the argument stream ended, keeping partial parsing active after the last consumer was done.

## Change

- Retain streamed argument text without parsing it when no partial reader is active.
- Parse the current buffer when the first reader registers, preserving readers created after earlier deltas or after completion.
- Remove resolved, closed, errored, and cancelled handles immediately so parsing stops when the final consumer settles.
- Preserve the final strict JSON parse used for frontend tool execution and malformed-argument errors.
- Add a public-path wall-time benchmark for execute-only tool arguments.

## Verification

- `pnpm -C packages/assistant-stream test`
  - 13 focused reader tests pass.
  - Full package suite passes against both supported peer versions.
  - The regression test observes zero partial parses when no reader is active; it fails before the fix.
  - Early, late, completed, settled, cancelled, and unparseable-delta reader behavior is covered.
- `pnpm -C packages/x-performance exec vitest bench --run bench/tool-args.bench.ts`
- `pnpm lint`
- `pnpm build` — 95/95 tasks passed.
- `pnpm changesets:check`
- `pnpm size:check`

Local median timings for the public execute-only path with 16-character deltas:

| Argument size | Before | After |
| --- | ---: | ---: |
| 5 KB | 11.19 ms | 3.12 ms |
| 10 KB | 34.15 ms | 4.78 ms |

## Public surface

- `assistant-stream`: internal argument-reader behavior only; no exports or types changed.
- `@assistant-ui/x-performance`: adds a private benchmark.
- Documentation: none.
- Templates: none.
- Changeset: patch for `assistant-stream`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-bU3sKqORMi6xWQCtI3WwmWVzDrGS3rN8ENpzS_iAlF0lsKt4oQpMZre7ec?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->