### PR TITLE
feat(core): avoid repeated external message scans

### DIFF
--- a/.changeset/quick-cats-join.md
+++ b/.changeset/quick-cats-join.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: avoid repeated scans while joining external message parts

--- a/packages/core/src/react/runtimes/external-message-converter.test.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.test.ts
@@ -205,6 +205,56 @@ describe("convertExternalMessages", () => {
       expect((toolCallParts[0] as any).argsText).toBe('{"query":"new"}');
     });
 
+    it("keeps a merged tool call in its original content position", () => {
+      const messages = [
+        {
+          role: "assistant" as const,
+          content: [
+            {
+              type: "tool-call" as const,
+              toolCallId: "tc1",
+              toolName: "search",
+              args: { query: "old" },
+            },
+            { type: "text" as const, text: "after tool" },
+          ],
+        },
+        {
+          role: "assistant" as const,
+          content: [
+            {
+              type: "tool-call" as const,
+              toolCallId: "tc1",
+              toolName: "search",
+              args: { query: "new" },
+            },
+          ],
+        },
+        {
+          role: "tool" as const,
+          toolCallId: "tc1",
+          result: "found",
+        },
+      ];
+
+      const result = convertExternalMessages(
+        messages,
+        (message) => message,
+        false,
+        {},
+      );
+
+      expect(result[0]!.content).toMatchObject([
+        {
+          type: "tool-call",
+          toolCallId: "tc1",
+          args: { query: "new" },
+          result: "found",
+        },
+        { type: "text", text: "after tool" },
+      ]);
+    });
+
     it("should ignore orphaned tool results without throwing", () => {
       const messages = [
         {

--- a/packages/core/src/runtime/utils/external-message-conversion.test.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.test.ts
@@ -33,7 +33,7 @@ describe("convertExternalMessageCallback", () => {
 });
 
 describe("joinExternalMessages", () => {
-  it("preserves runtime equality for malformed tool-call IDs", () => {
+  it("preserves strict equality for malformed numeric tool-call IDs", () => {
     const messages = [
       {
         role: "assistant",
@@ -57,7 +57,6 @@ describe("joinExternalMessages", () => {
           },
         ],
       },
-      { role: "tool", toolCallId: 1, result: "found" },
     ] as unknown as ExternalMessageConverterMessage[];
 
     expect(joinExternalMessages(messages).content).toMatchObject([
@@ -65,8 +64,35 @@ describe("joinExternalMessages", () => {
         type: "tool-call",
         toolCallId: 1,
         args: { query: "new" },
-        result: "found",
       },
+    ]);
+  });
+
+  it("does not merge malformed NaN tool-call IDs", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: Number.NaN,
+            toolName: "search",
+            args: { query: "first" },
+          },
+          {
+            type: "tool-call",
+            toolCallId: Number.NaN,
+            toolName: "search",
+            args: { query: "second" },
+          },
+        ],
+      },
+      { role: "tool", toolCallId: Number.NaN, result: "found" },
+    ] as unknown as ExternalMessageConverterMessage[];
+
+    expect(joinExternalMessages(messages).content).toMatchObject([
+      { type: "tool-call", args: { query: "first" } },
+      { type: "tool-call", args: { query: "second" } },
     ]);
   });
 });

--- a/packages/core/src/runtime/utils/external-message-conversion.test.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.test.ts
@@ -90,10 +90,14 @@ describe("joinExternalMessages", () => {
       { role: "tool", toolCallId: Number.NaN, result: "found" },
     ] as unknown as ExternalMessageConverterMessage[];
 
-    expect(joinExternalMessages(messages).content).toMatchObject([
+    const result = joinExternalMessages(messages);
+
+    expect(result.content).toMatchObject([
       { type: "tool-call", args: { query: "first" } },
       { type: "tool-call", args: { query: "second" } },
     ]);
+    expect(result.content[0]).not.toHaveProperty("result");
+    expect(result.content[1]).not.toHaveProperty("result");
   });
 });
 

--- a/packages/core/src/runtime/utils/external-message-conversion.test.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.test.ts
@@ -3,8 +3,10 @@ import {
   chunkExternalMessages,
   convertExternalMessageCallback,
   convertExternalMessageChunk,
+  joinExternalMessages,
   type ExternalMessageConverterCallback,
   type ExternalMessageConverterCallbackResult,
+  type ExternalMessageConverterMessage,
 } from "./external-message-conversion";
 
 describe("convertExternalMessageCallback", () => {
@@ -27,6 +29,45 @@ describe("convertExternalMessageCallback", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+});
+
+describe("joinExternalMessages", () => {
+  it("preserves runtime equality for malformed tool-call IDs", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: 1,
+            toolName: "search",
+            args: { query: "old" },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: 1,
+            toolName: "search",
+            args: { query: "new" },
+          },
+        ],
+      },
+      { role: "tool", toolCallId: 1, result: "found" },
+    ] as unknown as ExternalMessageConverterMessage[];
+
+    expect(joinExternalMessages(messages).content).toMatchObject([
+      {
+        type: "tool-call",
+        toolCallId: 1,
+        args: { query: "new" },
+        result: "found",
+      },
+    ]);
   });
 });
 

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -142,11 +142,14 @@ export const joinExternalMessages = (
     role: "assistant",
     content: [],
   };
-  const toolCallIndices = new Map<string | undefined, number>();
+  const toolCallIndices = new Map<unknown, number>();
   const reasoningIndices = new Map<string, number>();
   for (const output of messages) {
     if (output.role === "tool") {
-      const toolCallIdx = toolCallIndices.get(output.toolCallId) ?? -1;
+      const toolCallIdx =
+        output.toolCallId === output.toolCallId
+          ? (toolCallIndices.get(output.toolCallId) ?? -1)
+          : -1;
       // Ignore orphaned tool results so one bad tool message does not
       // prevent rendering the rest of the conversation.
       if (toolCallIdx !== -1) {
@@ -289,6 +292,7 @@ export const joinExternalMessages = (
             assistantMessage.content.push(part);
             if (
               part.type === "tool-call" &&
+              part.toolCallId === part.toolCallId &&
               !toolCallIndices.has(part.toolCallId)
             ) {
               toolCallIndices.set(part.toolCallId, partIdx);

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -142,7 +142,7 @@ export const joinExternalMessages = (
     role: "assistant",
     content: [],
   };
-  const toolCallIndices = new Map<unknown, number>();
+  const toolCallIndices = new Map<string | undefined, number>();
   const reasoningIndices = new Map<string, number>();
   for (const output of messages) {
     if (output.role === "tool") {
@@ -295,8 +295,7 @@ export const joinExternalMessages = (
             } else if (
               part.type === "reasoning" &&
               "parentId" in part &&
-              part.parentId &&
-              !reasoningIndices.has(part.parentId)
+              part.parentId
             ) {
               reasoningIndices.set(part.parentId, partIdx);
             }

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -142,11 +142,11 @@ export const joinExternalMessages = (
     role: "assistant",
     content: [],
   };
+  const toolCallIndices = new Map<string, number>();
+  const reasoningIndices = new Map<string, number>();
   for (const output of messages) {
     if (output.role === "tool") {
-      const toolCallIdx = assistantMessage.content.findIndex(
-        (c) => c.type === "tool-call" && c.toolCallId === output.toolCallId,
-      );
+      const toolCallIdx = toolCallIndices.get(output.toolCallId) ?? -1;
       // Ignore orphaned tool results so one bad tool message does not
       // prevent rendering the rest of the conversation.
       if (toolCallIdx !== -1) {
@@ -253,11 +253,8 @@ export const joinExternalMessages = (
           // Add content parts, merging reasoning parts with same parentId
           for (const part of content) {
             if (part.type === "tool-call" && part.toolCallId) {
-              const existingIdx = assistantMessage.content.findIndex(
-                (c) =>
-                  c.type === "tool-call" && c.toolCallId === part.toolCallId,
-              );
-              if (existingIdx !== -1) {
+              const existingIdx = toolCallIndices.get(part.toolCallId);
+              if (existingIdx !== undefined) {
                 const existing = assistantMessage.content[
                   existingIdx
                 ] as typeof part;
@@ -275,13 +272,8 @@ export const joinExternalMessages = (
               "parentId" in part &&
               part.parentId
             ) {
-              const existingIdx = assistantMessage.content.findIndex(
-                (c) =>
-                  c.type === "reasoning" &&
-                  "parentId" in c &&
-                  c.parentId === part.parentId,
-              );
-              if (existingIdx !== -1) {
+              const existingIdx = reasoningIndices.get(part.parentId);
+              if (existingIdx !== undefined) {
                 const existing = assistantMessage.content[
                   existingIdx
                 ] as typeof part;
@@ -293,7 +285,22 @@ export const joinExternalMessages = (
                 continue;
               }
             }
+            const partIdx = assistantMessage.content.length;
             assistantMessage.content.push(part);
+            if (
+              part.type === "tool-call" &&
+              typeof part.toolCallId === "string" &&
+              !toolCallIndices.has(part.toolCallId)
+            ) {
+              toolCallIndices.set(part.toolCallId, partIdx);
+            } else if (
+              part.type === "reasoning" &&
+              "parentId" in part &&
+              part.parentId &&
+              !reasoningIndices.has(part.parentId)
+            ) {
+              reasoningIndices.set(part.parentId, partIdx);
+            }
           }
           break;
         default: {

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -132,6 +132,9 @@ const mergeInnerMessages = (existing: object, incoming: object) => ({
   ],
 });
 
+const isNaNToolCallId = (toolCallId: unknown) =>
+  typeof toolCallId === "number" && Number.isNaN(toolCallId);
+
 export const joinExternalMessages = (
   messages: readonly ExternalMessageConverterMessage[],
 ): ThreadMessageLike => {
@@ -146,10 +149,9 @@ export const joinExternalMessages = (
   const reasoningIndices = new Map<string, number>();
   for (const output of messages) {
     if (output.role === "tool") {
-      const toolCallIdx =
-        output.toolCallId === output.toolCallId
-          ? (toolCallIndices.get(output.toolCallId) ?? -1)
-          : -1;
+      const toolCallIdx = !isNaNToolCallId(output.toolCallId)
+        ? (toolCallIndices.get(output.toolCallId) ?? -1)
+        : -1;
       // Ignore orphaned tool results so one bad tool message does not
       // prevent rendering the rest of the conversation.
       if (toolCallIdx !== -1) {
@@ -292,7 +294,7 @@ export const joinExternalMessages = (
             assistantMessage.content.push(part);
             if (
               part.type === "tool-call" &&
-              part.toolCallId === part.toolCallId &&
+              !isNaNToolCallId(part.toolCallId) &&
               !toolCallIndices.has(part.toolCallId)
             ) {
               toolCallIndices.set(part.toolCallId, partIdx);

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -142,7 +142,7 @@ export const joinExternalMessages = (
     role: "assistant",
     content: [],
   };
-  const toolCallIndices = new Map<string, number>();
+  const toolCallIndices = new Map<unknown, number>();
   const reasoningIndices = new Map<string, number>();
   for (const output of messages) {
     if (output.role === "tool") {
@@ -289,7 +289,6 @@ export const joinExternalMessages = (
             assistantMessage.content.push(part);
             if (
               part.type === "tool-call" &&
-              typeof part.toolCallId === "string" &&
               !toolCallIndices.has(part.toolCallId)
             ) {
               toolCallIndices.set(part.toolCallId, partIdx);

--- a/packages/x-performance/bench/external-message-conversion.bench.ts
+++ b/packages/x-performance/bench/external-message-conversion.bench.ts
@@ -1,7 +1,12 @@
-import { convertExternalMessages } from "@assistant-ui/core/react";
+import {
+  convertExternalMessages,
+  type useExternalMessageConverter,
+} from "@assistant-ui/core/react";
 import { bench, describe } from "vitest";
 
-const makeMessage = (count: number) => ({
+type Message = useExternalMessageConverter.Message;
+
+const makeToolCallMessage = (count: number): Message => ({
   role: "assistant" as const,
   content: Array.from({ length: count }, (_, index) => ({
     type: "tool-call" as const,
@@ -11,11 +16,47 @@ const makeMessage = (count: number) => ({
   })),
 });
 
-describe("core: external message tool calls", () => {
-  for (const count of [100, 1_000, 5_000]) {
-    const messages = [makeMessage(count)];
-    bench(`${count} unique tool calls`, () => {
-      convertExternalMessages(messages, (message) => message, false, {});
-    });
-  }
-});
+const makeToolResults = (count: number): Message[] => [
+  makeToolCallMessage(count),
+  ...Array.from({ length: count }, (_, index) => ({
+    role: "tool" as const,
+    toolCallId: `call-${index}`,
+    result: { index },
+  })),
+];
+
+const makeReasoningContinuations = (count: number): Message[] => [
+  {
+    role: "assistant",
+    content: [
+      ...Array.from({ length: count }, (_, index) => ({
+        type: "reasoning" as const,
+        parentId: `reasoning-${index}`,
+        text: `start-${index}`,
+      })),
+      ...Array.from({ length: count }, (_, index) => ({
+        type: "reasoning" as const,
+        parentId: `reasoning-${index}`,
+        text: `end-${index}`,
+      })),
+    ],
+  },
+];
+
+const benchmarkScenario = (
+  name: string,
+  makeOutputs: (count: number) => Message[],
+) => {
+  describe(`core: external message ${name}`, () => {
+    for (const count of [100, 1_000, 5_000]) {
+      const inputs = [{ outputs: makeOutputs(count) }];
+      bench(`${count} matches`, () => {
+        convertExternalMessages(inputs, (input) => input.outputs, false, {});
+      });
+    }
+  });
+};
+
+benchmarkScenario("unique tool calls", (count) => [makeToolCallMessage(count)]);
+benchmarkScenario("tool results", makeToolResults);
+benchmarkScenario("reasoning continuations", makeReasoningContinuations);

--- a/packages/x-performance/bench/external-message-conversion.bench.ts
+++ b/packages/x-performance/bench/external-message-conversion.bench.ts
@@ -1,0 +1,21 @@
+import { convertExternalMessages } from "@assistant-ui/core/react";
+import { bench, describe } from "vitest";
+
+const makeMessage = (count: number) => ({
+  role: "assistant" as const,
+  content: Array.from({ length: count }, (_, index) => ({
+    type: "tool-call" as const,
+    toolCallId: `call-${index}`,
+    toolName: "search",
+    args: { query: `query-${index}` },
+  })),
+});
+
+describe("core: external message tool calls", () => {
+  for (const count of [100, 1_000, 5_000]) {
+    const messages = [makeMessage(count)];
+    bench(`${count} unique tool calls`, () => {
+      convertExternalMessages(messages, (message) => message, false, {});
+    });
+  }
+});


### PR DESCRIPTION
## Problem

External message conversion repeatedly scanned every previously joined content part when matching tool calls, tool results, and reasoning continuations. Responses with many unique parts therefore took quadratic time to join.

On current `main`, an isolated benchmark took about 3.3 ms for 1,000 unique tool calls and 73 ms for 5,000.

Closes #7152.

## Root cause

`joinExternalMessages` used `findIndex` against the growing assistant content array for every ID-backed part. Joining 5,000 unique tool calls performed roughly 12.5 million comparisons.

## Change

Track the first content index for each tool-call ID and reasoning parent ID while constructing the joined message. Tool results and continuation parts now use constant-time lookups while retaining the existing first-match ordering and merge behavior, including malformed runtime IDs.

Focused contracts verify that duplicate tool calls and their result still merge at the original content position and that runtime ID equality is preserved. Public-entry wall-time benchmarks cover unique tool calls, matching tool results, and reasoning continuations.

The original isolated benchmark measured about 0.15 ms for 1,000 calls and 0.9 ms for 5,000 after the change. The expanded public benchmark keeps all three 5,000-item scenarios near 2-3 ms locally.

## Verification

- `pnpm --filter @assistant-ui/core build`
- `pnpm --filter @assistant-ui/core test` (168 files, 1,803 tests)
- `pnpm -C packages/x-performance exec vitest bench bench/external-message-conversion.bench.ts --run`
- `pnpm changesets:check`
- `pnpm lint`
- `pnpm size:check`

## Public surface

Affected package: `@assistant-ui/core` with a patch changeset. No exports, API reference, templates, or documentation change.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.kgMNok4eLg4zeJZrHrS6wOCQmTYHCKlZAntPuHtGq87cXQ75ldP-vVXtRFk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->