### PR TITLE
fix(react-ag-ui): avoid reparsing incomplete tool arguments

### DIFF
--- a/.changeset/quiet-tools-finish.md
+++ b/.changeset/quiet-tools-finish.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: avoid repeatedly parsing incomplete streamed tool arguments

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -87,6 +87,7 @@ type ToolCallState = {
   toolCallId: string;
   toolCallName: string;
   argsText: string;
+  argsTextScanner?: JSONContainerScanner | undefined;
   parsedArgs: Record<string, unknown> | undefined;
   result: unknown;
   isError: boolean | undefined;
@@ -97,6 +98,80 @@ type ToolCallState = {
   modelContent?: ToolModelContentPart[];
   snapshotResultApplied: boolean;
   subagentRunId?: string;
+};
+
+type JSONContainerScanner = {
+  state: "pending" | "open" | "complete" | "invalid";
+  stack: ("{" | "[")[];
+  inString: boolean;
+  escaped: boolean;
+};
+
+const createJSONContainerScanner = (): JSONContainerScanner => ({
+  state: "pending",
+  stack: [],
+  inString: false,
+  escaped: false,
+});
+
+const isJSONWhitespace = (char: string): boolean =>
+  char === " " || char === "\t" || char === "\n" || char === "\r";
+
+const scanJSONContainerDelta = (
+  scanner: JSONContainerScanner,
+  delta: string,
+): boolean => {
+  let completed = false;
+
+  for (const char of delta) {
+    if (scanner.state === "invalid") continue;
+    if (scanner.state === "complete") {
+      if (isJSONWhitespace(char)) continue;
+      scanner.state = "invalid";
+      continue;
+    }
+    if (scanner.state === "pending") {
+      if (isJSONWhitespace(char)) continue;
+      if (char !== "{" && char !== "[") {
+        scanner.state = "invalid";
+        continue;
+      }
+      scanner.state = "open";
+      scanner.stack.push(char);
+      continue;
+    }
+    if (scanner.inString) {
+      if (scanner.escaped) {
+        scanner.escaped = false;
+      } else if (char === "\\") {
+        scanner.escaped = true;
+      } else if (char === '"') {
+        scanner.inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      scanner.inString = true;
+      continue;
+    }
+    if (char === "{" || char === "[") {
+      scanner.stack.push(char);
+      continue;
+    }
+    if (char === "}" || char === "]") {
+      const expected = char === "}" ? "{" : "[";
+      if (scanner.stack.pop() !== expected) {
+        scanner.state = "invalid";
+        continue;
+      }
+      if (scanner.stack.length === 0) {
+        scanner.state = "complete";
+        completed = true;
+      }
+    }
+  }
+
+  return completed && scanner.state === "complete";
 };
 
 export const MCP_APPS_ACTIVITY_TYPE = "mcp-apps";
@@ -816,7 +891,18 @@ export class RunAggregator {
   private appendToolArgs(id: string | undefined, delta: string) {
     const entry = id ? this.toolCalls.get(id) : undefined;
     if (!entry) return;
+    if (!entry.argsTextScanner) {
+      entry.argsTextScanner = createJSONContainerScanner();
+      scanJSONContainerDelta(entry.argsTextScanner, entry.argsText);
+    }
     entry.argsText += delta;
+    const shouldParse = scanJSONContainerDelta(entry.argsTextScanner, delta);
+    if (!shouldParse) {
+      if (entry.argsTextScanner.state === "invalid") {
+        entry.parsedArgs = undefined;
+      }
+      return;
+    }
     try {
       const parsed = JSON.parse(entry.argsText);
       if (parsed && typeof parsed === "object") {

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -893,7 +893,6 @@ export class RunAggregator {
     if (!entry) return;
     if (!entry.argsTextScanner) {
       entry.argsTextScanner = createJSONContainerScanner();
-      scanJSONContainerDelta(entry.argsTextScanner, entry.argsText);
     }
     entry.argsText += delta;
     const shouldParse = scanJSONContainerDelta(entry.argsTextScanner, delta);

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -1882,6 +1882,56 @@ describe("RunAggregator", () => {
     expect(toolPart.args).toEqual({ query: "pizza" });
   });
 
+  it("parses accumulated tool args only when the JSON container closes", () => {
+    const aggregator = createAggregator(false);
+    const args = {
+      query: `brace } quote " slash \\ ${"x".repeat(512)}`,
+      nested: { values: [1, 2, 3] },
+    };
+    const argsText = JSON.stringify(args);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "search",
+    } as AgUiEvent);
+
+    const parse = vi.spyOn(JSON, "parse");
+    try {
+      for (const delta of argsText.slice(0, -1)) {
+        aggregator.handle({
+          type: "TOOL_CALL_ARGS",
+          toolCallId: "tool1",
+          delta,
+        } as AgUiEvent);
+      }
+      expect(parse).not.toHaveBeenCalled();
+
+      aggregator.handle({
+        type: "TOOL_CALL_ARGS",
+        toolCallId: "tool1",
+        delta: argsText.at(-1)!,
+      } as AgUiEvent);
+      aggregator.handle({
+        type: "TOOL_CALL_ARGS",
+        toolCallId: "tool1",
+        delta: " \n",
+      } as AgUiEvent);
+
+      expect(parse).toHaveBeenCalledTimes(1);
+      const toolPart = results
+        .at(-1)
+        ?.content?.find((part) => part.type === "tool-call");
+      expect(toolPart).toMatchObject({
+        args,
+        argsText: `${argsText} \n`,
+      });
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
   it("positions reasoning content before text when thinking is shown", () => {
     const aggregator = createAggregator(true);
 

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -53,8 +53,8 @@
   },
   "@assistant-ui/react-ag-ui": {
     ".": {
-      "min": 74627,
-      "gzip": 19567
+      "min": 76589,
+      "gzip": 20144
     }
   },
   "@assistant-ui/react-ai-sdk": {


### PR DESCRIPTION
## Problem

In `@assistant-ui/react-ag-ui` 0.0.58, every `TOOL_CALL_ARGS` delta attempts to parse the full accumulated argument string. A tool call streamed one character at a time therefore repeats `JSON.parse` for every incomplete prefix, and the work grows with both the number of chunks and the argument size.

A minimal reproduction is a `TOOL_CALL_START` followed by character-sized `TOOL_CALL_ARGS` events containing a nested JSON object. Before this change, parsing is attempted for every event; only the final attempt can succeed.

## Root cause

`RunAggregator.appendToolArgs` appended each delta and unconditionally called `JSON.parse` on the entire accumulated string. It had no incremental knowledge of whether the top-level JSON container had closed.

## Change

Track the JSON container boundary while deltas arrive, including nested objects and arrays, string escapes, and braces inside strings. The aggregator now parses the accumulated value once, when the root container closes, while preserving the existing behavior that parsed arguments become available as soon as the complete JSON arrives. `argsText` continues to contain the exact streamed text.

The regression test streams a nested argument object one character at a time and asserts that `JSON.parse` is called exactly once.

## Verification

- `pnpm exec vitest run test/run-aggregator.spec.ts` — 115 tests passed
- `pnpm exec oxlint src/runtime/adapter/run-aggregator.ts test/run-aggregator.spec.ts`
- `pnpm --filter @assistant-ui/react-ag-ui build`
- `pnpm size:check`
- `pnpm changesets:check`
- `pnpm exec oxfmt --check packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts packages/react-ag-ui/test/run-aggregator.spec.ts .changeset/quiet-tools-finish.md`

The package-wide suite currently has one unrelated failure in `useAgUiRuntime.toolDeferral.test.tsx`; the same failure reproduces on the untouched `main` commit used as this branch's base.

## Public surface

- Published package: `@assistant-ui/react-ag-ui` (patch changeset)
- Size budget: updated for the incremental scanner
- Exports: none
- Documentation, API-reference output, and templates: none

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.JvKrAL9NIEBKwjRf8Qc6OiNzaJo_AL4JdVJZuXnXEoMCKf17oNgTf1coaWw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->