### PR TITLE
fix(react-langgraph): avoid repeated tool-call chunk scans

### DIFF
--- a/.changeset/fast-tools-match.md
+++ b/.changeset/fast-tools-match.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: index streamed tool-call chunks before matching completed calls

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1327,6 +1327,52 @@ describe("convertLangChainMessages tool call id stability", () => {
 
     expect(readId).toHaveBeenCalledTimes(toolCallCount);
   });
+
+  it("does not index chunks when there are no completed tool calls", () => {
+    const readId = vi.fn();
+
+    convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_call_chunks: [
+        {
+          index: 0,
+          name: "search",
+          args: '{"query":"weather"}',
+          get id() {
+            readId();
+            return "tool-1";
+          },
+        },
+      ],
+    });
+
+    expect(readId).not.toHaveBeenCalled();
+  });
+
+  it("does not match tool-call chunks with NaN indices", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [
+        { id: "", name: "search", args: { source: "tool-call" }, index: NaN },
+      ],
+      tool_call_chunks: [
+        {
+          id: "",
+          index: NaN,
+          name: "search",
+          args: '{"source":"tool-call-chunk"}',
+        },
+      ],
+    });
+
+    expect(result.content.find((part) => part.type === "tool-call")).toEqual(
+      expect.objectContaining({ argsText: '{"source":"tool-call"}' }),
+    );
+  });
 });
 
 describe("getMessageContent audio and data parts", () => {

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1273,6 +1273,60 @@ describe("convertLangChainMessages tool call id stability", () => {
       argsText: '{"url":"https://example.com"}',
     });
   });
+
+  it("uses the first tool_call_chunk for duplicate ids and indices", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [
+        { id: "tool-1", name: "by_id", args: {} },
+        { id: "", name: "by_index", args: {}, index: 1 },
+      ],
+      tool_call_chunks: [
+        { id: "tool-1", index: 7, name: "by_id", args: '{"match":1}' },
+        { id: "tool-1", index: 8, name: "by_id", args: '{"match":2}' },
+        { id: "", index: 1, name: "by_index", args: '{"match":3}' },
+        { id: "", index: 1, name: "by_index", args: '{"match":4}' },
+      ],
+    });
+
+    expect(result.content.filter((part) => part.type === "tool-call")).toEqual([
+      expect.objectContaining({ argsText: '{"match":1}' }),
+      expect.objectContaining({ argsText: '{"match":3}' }),
+    ]);
+  });
+
+  it("reads each streamed tool-call identity once", () => {
+    const toolCallCount = 100;
+    const readId = vi.fn();
+    const toolCallChunks = Array.from(
+      { length: toolCallCount },
+      (_, index) => ({
+        index,
+        name: "search",
+        args: `{"index":${index}}`,
+        get id() {
+          readId();
+          return `tool-${index}`;
+        },
+      }),
+    );
+
+    convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: Array.from({ length: toolCallCount }, (_, index) => ({
+        id: `tool-${index}`,
+        name: "search",
+        args: {},
+      })),
+      tool_call_chunks: toolCallChunks,
+    });
+
+    expect(readId).toHaveBeenCalledTimes(toolCallCount);
+  });
 });
 
 describe("getMessageContent audio and data parts", () => {

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -235,13 +235,15 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
     case "ai": {
       const toolCallChunksById = new Map<string, LangChainToolCallChunk>();
       const toolCallChunksByIndex = new Map<number, LangChainToolCallChunk>();
-      for (const toolCallChunk of message.tool_call_chunks ?? []) {
-        const { id, index } = toolCallChunk;
-        if (!toolCallChunksById.has(id)) {
-          toolCallChunksById.set(id, toolCallChunk);
-        }
-        if (!toolCallChunksByIndex.has(index)) {
-          toolCallChunksByIndex.set(index, toolCallChunk);
+      if (message.tool_calls?.length) {
+        for (const toolCallChunk of message.tool_call_chunks ?? []) {
+          const { id, index } = toolCallChunk;
+          if (!toolCallChunksById.has(id)) {
+            toolCallChunksById.set(id, toolCallChunk);
+          }
+          if (!Number.isNaN(index) && !toolCallChunksByIndex.has(index)) {
+            toolCallChunksByIndex.set(index, toolCallChunk);
+          }
         }
       }
 

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -233,15 +233,27 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
       };
     }
     case "ai": {
+      const toolCallChunksById = new Map<string, LangChainToolCallChunk>();
+      const toolCallChunksByIndex = new Map<number, LangChainToolCallChunk>();
+      for (const toolCallChunk of message.tool_call_chunks ?? []) {
+        const { id, index } = toolCallChunk;
+        if (!toolCallChunksById.has(id)) {
+          toolCallChunksById.set(id, toolCallChunk);
+        }
+        if (!toolCallChunksByIndex.has(index)) {
+          toolCallChunksByIndex.set(index, toolCallChunk);
+        }
+      }
+
       const toolCallParts =
         message.tool_calls?.map((chunk, idx): ToolCallMessagePart => {
           const fallbackIndex = chunk.index ?? idx;
           const toolCallId = chunk.id
             ? chunk.id
             : `lc-toolcall-${message.id ?? "unknown"}-${fallbackIndex}`;
-          const matchingToolCallChunk = message.tool_call_chunks?.find((c) =>
-            chunk.id ? c.id === chunk.id : c.index === fallbackIndex,
-          );
+          const matchingToolCallChunk = chunk.id
+            ? toolCallChunksById.get(chunk.id)
+            : toolCallChunksByIndex.get(fallbackIndex);
           const { args, argsText } = resolveToolCallArgs({
             chunk,
             matchingToolCallChunk,


### PR DESCRIPTION
## Problem

In `@assistant-ui/react-langgraph` 0.14.26, converting an AI message with many tool calls repeatedly scans `tool_call_chunks` from the beginning for every completed call. With tool calls ordered opposite their streamed chunks, this performs a quadratic number of identity comparisons.

A local reproduction with generated tool calls measured median conversion time at about 2.56 ms for 1,000 calls and 49.1 ms for 5,000 calls on the base commit.

## Root cause

Each entry in `message.tool_calls` used `message.tool_call_chunks.find(...)` to locate its streamed arguments. Matching `n` calls against `n` chunks therefore required up to `n²` chunk visits.

## Change

When completed tool calls are present, build first-match indexes for chunk IDs and indices once per AI message, then resolve each tool call through a constant-time lookup. The indexes deliberately keep the first entry for duplicate IDs or indices, matching the previous `Array.find` behavior. Chunk-only messages skip indexing, and malformed `NaN` indices remain unmatched to preserve strict-equality semantics.

The regression tests verify that 100 streamed chunk identities are each read exactly once, chunk-only messages perform no identity reads, duplicate matches keep the first chunk, and `NaN` indices do not match.

With the same local reproduction after the change, median conversion time was about 0.66 ms for 1,000 calls and 2.76 ms for 5,000 calls.

## Verification

- `pnpm --filter @assistant-ui/react-langgraph test` — 322 tests passed
- `pnpm --filter @assistant-ui/react-langgraph build`
- `pnpm exec oxlint packages/react-langgraph/src/convertLangChainMessages.ts packages/react-langgraph/src/convertLangChainMessages.test.ts`
- `pnpm exec oxfmt --check packages/react-langgraph/src/convertLangChainMessages.ts packages/react-langgraph/src/convertLangChainMessages.test.ts .changeset/fast-tools-match.md`
- `pnpm changesets:check`

## Public surface

- Published package: `@assistant-ui/react-langgraph` (patch changeset)
- Exports: none
- Documentation, API-reference output, and templates: none

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.KwJAu_RSWT3yrhAa1ywPAbCJeZ7vTwhBRjXHEN_HiabaV9Fcr2MUj_zAVFw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->