### PR TITLE
fix(react-generative-ui): tolerate malformed text props

### DIFF
--- a/.changeset/calm-text-values.md
+++ b/.changeset/calm-text-values.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: tolerate malformed text properties while rendering generated UI

--- a/packages/react-generative-ui/src/vocabulary/alert.test.tsx
+++ b/packages/react-generative-ui/src/vocabulary/alert.test.tsx
@@ -26,6 +26,16 @@ describe("alertVocabulary", () => {
     ).toContain('data-aui-tone="danger"');
   });
 
+  it("Alert ignores malformed text properties", () => {
+    expect(
+      render({
+        $type: "Alert",
+        title: { unexpected: true },
+        description: { unexpected: true },
+      }),
+    ).toBe('<div data-aui="alert" data-aui-tone="info" role="alert"></div>');
+  });
+
   it("Carousel wraps each child Card in a slide, capped at 10", () => {
     const children = Array.from({ length: 12 }, (_, i) => ({
       $type: "Card",

--- a/packages/react-generative-ui/src/vocabulary/alert.tsx
+++ b/packages/react-generative-ui/src/vocabulary/alert.tsx
@@ -2,6 +2,7 @@ import { Children } from "react";
 import { z } from "zod";
 import type { GenerativeUILibrary } from "../types";
 import { ALERT_TONES } from "../ir";
+import { toTextContent } from "./toTextContent";
 
 const MAX_CARDS = 10;
 
@@ -20,13 +21,21 @@ export const alertVocabulary = {
         .optional()
         .describe("Severity tone; defaults to `info`."),
     }),
-    render: ({ title, description, tone, children }) => (
-      <div data-aui="alert" data-aui-tone={tone ?? "info"} role="alert">
-        {title ? <header data-aui="alert-title">{title}</header> : null}
-        {description ? <p data-aui="alert-desc">{description}</p> : null}
-        {children}
-      </div>
-    ),
+    render: ({ title, description, tone, children }) => {
+      const alertTitle = toTextContent(title);
+      const alertDescription = toTextContent(description);
+      return (
+        <div data-aui="alert" data-aui-tone={tone ?? "info"} role="alert">
+          {alertTitle ? (
+            <header data-aui="alert-title">{alertTitle}</header>
+          ) : null}
+          {alertDescription ? (
+            <p data-aui="alert-desc">{alertDescription}</p>
+          ) : null}
+          {children}
+        </div>
+      );
+    },
   },
   Carousel: {
     description:

--- a/packages/react-generative-ui/src/vocabulary/data.test.tsx
+++ b/packages/react-generative-ui/src/vocabulary/data.test.tsx
@@ -78,6 +78,20 @@ describe("dataVocabulary", () => {
     ).toBe('<div data-aui="markdown">partial</div>');
   });
 
+  it("Markdown ignores malformed streaming values", () => {
+    expect(
+      renderToStaticMarkup(
+        <>
+          {renderGenerativeUI(
+            { $type: "Markdown", value: { unexpected: true } },
+            dataVocabulary,
+            { status: "streaming" },
+          )}
+        </>,
+      ),
+    ).toBe('<div data-aui="markdown"></div>');
+  });
+
   it("Chart bar variant renders one rect per data point", () => {
     const html = render({
       $type: "Chart",

--- a/packages/react-generative-ui/src/vocabulary/data.tsx
+++ b/packages/react-generative-ui/src/vocabulary/data.tsx
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { GenerativeUILibrary } from "../types";
+import { toTextContent } from "./toTextContent";
 
 const columnSchema = z.object({
   label: z.string().describe("Column header label."),
@@ -339,7 +340,7 @@ export const dataVocabulary = {
     streamProperties: true,
     render: ({ value, children }) => (
       <div data-aui="markdown">
-        {value}
+        {toTextContent(value)}
         {children}
       </div>
     ),

--- a/packages/react-generative-ui/src/vocabulary/fact.test.tsx
+++ b/packages/react-generative-ui/src/vocabulary/fact.test.tsx
@@ -12,4 +12,16 @@ describe("factVocabulary", () => {
       '<dl data-aui="fact"><dt data-aui="fact-label">Status</dt><dd data-aui="fact-value">open</dd></dl>',
     );
   });
+
+  it("Fact ignores malformed text properties", () => {
+    expect(
+      render({
+        $type: "Fact",
+        label: { unexpected: true },
+        value: { unexpected: true },
+      }),
+    ).toBe(
+      '<dl data-aui="fact"><dt data-aui="fact-label"></dt><dd data-aui="fact-value"></dd></dl>',
+    );
+  });
 });

--- a/packages/react-generative-ui/src/vocabulary/fact.tsx
+++ b/packages/react-generative-ui/src/vocabulary/fact.tsx
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { GenerativeUILibrary } from "../types";
+import { toTextContent } from "./toTextContent";
 
 export const factVocabulary = {
   Fact: {
@@ -11,9 +12,9 @@ export const factVocabulary = {
     }),
     render: ({ label, value, children }) => (
       <dl data-aui="fact">
-        <dt data-aui="fact-label">{label}</dt>
+        <dt data-aui="fact-label">{toTextContent(label)}</dt>
         <dd data-aui="fact-value">
-          {value}
+          {toTextContent(value)}
           {children}
         </dd>
       </dl>

--- a/packages/react-generative-ui/src/vocabulary/interactive.test.tsx
+++ b/packages/react-generative-ui/src/vocabulary/interactive.test.tsx
@@ -177,6 +177,27 @@ describe("interactiveVocabulary", () => {
     expect(html).toContain('checked=""');
   });
 
+  it.each([
+    [
+      { $type: "Button", label: { unexpected: true } },
+      '<button type="button" data-aui="button"></button>',
+    ],
+    [
+      {
+        $type: "Select",
+        placeholder: { unexpected: true },
+        options: [],
+      },
+      '<select data-aui="select"></select>',
+    ],
+    [
+      { $type: "Checkbox", label: { unexpected: true } },
+      '<label data-aui="checkbox"><input type="checkbox"/><span data-aui="checkbox-label"></span></label>',
+    ],
+  ])("ignores malformed control text properties", (node, expected) => {
+    expect(render(node)).toBe(expected);
+  });
+
   it("RadioGroup renders a fieldset with one radio per option", () => {
     const html = render({
       $type: "RadioGroup",

--- a/packages/react-generative-ui/src/vocabulary/interactive.tsx
+++ b/packages/react-generative-ui/src/vocabulary/interactive.tsx
@@ -4,6 +4,7 @@ import type { Action } from "../ir";
 import { BUTTON_STYLES } from "../ir";
 import type { GenerativeUIDispatch, GenerativeUILibrary } from "../types";
 import { actionAttr, fire } from "./dispatch";
+import { toTextContent } from "./toTextContent";
 
 const optionSchema = z.object({
   label: z.string(),
@@ -100,7 +101,7 @@ export const interactiveVocabulary = {
         data-aui-action={actionAttr($action)}
         onClick={submit ? undefined : () => fire($action, $dispatch)}
       >
-        {label}
+        {toTextContent(label)}
         {children}
       </button>
     ),
@@ -128,30 +129,33 @@ export const interactiveVocabulary = {
       $action,
       $dispatch,
       children,
-    }) => (
-      <select
-        data-aui="select"
-        data-aui-action={actionAttr($action)}
-        name={name}
-        aria-label={label}
-        defaultValue=""
-        onChange={(e) => fire($action, $dispatch, e.currentTarget.value)}
-      >
-        {placeholder ? (
-          <option value="" disabled>
-            {placeholder}
-          </option>
-        ) : null}
-        {(Array.isArray(options) ? options : []).map((option, i) =>
-          isOption(option) ? (
-            <option key={i} value={option.value}>
-              {option.label}
+    }) => {
+      const placeholderText = toTextContent(placeholder);
+      return (
+        <select
+          data-aui="select"
+          data-aui-action={actionAttr($action)}
+          name={name}
+          aria-label={label}
+          defaultValue=""
+          onChange={(e) => fire($action, $dispatch, e.currentTarget.value)}
+        >
+          {placeholderText ? (
+            <option value="" disabled>
+              {placeholderText}
             </option>
-          ) : null,
-        )}
-        {children}
-      </select>
-    ),
+          ) : null}
+          {(Array.isArray(options) ? options : []).map((option, i) =>
+            isOption(option) ? (
+              <option key={i} value={option.value}>
+                {option.label}
+              </option>
+            ) : null,
+          )}
+          {children}
+        </select>
+      );
+    },
   },
   Input: {
     description:
@@ -261,7 +265,7 @@ export const interactiveVocabulary = {
           defaultChecked={defaultChecked}
           onChange={(e) => fire($action, $dispatch, e.currentTarget.checked)}
         />
-        <span data-aui="checkbox-label">{label}</span>
+        <span data-aui="checkbox-label">{toTextContent(label)}</span>
       </label>
     ),
   },

--- a/packages/react-generative-ui/src/vocabulary/layout.test.tsx
+++ b/packages/react-generative-ui/src/vocabulary/layout.test.tsx
@@ -114,6 +114,22 @@ describe("layoutVocabulary", () => {
       '<span data-aui="badge" data-aui-variant="success">new</span>',
     );
   });
+
+  it("ignores malformed card and badge text properties", () => {
+    expect(
+      render({
+        $type: "Card",
+        title: { unexpected: true },
+        confirm: { label: { unexpected: true } },
+        cancel: { label: { unexpected: true } },
+      }),
+    ).toBe(
+      '<section data-aui="card" data-aui-surface=""><footer data-aui="card-footer"><button type="button" data-aui="card-confirm"></button><button type="button" data-aui="card-cancel"></button></footer></section>',
+    );
+    expect(render({ $type: "Badge", value: { unexpected: true } })).toBe(
+      '<span data-aui="badge"></span>',
+    );
+  });
 });
 
 describe("layoutVocabulary Box", () => {

--- a/packages/react-generative-ui/src/vocabulary/layout.tsx
+++ b/packages/react-generative-ui/src/vocabulary/layout.tsx
@@ -4,6 +4,7 @@ import type { GenerativeUILibrary } from "../types";
 import { ALIGNS, JUSTIFIES } from "../ir";
 import { fire } from "./dispatch";
 import { collectFormValuesFromEvent } from "./collectFormValues";
+import { toTextContent } from "./toTextContent";
 
 const toCssLength = (value: string | number): string =>
   typeof value === "number" ? `${value}px` : value;
@@ -65,6 +66,7 @@ export const layoutVocabulary = {
       children,
     }) => {
       const Root = asForm ? "form" : "section";
+      const cardTitle = toTextContent(title);
       const footer =
         confirm || cancel ? (
           <footer data-aui="card-footer">
@@ -76,7 +78,7 @@ export const layoutVocabulary = {
                   asForm ? undefined : () => fire(confirm.$action, $dispatch)
                 }
               >
-                {confirm.label}
+                {toTextContent(confirm.label)}
               </button>
             ) : null}
             {cancel ? (
@@ -85,7 +87,7 @@ export const layoutVocabulary = {
                 data-aui="card-cancel"
                 onClick={() => fire(cancel.$action, $dispatch)}
               >
-                {cancel.label}
+                {toTextContent(cancel.label)}
               </button>
             ) : null}
           </footer>
@@ -118,7 +120,9 @@ export const layoutVocabulary = {
               : undefined
           }
         >
-          {title ? <header data-aui="card-title">{title}</header> : null}
+          {cardTitle ? (
+            <header data-aui="card-title">{cardTitle}</header>
+          ) : null}
           {children}
           {footer}
         </Root>
@@ -182,7 +186,7 @@ export const layoutVocabulary = {
     }),
     render: ({ value, variant, children }) => (
       <span data-aui="badge" data-aui-variant={variant}>
-        {value}
+        {toTextContent(value)}
         {children}
       </span>
     ),

--- a/packages/react-generative-ui/src/vocabulary/text.test.tsx
+++ b/packages/react-generative-ui/src/vocabulary/text.test.tsx
@@ -87,14 +87,16 @@ describe("textVocabulary", () => {
       { status: "streaming" as const },
       '<p data-aui="caption"></p>',
     ],
-  ])(
-    "renders malformed text properties as empty text",
-    (node, options, expected) => {
-      expect(
-        renderToStaticMarkup(
-          <>{renderGenerativeUI(node, textVocabulary, options)}</>,
-        ),
-      ).toBe(expected);
-    },
-  );
+    [
+      { $type: "Text", value: 42 },
+      { status: "streaming" as const },
+      '<span data-aui="text" data-aui-size="md">42</span>',
+    ],
+  ])("renders only supported text properties", (node, options, expected) => {
+    expect(
+      renderToStaticMarkup(
+        <>{renderGenerativeUI(node, textVocabulary, options)}</>,
+      ),
+    ).toBe(expected);
+  });
 });

--- a/packages/react-generative-ui/src/vocabulary/text.test.tsx
+++ b/packages/react-generative-ui/src/vocabulary/text.test.tsx
@@ -70,4 +70,31 @@ describe("textVocabulary", () => {
       '<p data-aui="caption">muted note</p>',
     );
   });
+
+  it.each([
+    [
+      { $type: "Header", text: { unexpected: true } },
+      undefined,
+      '<h2 data-aui="header" data-aui-size="lg"></h2>',
+    ],
+    [
+      { $type: "Text", value: { unexpected: true } },
+      { status: "streaming" as const },
+      '<span data-aui="text" data-aui-size="md"></span>',
+    ],
+    [
+      { $type: "Caption", value: { unexpected: true } },
+      { status: "streaming" as const },
+      '<p data-aui="caption"></p>',
+    ],
+  ])(
+    "renders malformed text properties as empty text",
+    (node, options, expected) => {
+      expect(
+        renderToStaticMarkup(
+          <>{renderGenerativeUI(node, textVocabulary, options)}</>,
+        ),
+      ).toBe(expected);
+    },
+  );
 });

--- a/packages/react-generative-ui/src/vocabulary/text.tsx
+++ b/packages/react-generative-ui/src/vocabulary/text.tsx
@@ -1,9 +1,7 @@
 import { z } from "zod";
 import type { GenerativeUILibrary } from "../types";
 import { COLORS, TEXT_SIZES, WEIGHTS } from "../ir";
-
-const safeTextValue = (value: unknown) =>
-  typeof value === "string" ? value : null;
+import { toTextContent } from "./toTextContent";
 
 export const textVocabulary = {
   Header: {
@@ -17,7 +15,7 @@ export const textVocabulary = {
     }),
     render: ({ text, size, children }) => (
       <h2 data-aui="header" data-aui-size={size ?? "lg"}>
-        {safeTextValue(text)}
+        {toTextContent(text)}
         {children}
       </h2>
     ),
@@ -41,7 +39,7 @@ export const textVocabulary = {
         data-aui-weight={weight}
         data-aui-color={color}
       >
-        {safeTextValue(value)}
+        {toTextContent(value)}
         {children}
       </span>
     ),
@@ -54,7 +52,7 @@ export const textVocabulary = {
     streamProperties: true,
     render: ({ value, children }) => (
       <p data-aui="caption">
-        {safeTextValue(value)}
+        {toTextContent(value)}
         {children}
       </p>
     ),

--- a/packages/react-generative-ui/src/vocabulary/text.tsx
+++ b/packages/react-generative-ui/src/vocabulary/text.tsx
@@ -2,6 +2,9 @@ import { z } from "zod";
 import type { GenerativeUILibrary } from "../types";
 import { COLORS, TEXT_SIZES, WEIGHTS } from "../ir";
 
+const safeTextValue = (value: unknown) =>
+  typeof value === "string" ? value : null;
+
 export const textVocabulary = {
   Header: {
     description: "A section heading. Renders as a bold title.",
@@ -14,7 +17,7 @@ export const textVocabulary = {
     }),
     render: ({ text, size, children }) => (
       <h2 data-aui="header" data-aui-size={size ?? "lg"}>
-        {text}
+        {safeTextValue(text)}
         {children}
       </h2>
     ),
@@ -38,7 +41,7 @@ export const textVocabulary = {
         data-aui-weight={weight}
         data-aui-color={color}
       >
-        {value}
+        {safeTextValue(value)}
         {children}
       </span>
     ),
@@ -51,7 +54,7 @@ export const textVocabulary = {
     streamProperties: true,
     render: ({ value, children }) => (
       <p data-aui="caption">
-        {value}
+        {safeTextValue(value)}
         {children}
       </p>
     ),

--- a/packages/react-generative-ui/src/vocabulary/toTextContent.ts
+++ b/packages/react-generative-ui/src/vocabulary/toTextContent.ts
@@ -1,0 +1,2 @@
+export const toTextContent = (value: unknown): string | number | null =>
+  typeof value === "string" || typeof value === "number" ? value : null;


### PR DESCRIPTION
## Problem

Non-conforming model output can place an object in a built-in vocabulary property that renders as text. React then throws `Objects are not valid as a React child` and interrupts the generated UI instead of rendering the remaining response. Numeric values already rendered successfully and must remain supported.

## Root cause

Generative UI schemas guide model output but are not runtime validators. Several built-in vocabulary components passed their text properties directly to React without narrowing their runtime type.

## Change

Use one internal text-content guard across the built-in text, Markdown, fact, layout, alert, and interactive vocabularies. Strings and numbers render unchanged; unsupported values render no text while nested children and component structure remain intact.

## Verification

- Added focused coverage for every affected built-in text-child path, including streaming `Text`, `Caption`, and `Markdown` values.
- Added coverage confirming numeric text still renders.
- `pnpm -C packages/react-generative-ui test`: 650 tests passed.
- `aui-build` for `@assistant-ui/react-generative-ui` passed.
- Focused oxlint and changeset validation passed.

## Public surface

`@assistant-ui/react-generative-ui` runtime behavior only. Release tooling also patches its direct dependent `@assistant-ui/react-ag-ui`; no source or API signatures change there. No exports or API signatures changed. Includes a patch changeset.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ktTOSBENEE8YP0wkVCptkTnlfpF_PSNlkjz3iA80lPC_JzK1kbyZRHP9mxs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->