### PR TITLE
fix(cloud-ai-sdk): cancel telemetry streams with chat runs

### DIFF
--- a/.changeset/quiet-cloud-streams.md
+++ b/.changeset/quiet-cloud-streams.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: propagate chat cancellation through telemetry stream observation

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -218,6 +218,25 @@ describe("CloudChatCore", () => {
     );
   });
 
+  it("cancels the transport stream while waiting for the first token", async () => {
+    const cancel = vi.fn();
+    const source = new ReadableStream({ cancel });
+    const sendMessages = vi.fn().mockResolvedValue(source);
+    const core = createCore({
+      baseTransport: { sendMessages, reconnectToStream: vi.fn() },
+    });
+    vi.spyOn(core, "ensureThreadId").mockResolvedValue("thread-1");
+    vi.spyOn(core, "persist").mockResolvedValue(undefined);
+
+    const stream = await core
+      .createTransport("chat-1", registry)
+      .sendMessages({ messages: [] } as never);
+    const reason = new Error("stopped");
+    await stream.cancel(reason);
+
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
   it("reports message_sent for a user submission only", async () => {
     const sendMessages = vi.fn(() => Promise.resolve(new ReadableStream()));
     const core = createCore({

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -195,6 +195,7 @@ describe("CloudChatCore", () => {
     controller!.enqueue({ type: "text-delta", id: "part-1", delta: "hi" });
     controller!.close();
     await new Promise((resolve) => setTimeout(resolve, 0));
+    clock = 150;
     await stream.pipeTo(new WritableStream());
     expect(source.locked).toBe(false);
     clock = 180;

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -272,6 +272,30 @@ describe("CloudChatCore", () => {
     expect(source.locked).toBe(false);
   });
 
+  it("forwards transport stream errors and releases the source reader", async () => {
+    let controller: ReadableStreamDefaultController | undefined;
+    const source = new ReadableStream({
+      start(sourceController) {
+        controller = sourceController;
+      },
+    });
+    const sendMessages = vi.fn().mockResolvedValue(source);
+    const core = createCore({
+      baseTransport: { sendMessages, reconnectToStream: vi.fn() },
+    });
+    vi.spyOn(core, "ensureThreadId").mockResolvedValue("thread-1");
+    vi.spyOn(core, "persist").mockResolvedValue(undefined);
+
+    const stream = await core
+      .createTransport("chat-1", registry)
+      .sendMessages({ messages: [] } as never);
+    const error = new Error("stream failed");
+    controller!.error(error);
+
+    await expect(stream.getReader().read()).rejects.toBe(error);
+    expect(source.locked).toBe(false);
+  });
+
   it("reports message_sent for a user submission only", async () => {
     const sendMessages = vi.fn(() => Promise.resolve(new ReadableStream()));
     const core = createCore({

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -194,7 +194,7 @@ describe("CloudChatCore", () => {
     controller!.enqueue({ type: "text-start", id: "part-1" });
     controller!.enqueue({ type: "text-delta", id: "part-1", delta: "hi" });
     controller!.close();
-    await stream.getReader().read();
+    await stream.pipeTo(new WritableStream());
     await new Promise((resolve) => setTimeout(resolve, 0));
     clock = 180;
     const onFinish = chatOptionsRef.current?.onFinish as (
@@ -235,6 +235,7 @@ describe("CloudChatCore", () => {
     await stream.cancel(reason);
 
     expect(cancel).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledWith(reason);
   });
 
   it("reports message_sent for a user submission only", async () => {

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -296,6 +296,28 @@ describe("CloudChatCore", () => {
     expect(source.locked).toBe(false);
   });
 
+  it("allows cancellation after a tokenless source has closed", async () => {
+    const source = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: "text-start", id: "part-1" });
+        controller.close();
+      },
+    });
+    const sendMessages = vi.fn().mockResolvedValue(source);
+    const core = createCore({
+      baseTransport: { sendMessages, reconnectToStream: vi.fn() },
+    });
+    vi.spyOn(core, "ensureThreadId").mockResolvedValue("thread-1");
+    vi.spyOn(core, "persist").mockResolvedValue(undefined);
+
+    const stream = await core
+      .createTransport("chat-1", registry)
+      .sendMessages({ messages: [] } as never);
+    await vi.waitFor(() => expect(source.locked).toBe(false));
+
+    await expect(stream.cancel(new Error("stopped"))).resolves.toBeUndefined();
+  });
+
   it("reports message_sent for a user submission only", async () => {
     const sendMessages = vi.fn(() => Promise.resolve(new ReadableStream()));
     const core = createCore({

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -194,8 +194,9 @@ describe("CloudChatCore", () => {
     controller!.enqueue({ type: "text-start", id: "part-1" });
     controller!.enqueue({ type: "text-delta", id: "part-1", delta: "hi" });
     controller!.close();
-    await stream.pipeTo(new WritableStream());
     await new Promise((resolve) => setTimeout(resolve, 0));
+    await stream.pipeTo(new WritableStream());
+    expect(source.locked).toBe(false);
     clock = 180;
     const onFinish = chatOptionsRef.current?.onFinish as (
       event: unknown,
@@ -232,10 +233,42 @@ describe("CloudChatCore", () => {
       .createTransport("chat-1", registry)
       .sendMessages({ messages: [] } as never);
     const reason = new Error("stopped");
+    const cancellation = stream.cancel(reason);
+
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce(), {
+      timeout: 250,
+    });
+    await cancellation;
+    expect(cancel).toHaveBeenCalledWith(reason);
+    expect(source.locked).toBe(false);
+  });
+
+  it("cancels the transport stream after observing the first token", async () => {
+    let controller: ReadableStreamDefaultController | undefined;
+    const cancel = vi.fn();
+    const source = new ReadableStream({
+      start(sourceController) {
+        controller = sourceController;
+      },
+      cancel,
+    });
+    const sendMessages = vi.fn().mockResolvedValue(source);
+    const core = createCore({
+      baseTransport: { sendMessages, reconnectToStream: vi.fn() },
+    });
+    vi.spyOn(core, "ensureThreadId").mockResolvedValue("thread-1");
+    vi.spyOn(core, "persist").mockResolvedValue(undefined);
+
+    const stream = await core
+      .createTransport("chat-1", registry)
+      .sendMessages({ messages: [] } as never);
+    controller!.enqueue({ type: "text-delta", id: "part-1", delta: "hi" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const reason = new Error("stopped");
     await stream.cancel(reason);
 
-    expect(cancel).toHaveBeenCalledOnce();
     expect(cancel).toHaveBeenCalledWith(reason);
+    expect(source.locked).toBe(false);
   });
 
   it("reports message_sent for a user submission only", async () => {

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -318,19 +318,70 @@ export class CloudChatCore {
     stream: ReadableStream<UIMessageChunk>,
     timing: ActiveTelemetryTiming,
   ): ReadableStream<UIMessageChunk> {
-    return stream.pipeThrough(
-      new TransformStream<UIMessageChunk, UIMessageChunk>({
-        transform(chunk, controller) {
-          if (
-            timing.firstTokenMs === undefined &&
-            (chunk.type === "text-delta" || chunk.type === "reasoning-delta")
-          ) {
-            timing.firstTokenMs = Date.now() - timing.startedAt;
-          }
-          controller.enqueue(chunk);
-        },
-      }),
-    );
+    const reader = stream.getReader();
+    let observeFirstToken = timing.firstTokenMs === undefined;
+    let cancelled = false;
+    let readerReleased = false;
+    let eagerRead: Promise<void> | undefined;
+
+    const releaseReader = () => {
+      if (readerReleased) return;
+      readerReleased = true;
+      reader.releaseLock();
+    };
+    const forwardNext = async (
+      controller: ReadableStreamDefaultController<UIMessageChunk>,
+    ) => {
+      try {
+        const { done, value } = await reader.read();
+        if (cancelled) return false;
+        if (done) {
+          releaseReader();
+          controller.close();
+          return false;
+        }
+        if (
+          observeFirstToken &&
+          (value.type === "text-delta" || value.type === "reasoning-delta")
+        ) {
+          timing.firstTokenMs = Date.now() - timing.startedAt;
+          observeFirstToken = false;
+        }
+        controller.enqueue(value);
+        return true;
+      } catch (error) {
+        releaseReader();
+        if (!cancelled) controller.error(error);
+        return false;
+      }
+    };
+    const readUntilFirstToken = async (
+      controller: ReadableStreamDefaultController<UIMessageChunk>,
+    ) => {
+      while (observeFirstToken && (await forwardNext(controller))) {}
+    };
+
+    return new ReadableStream<UIMessageChunk>({
+      start(controller) {
+        eagerRead = readUntilFirstToken(controller);
+      },
+      async pull(controller) {
+        if (eagerRead) {
+          await eagerRead;
+          eagerRead = undefined;
+        } else {
+          await forwardNext(controller);
+        }
+      },
+      async cancel(reason) {
+        cancelled = true;
+        try {
+          await reader.cancel(reason);
+        } finally {
+          releaseReader();
+        }
+      },
+    });
   }
 
   private handleSyncError(err: unknown): void {

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -319,10 +319,21 @@ export class CloudChatCore {
     timing: ActiveTelemetryTiming,
   ): ReadableStream<UIMessageChunk> {
     const [chatStream, timingStream] = stream.tee();
-    const reader = timingStream.getReader();
+    const timingReader = timingStream.getReader();
+    let timingCleanup: Promise<void> | undefined;
+    const stopTiming = (reason?: unknown) => {
+      timingCleanup ??= (async () => {
+        try {
+          await timingReader.cancel(reason);
+        } finally {
+          timingReader.releaseLock();
+        }
+      })();
+      return timingCleanup;
+    };
     const readUntilFirstToken = async () => {
       while (true) {
-        const { done, value } = await reader.read();
+        const { done, value } = await timingReader.read();
         if (done) return;
         if (value.type === "text-delta" || value.type === "reasoning-delta") {
           timing.firstTokenMs = Date.now() - timing.startedAt;
@@ -332,8 +343,46 @@ export class CloudChatCore {
     };
     void readUntilFirstToken()
       .catch(() => {})
-      .finally(() => reader.cancel().catch(() => {}));
-    return chatStream;
+      .finally(() => stopTiming().catch(() => {}));
+
+    const chatReader = chatStream.getReader();
+    let chatCleanup: Promise<void> | undefined;
+    let chatReaderReleased = false;
+    const releaseChatReader = () => {
+      if (chatReaderReleased) return;
+      chatReaderReleased = true;
+      chatReader.releaseLock();
+    };
+    const stopChat = (reason?: unknown) => {
+      chatCleanup ??= (async () => {
+        try {
+          await chatReader.cancel(reason);
+        } finally {
+          releaseChatReader();
+        }
+      })();
+      return chatCleanup;
+    };
+
+    return new ReadableStream<UIMessageChunk>({
+      async pull(controller) {
+        try {
+          const { done, value } = await chatReader.read();
+          if (done) {
+            releaseChatReader();
+            controller.close();
+          } else {
+            controller.enqueue(value);
+          }
+        } catch (error) {
+          releaseChatReader();
+          controller.error(error);
+        }
+      },
+      async cancel(reason) {
+        await Promise.all([stopChat(reason), stopTiming(reason)]);
+      },
+    });
   }
 
   private handleSyncError(err: unknown): void {

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -318,6 +318,7 @@ export class CloudChatCore {
     stream: ReadableStream<UIMessageChunk>,
     timing: ActiveTelemetryTiming,
   ): ReadableStream<UIMessageChunk> {
+    // Read eagerly until the first token so its timing reflects arrival rather than downstream consumption.
     const reader = stream.getReader();
     let observeFirstToken = timing.firstTokenMs === undefined;
     let cancelled = false;
@@ -376,7 +377,9 @@ export class CloudChatCore {
       async cancel(reason) {
         cancelled = true;
         try {
-          await reader.cancel(reason);
+          if (!readerReleased) {
+            await reader.cancel(reason);
+          }
         } finally {
           releaseReader();
         }

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -318,71 +318,19 @@ export class CloudChatCore {
     stream: ReadableStream<UIMessageChunk>,
     timing: ActiveTelemetryTiming,
   ): ReadableStream<UIMessageChunk> {
-    const [chatStream, timingStream] = stream.tee();
-    const timingReader = timingStream.getReader();
-    let timingCleanup: Promise<void> | undefined;
-    const stopTiming = (reason?: unknown) => {
-      timingCleanup ??= (async () => {
-        try {
-          await timingReader.cancel(reason);
-        } finally {
-          timingReader.releaseLock();
-        }
-      })();
-      return timingCleanup;
-    };
-    const readUntilFirstToken = async () => {
-      while (true) {
-        const { done, value } = await timingReader.read();
-        if (done) return;
-        if (value.type === "text-delta" || value.type === "reasoning-delta") {
-          timing.firstTokenMs = Date.now() - timing.startedAt;
-          return;
-        }
-      }
-    };
-    void readUntilFirstToken()
-      .catch(() => {})
-      .finally(() => stopTiming().catch(() => {}));
-
-    const chatReader = chatStream.getReader();
-    let chatCleanup: Promise<void> | undefined;
-    let chatReaderReleased = false;
-    const releaseChatReader = () => {
-      if (chatReaderReleased) return;
-      chatReaderReleased = true;
-      chatReader.releaseLock();
-    };
-    const stopChat = (reason?: unknown) => {
-      chatCleanup ??= (async () => {
-        try {
-          await chatReader.cancel(reason);
-        } finally {
-          releaseChatReader();
-        }
-      })();
-      return chatCleanup;
-    };
-
-    return new ReadableStream<UIMessageChunk>({
-      async pull(controller) {
-        try {
-          const { done, value } = await chatReader.read();
-          if (done) {
-            releaseChatReader();
-            controller.close();
-          } else {
-            controller.enqueue(value);
+    return stream.pipeThrough(
+      new TransformStream<UIMessageChunk, UIMessageChunk>({
+        transform(chunk, controller) {
+          if (
+            timing.firstTokenMs === undefined &&
+            (chunk.type === "text-delta" || chunk.type === "reasoning-delta")
+          ) {
+            timing.firstTokenMs = Date.now() - timing.startedAt;
           }
-        } catch (error) {
-          releaseChatReader();
-          controller.error(error);
-        }
-      },
-      async cancel(reason) {
-        await Promise.all([stopChat(reason), stopTiming(reason)]);
-      },
-    });
+          controller.enqueue(chunk);
+        },
+      }),
+    );
   }
 
   private handleSyncError(err: unknown): void {


### PR DESCRIPTION
## Problem

Cancelling a Cloud chat before its first token did not cancel the response stream for custom transports that rely on stream cancellation. The transport stream was split for telemetry, but cancellation only reached the branch returned to the chat runtime, leaving the telemetry branch waiting for a token.

## Root cause

`observeTelemetryStream()` returned one side of a `ReadableStream.tee()` while consuming the other side in the background. A tee source is cancelled only after both branches are cancelled, so cancelling the chat branch alone never propagated to the source.

## Change

Forward chunks through one owned source reader. It reads eagerly only until the first token to preserve arrival-time telemetry, then follows downstream backpressure. Cancellation now reaches the source with the caller's original reason, and every completion path releases the reader lock.

## Verification

- Added a bounded pre-token cancellation regression that hangs before this change and confirms the original reason reaches the source after it.
- Added post-token cancellation and source-error forwarding coverage.
- Extended the telemetry completion test to pin eager first-token timing and source lock release.
- `pnpm -C packages/cloud-ai-sdk test`: 134 tests passed.
- `aui-build` for `@assistant-ui/cloud-ai-sdk` passed.
- Focused oxlint and changeset validation passed.

## Public surface

`@assistant-ui/cloud-ai-sdk` runtime behavior only. No exports or API signatures changed. Includes a patch changeset.
