### PR TITLE
fix(ai-sdk): avoid repeated toolkit schema conversion

### DIFF
--- a/.changeset/lazy-toolkit-snapshot.md
+++ b/.changeset/lazy-toolkit-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+perf: reuse compiled provider and backend tool definitions across requests

--- a/.changeset/lazy-toolkit-snapshot.md
+++ b/.changeset/lazy-toolkit-snapshot.md
@@ -2,4 +2,4 @@
 "@assistant-ui/ai-sdk": patch
 ---
 
-perf: reuse compiled provider and backend tool definitions across requests
+fix: avoid repeated toolkit parameter schema conversion

--- a/.github/workflows/perf-nightly.yaml
+++ b/.github/workflows/perf-nightly.yaml
@@ -35,7 +35,7 @@ jobs:
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-        run: pnpm turbo run build --filter=@assistant-ui/tap --filter=@assistant-ui/core --filter=@assistant-ui/store --filter=assistant-stream --filter=@assistant-ui/react --filter=@assistant-ui/react-markdown
+        run: pnpm turbo run build --filter=@assistant-ui/tap --filter=@assistant-ui/core --filter=@assistant-ui/store --filter=assistant-stream --filter=@assistant-ui/react --filter=@assistant-ui/react-markdown --filter=@assistant-ui/ai-sdk
 
       - name: Record nightly benchmarks
         run: node packages/x-performance/bin/aui-perf.mjs record nightly.json --runs 4

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -11,6 +11,7 @@ on:
       - "packages/assistant-stream/**"
       - "packages/react/**"
       - "packages/react-markdown/**"
+      - "packages/ai-sdk/**"
       - "packages/tw-shimmer/**"
       - ".github/workflows/perf.yaml"
 
@@ -44,7 +45,7 @@ jobs:
           changed=$(git diff --name-only "$BASE_SHA...HEAD")
           bench=false
           trace=false
-          if grep -qE '^(packages/(x-performance|tap|core|store|assistant-stream|react|react-markdown)/|\.github/workflows/perf\.yaml)' <<<"$changed"; then bench=true; fi
+          if grep -qE '^(packages/(x-performance|tap|core|store|assistant-stream|react|react-markdown|ai-sdk)/|\.github/workflows/perf\.yaml)' <<<"$changed"; then bench=true; fi
           if grep -qE '^(packages/tw-shimmer/|packages/x-performance/(fixtures|lib/trace)|\.github/workflows/perf\.yaml)' <<<"$changed"; then trace=true; fi
           echo "bench=$bench" >> "$GITHUB_OUTPUT"
           echo "trace=$trace" >> "$GITHUB_OUTPUT"
@@ -65,7 +66,7 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
         if: steps.lanes.outputs.bench == 'true'
-        run: pnpm turbo run build --filter=@assistant-ui/tap --filter=@assistant-ui/core --filter=@assistant-ui/store --filter=assistant-stream --filter=@assistant-ui/react --filter=@assistant-ui/react-markdown
+        run: pnpm turbo run build --filter=@assistant-ui/tap --filter=@assistant-ui/core --filter=@assistant-ui/store --filter=assistant-stream --filter=@assistant-ui/react --filter=@assistant-ui/react-markdown --filter=@assistant-ui/ai-sdk
 
       - name: Bench PR head against the base commit
         if: steps.lanes.outputs.bench == 'true'

--- a/apps/docs/content/docs/tools/backend.mdx
+++ b/apps/docs/content/docs/tools/backend.mdx
@@ -54,6 +54,10 @@ export async function POST(req: Request) {
 
 `AISDKToolkit.tools()` registers every toolkit tool with the model using its schema, wires the backend `execute` where the server build carries one, and merges in the uploaded frontend tools. A server `execute` wins over an uploaded entry of the same name. Frontend and human tools (no server `execute`) are exposed schema-only and left for the client and the user to fulfill.
 
+Parameter schema conversion is cached by schema object identity. Treat schema
+definitions as immutable; replace the `parameters` object when changing a
+tool's schema.
+
 <Callout type="info">
   If your toolkit spreads in MCP server tools (`defineMcpToolkit`), `.tools()`
   also opens those connections. A module-scope `aiToolkit` pools them across

--- a/apps/docs/content/docs/tools/backend.mdx
+++ b/apps/docs/content/docs/tools/backend.mdx
@@ -54,13 +54,6 @@ export async function POST(req: Request) {
 
 `AISDKToolkit.tools()` registers every toolkit tool with the model using its schema, wires the backend `execute` where the server build carries one, and merges in the uploaded frontend tools. A server `execute` wins over an uploaded entry of the same name. Frontend and human tools (no server `execute`) are exposed schema-only and left for the client and the user to fulfill.
 
-Create `AISDKToolkit` once at module scope. On its first `.tools()` call, the
-instance compiles its provider and backend definitions and then reuses them
-across requests. Uploaded frontend tools and MCP tools are still refreshed on
-every call. If you replace or mutate a provider or backend toolkit entry while
-the server is running, create a new `AISDKToolkit` instance to pick up that
-change.
-
 <Callout type="info">
   If your toolkit spreads in MCP server tools (`defineMcpToolkit`), `.tools()`
   also opens those connections. A module-scope `aiToolkit` pools them across

--- a/apps/docs/content/docs/tools/backend.mdx
+++ b/apps/docs/content/docs/tools/backend.mdx
@@ -54,6 +54,13 @@ export async function POST(req: Request) {
 
 `AISDKToolkit.tools()` registers every toolkit tool with the model using its schema, wires the backend `execute` where the server build carries one, and merges in the uploaded frontend tools. A server `execute` wins over an uploaded entry of the same name. Frontend and human tools (no server `execute`) are exposed schema-only and left for the client and the user to fulfill.
 
+Create `AISDKToolkit` once at module scope. On its first `.tools()` call, the
+instance compiles its provider and backend definitions and then reuses them
+across requests. Uploaded frontend tools and MCP tools are still refreshed on
+every call. If you replace or mutate a provider or backend toolkit entry while
+the server is running, create a new `AISDKToolkit` instance to pick up that
+change.
+
 <Callout type="info">
   If your toolkit spreads in MCP server tools (`defineMcpToolkit`), `.tools()`
   also opens those connections. A module-scope `aiToolkit` pools them across

--- a/packages/ai-sdk/src/tools/generativeTools.test.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.test.ts
@@ -143,24 +143,24 @@ describe("AISDKToolkit.tools()", () => {
       type: "object" as const,
       properties: {},
     }));
-    const toolkit = new AISDKToolkit({
-      toolkit: {
-        serverTool: {
-          type: "backend",
-          parameters: { toJSONSchema: toBackendJSONSchema },
-          execute: async () => "ok",
-        } as never,
-        providerTool: {
-          type: "provider",
-          providerId: "provider.tool",
-          args: {},
-          parameters: { toJSONSchema: toProviderJSONSchema },
-        } as never,
-      },
-    });
+    const toolkitDefinition = {
+      serverTool: {
+        type: "backend",
+        parameters: { toJSONSchema: toBackendJSONSchema },
+        execute: async () => "ok",
+      } as never,
+      providerTool: {
+        type: "provider",
+        providerId: "provider.tool",
+        args: {},
+        parameters: { toJSONSchema: toProviderJSONSchema },
+      } as never,
+    };
+    const firstToolkit = new AISDKToolkit({ toolkit: toolkitDefinition });
+    const secondToolkit = new AISDKToolkit({ toolkit: toolkitDefinition });
 
-    const first = await toolkit.tools();
-    const second = await toolkit.tools();
+    const first = await firstToolkit.tools();
+    const second = await secondToolkit.tools();
 
     expect(toBackendJSONSchema).toHaveBeenCalledTimes(1);
     expect(toProviderJSONSchema).toHaveBeenCalledTimes(1);

--- a/packages/ai-sdk/src/tools/generativeTools.test.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.test.ts
@@ -243,6 +243,34 @@ describe("AISDKToolkit.tools()", () => {
     expect(refreshed.serverTool?.description).toBe("Replacement tool");
   });
 
+  it("reconverts a replaced parameters object", async () => {
+    const firstConversion = vi.fn(() => ({
+      type: "object" as const,
+      properties: { first: { type: "string" } },
+    }));
+    const secondConversion = vi.fn(() => ({
+      type: "object" as const,
+      properties: { second: { type: "string" } },
+    }));
+    const definition: ToolkitDefinition = {
+      serverTool: {
+        type: "backend",
+        parameters: { toJSONSchema: firstConversion },
+        execute: async () => "ok",
+      } as never,
+    };
+    const toolkit = new AISDKToolkit({ toolkit: definition });
+
+    await toolkit.tools();
+    definition.serverTool!.parameters = {
+      toJSONSchema: secondConversion,
+    } as never;
+    await toolkit.tools();
+
+    expect(firstConversion).toHaveBeenCalledOnce();
+    expect(secondConversion).toHaveBeenCalledOnce();
+  });
+
   it("reflects in-place toolkit entry changes on the next call", async () => {
     const definition: ToolkitDefinition = {
       serverTool: {

--- a/packages/ai-sdk/src/tools/generativeTools.test.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.test.ts
@@ -166,6 +166,14 @@ describe("AISDKToolkit.tools()", () => {
     expect(toProviderJSONSchema).toHaveBeenCalledTimes(1);
     expect(second.serverTool).not.toBe(first.serverTool);
     expect(second.providerTool).not.toBe(first.providerTool);
+    expect(second.serverTool!.inputSchema).not.toBe(
+      first.serverTool!.inputSchema,
+    );
+    expect(
+      (second.serverTool!.inputSchema as { jsonSchema: unknown }).jsonSchema,
+    ).toBe(
+      (first.serverTool!.inputSchema as { jsonSchema: unknown }).jsonSchema,
+    );
   });
 
   it("converts the current frontend tools on every call", async () => {

--- a/packages/ai-sdk/src/tools/generativeTools.test.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.test.ts
@@ -134,7 +134,7 @@ describe("AISDKToolkit.tools()", () => {
     });
   });
 
-  it("compiles static provider and backend tools once per instance", async () => {
+  it("converts unchanged provider and backend schemas once", async () => {
     const toBackendJSONSchema = vi.fn(() => ({
       type: "object" as const,
       properties: {},
@@ -164,8 +164,8 @@ describe("AISDKToolkit.tools()", () => {
 
     expect(toBackendJSONSchema).toHaveBeenCalledTimes(1);
     expect(toProviderJSONSchema).toHaveBeenCalledTimes(1);
-    expect(second.serverTool).toBe(first.serverTool);
-    expect(second.providerTool).toBe(first.providerTool);
+    expect(second.serverTool).not.toBe(first.serverTool);
+    expect(second.providerTool).not.toBe(first.providerTool);
   });
 
   it("converts the current frontend tools on every call", async () => {
@@ -192,7 +192,7 @@ describe("AISDKToolkit.tools()", () => {
     expect(second).not.toHaveProperty("firstClientTool");
   });
 
-  it("does not compile disabled static toolkit entries", async () => {
+  it("does not convert disabled static toolkit entries", async () => {
     const toJSONSchema = vi.fn(() => ({
       type: "object" as const,
       properties: {},
@@ -218,7 +218,7 @@ describe("AISDKToolkit.tools()", () => {
     expect(toJSONSchema).not.toHaveBeenCalled();
   });
 
-  it("requires a new instance after replacing static toolkit entries", async () => {
+  it("reflects replaced toolkit entries on the next call", async () => {
     const definition: ToolkitDefinition = {
       serverTool: {
         type: "backend",
@@ -237,12 +237,54 @@ describe("AISDKToolkit.tools()", () => {
       execute: async () => "replacement",
     };
 
-    const cached = await toolkit.tools();
-    const refreshed = await new AISDKToolkit({ toolkit: definition }).tools();
+    const refreshed = await toolkit.tools();
 
     expect(first.serverTool?.description).toBe("Original tool");
-    expect(cached.serverTool).toBe(first.serverTool);
     expect(refreshed.serverTool?.description).toBe("Replacement tool");
+  });
+
+  it("reflects in-place toolkit entry changes on the next call", async () => {
+    const definition: ToolkitDefinition = {
+      serverTool: {
+        type: "backend",
+        description: "Original tool",
+        parameters: { type: "object", properties: {} },
+        execute: async () => "ok",
+      },
+    };
+    const toolkit = new AISDKToolkit({ toolkit: definition });
+
+    expect((await toolkit.tools()).serverTool?.description).toBe(
+      "Original tool",
+    );
+
+    definition.serverTool!.description = "Updated tool";
+    expect((await toolkit.tools()).serverTool?.description).toBe(
+      "Updated tool",
+    );
+
+    definition.serverTool!.disabled = true;
+    expect(await toolkit.tools()).not.toHaveProperty("serverTool");
+  });
+
+  it("does not share mutable tool entries between calls", async () => {
+    const toolkit = new AISDKToolkit({
+      toolkit: {
+        serverTool: {
+          type: "backend",
+          description: "Original tool",
+          parameters: { type: "object", properties: {} },
+          execute: async () => "ok",
+        },
+      },
+    });
+
+    const first = await toolkit.tools();
+    first.serverTool!.description = "Changed returned tool";
+
+    const second = await toolkit.tools();
+
+    expect(second.serverTool?.description).toBe("Original tool");
   });
 });
 

--- a/packages/ai-sdk/src/tools/generativeTools.test.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { defineMcpToolkit } from "@assistant-ui/core/react";
+import {
+  defineMcpToolkit,
+  type ToolkitDefinition,
+} from "@assistant-ui/core/react";
 import { AISDKToolkit } from "./generativeTools";
 import { wrapModelContentEnvelope } from "../converters/modelContentEnvelope";
 
@@ -129,6 +132,117 @@ describe("AISDKToolkit.tools()", () => {
     expect(toolSet.web_search).toMatchObject({
       supportsDeferredResults: false,
     });
+  });
+
+  it("compiles static provider and backend tools once per instance", async () => {
+    const toBackendJSONSchema = vi.fn(() => ({
+      type: "object" as const,
+      properties: {},
+    }));
+    const toProviderJSONSchema = vi.fn(() => ({
+      type: "object" as const,
+      properties: {},
+    }));
+    const toolkit = new AISDKToolkit({
+      toolkit: {
+        serverTool: {
+          type: "backend",
+          parameters: { toJSONSchema: toBackendJSONSchema },
+          execute: async () => "ok",
+        } as never,
+        providerTool: {
+          type: "provider",
+          providerId: "provider.tool",
+          args: {},
+          parameters: { toJSONSchema: toProviderJSONSchema },
+        } as never,
+      },
+    });
+
+    const first = await toolkit.tools();
+    const second = await toolkit.tools();
+
+    expect(toBackendJSONSchema).toHaveBeenCalledTimes(1);
+    expect(toProviderJSONSchema).toHaveBeenCalledTimes(1);
+    expect(second.serverTool).toBe(first.serverTool);
+    expect(second.providerTool).toBe(first.providerTool);
+  });
+
+  it("converts the current frontend tools on every call", async () => {
+    const toolkit = new AISDKToolkit({ toolkit: {} });
+
+    const first = await toolkit.tools({
+      frontend: {
+        firstClientTool: {
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    });
+    const second = await toolkit.tools({
+      frontend: {
+        secondClientTool: {
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    });
+
+    expect(first).toHaveProperty("firstClientTool");
+    expect(first).not.toHaveProperty("secondClientTool");
+    expect(second).toHaveProperty("secondClientTool");
+    expect(second).not.toHaveProperty("firstClientTool");
+  });
+
+  it("does not compile disabled static toolkit entries", async () => {
+    const toJSONSchema = vi.fn(() => ({
+      type: "object" as const,
+      properties: {},
+    }));
+    const toolkit = new AISDKToolkit({
+      toolkit: {
+        disabledServerTool: {
+          type: "backend",
+          disabled: true,
+          parameters: { toJSONSchema },
+        } as never,
+        disabledProviderTool: {
+          type: "provider",
+          disabled: true,
+          providerId: "provider.tool",
+          args: {},
+          parameters: { toJSONSchema },
+        } as never,
+      },
+    });
+
+    await expect(toolkit.tools()).resolves.toEqual({});
+    expect(toJSONSchema).not.toHaveBeenCalled();
+  });
+
+  it("requires a new instance after replacing static toolkit entries", async () => {
+    const definition: ToolkitDefinition = {
+      serverTool: {
+        type: "backend",
+        description: "Original tool",
+        parameters: { type: "object", properties: {} },
+        execute: async () => "original",
+      },
+    };
+    const toolkit = new AISDKToolkit({ toolkit: definition });
+
+    const first = await toolkit.tools();
+    definition.serverTool = {
+      type: "backend",
+      description: "Replacement tool",
+      parameters: { type: "object", properties: {} },
+      execute: async () => "replacement",
+    };
+
+    const cached = await toolkit.tools();
+    const refreshed = await new AISDKToolkit({ toolkit: definition }).tools();
+
+    expect(first.serverTool?.description).toBe("Original tool");
+    expect(cached.serverTool).toBe(first.serverTool);
+    expect(refreshed.serverTool?.description).toBe("Replacement tool");
   });
 });
 

--- a/packages/ai-sdk/src/tools/generativeTools.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.ts
@@ -81,17 +81,22 @@ const convertedParameterSchemas = new WeakMap<
   ReturnType<typeof toJSONSchema>
 >();
 
+const getOrConvertParameterSchema = (
+  parameters: NonNullable<Tool["parameters"]>,
+) => {
+  const cached = convertedParameterSchemas.get(parameters);
+  if (cached) return cached;
+
+  const converted = toJSONSchema(parameters);
+  convertedParameterSchemas.set(parameters, converted);
+  return converted;
+};
+
 const parametersToInputSchema = (
   parameters: Tool["parameters"] | undefined,
 ) => {
   if (!parameters) return jsonSchema(EMPTY_SCHEMA);
-
-  let schema = convertedParameterSchemas.get(parameters);
-  if (!schema) {
-    schema = toJSONSchema(parameters);
-    convertedParameterSchemas.set(parameters, schema);
-  }
-  return jsonSchema(schema);
+  return jsonSchema(getOrConvertParameterSchema(parameters));
 };
 
 /**

--- a/packages/ai-sdk/src/tools/generativeTools.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.ts
@@ -76,6 +76,7 @@ const withMcpConnectionTimeout = async <T>(
   }
 };
 
+// Converted schemas are shared by parameter identity and treated as immutable.
 const convertedParameterSchemas = new WeakMap<
   object,
   ReturnType<typeof toJSONSchema>

--- a/packages/ai-sdk/src/tools/generativeTools.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.ts
@@ -76,8 +76,23 @@ const withMcpConnectionTimeout = async <T>(
   }
 };
 
-const parametersToInputSchema = (parameters: Tool["parameters"] | undefined) =>
-  jsonSchema(parameters ? toJSONSchema(parameters) : EMPTY_SCHEMA);
+const convertedParameterSchemas = new WeakMap<
+  object,
+  ReturnType<typeof toJSONSchema>
+>();
+
+const parametersToInputSchema = (
+  parameters: Tool["parameters"] | undefined,
+) => {
+  if (!parameters) return jsonSchema(EMPTY_SCHEMA);
+
+  let schema = convertedParameterSchemas.get(parameters);
+  if (!schema) {
+    schema = toJSONSchema(parameters);
+    convertedParameterSchemas.set(parameters, schema);
+  }
+  return jsonSchema(schema);
+};
 
 /**
  * @deprecated Options for the deprecated {@link generativeTools}. Use
@@ -100,12 +115,6 @@ export interface GenerativeToolsOptions {
 }
 
 export type AISDKToolkitOptions = {
-  /**
-   * Static provider and backend tools. Their AI SDK definitions are compiled
-   * on the first {@link AISDKToolkit.tools} call and reused for the lifetime of
-   * this instance. Create a new instance after changing these toolkit entries.
-   * Frontend tools and MCP discovery remain dynamic on every call.
-   */
   toolkit: Toolkit;
 };
 
@@ -162,8 +171,6 @@ export const generativeTools = (options: GenerativeToolsOptions): ToolSet => {
 export class AISDKToolkit {
   readonly #toolkit: Toolkit;
   readonly #mcpClients = new Map<string, Promise<MCPClient>>();
-  #staticToolSets: { provider: ToolSet; server: ToolSet } | undefined =
-    undefined;
 
   constructor(options: AISDKToolkitOptions) {
     this.#toolkit = options.toolkit;
@@ -174,8 +181,8 @@ export class AISDKToolkit {
       ? frontendTools(options.frontend)
       : {};
     const mcpToolSet = await this.#mcpTools();
-    const { provider: providerToolSet, server: serverToolSet } =
-      this.#staticTools();
+    const providerToolSet = toProviderToolSet(this.#toolkit);
+    const serverToolSet = toServerToolSet(this.#toolkit as ToolkitDefinition);
 
     assertNoMcpToolNameCollisions(mcpToolSet, [
       { source: "frontend", tools: frontendToolSet },
@@ -189,13 +196,6 @@ export class AISDKToolkit {
       ...providerToolSet,
       ...serverToolSet,
     };
-  }
-
-  #staticTools(): { provider: ToolSet; server: ToolSet } {
-    return (this.#staticToolSets ??= {
-      provider: toProviderToolSet(this.#toolkit),
-      server: toServerToolSet(this.#toolkit as ToolkitDefinition),
-    });
   }
 
   async close(): Promise<void> {

--- a/packages/ai-sdk/src/tools/generativeTools.ts
+++ b/packages/ai-sdk/src/tools/generativeTools.ts
@@ -100,6 +100,12 @@ export interface GenerativeToolsOptions {
 }
 
 export type AISDKToolkitOptions = {
+  /**
+   * Static provider and backend tools. Their AI SDK definitions are compiled
+   * on the first {@link AISDKToolkit.tools} call and reused for the lifetime of
+   * this instance. Create a new instance after changing these toolkit entries.
+   * Frontend tools and MCP discovery remain dynamic on every call.
+   */
   toolkit: Toolkit;
 };
 
@@ -156,6 +162,8 @@ export const generativeTools = (options: GenerativeToolsOptions): ToolSet => {
 export class AISDKToolkit {
   readonly #toolkit: Toolkit;
   readonly #mcpClients = new Map<string, Promise<MCPClient>>();
+  #staticToolSets: { provider: ToolSet; server: ToolSet } | undefined =
+    undefined;
 
   constructor(options: AISDKToolkitOptions) {
     this.#toolkit = options.toolkit;
@@ -166,8 +174,8 @@ export class AISDKToolkit {
       ? frontendTools(options.frontend)
       : {};
     const mcpToolSet = await this.#mcpTools();
-    const providerToolSet = toProviderToolSet(this.#toolkit);
-    const serverToolSet = toServerToolSet(this.#toolkit as ToolkitDefinition);
+    const { provider: providerToolSet, server: serverToolSet } =
+      this.#staticTools();
 
     assertNoMcpToolNameCollisions(mcpToolSet, [
       { source: "frontend", tools: frontendToolSet },
@@ -181,6 +189,13 @@ export class AISDKToolkit {
       ...providerToolSet,
       ...serverToolSet,
     };
+  }
+
+  #staticTools(): { provider: ToolSet; server: ToolSet } {
+    return (this.#staticToolSets ??= {
+      provider: toProviderToolSet(this.#toolkit),
+      server: toServerToolSet(this.#toolkit as ToolkitDefinition),
+    });
   }
 
   async close(): Promise<void> {

--- a/packages/x-performance/bench/ai-sdk-toolkit.bench.ts
+++ b/packages/x-performance/bench/ai-sdk-toolkit.bench.ts
@@ -32,7 +32,7 @@ await Promise.all(
   [...reusedToolkits.values()].map((toolkit) => toolkit.tools()),
 );
 
-describe("ai-sdk: reuse compiled AISDKToolkit definitions", () => {
+describe("ai-sdk: reuse converted AISDKToolkit schemas", () => {
   for (const size of SIZES) {
     bench(`${size} static tools`, async () => {
       await reusedToolkits.get(size)!.tools();
@@ -40,12 +40,10 @@ describe("ai-sdk: reuse compiled AISDKToolkit definitions", () => {
   }
 });
 
-describe("ai-sdk: compile a fresh AISDKToolkit", () => {
+describe("ai-sdk: convert fresh AISDKToolkit schemas", () => {
   for (const size of SIZES) {
-    const definition = makeToolkit(size);
-
     bench(`${size} static tools`, async () => {
-      await new AISDKToolkit({ toolkit: definition }).tools();
+      await new AISDKToolkit({ toolkit: makeToolkit(size) }).tools();
     });
   }
 });

--- a/packages/x-performance/bench/ai-sdk-toolkit.bench.ts
+++ b/packages/x-performance/bench/ai-sdk-toolkit.bench.ts
@@ -1,0 +1,51 @@
+import { AISDKToolkit } from "@assistant-ui/ai-sdk";
+import { bench, describe } from "vitest";
+
+const makeToolkit = (size: number) =>
+  Object.fromEntries(
+    Array.from({ length: size }, (_, index) => [
+      `tool_${index}`,
+      {
+        type: "backend",
+        description: `Tool ${index}`,
+        parameters: {
+          toJSONSchema: () => ({
+            type: "object",
+            properties: Object.fromEntries(
+              Array.from({ length: 20 }, (_, propertyIndex) => [
+                `property_${propertyIndex}`,
+                { type: "string" },
+              ]),
+            ),
+          }),
+        },
+        execute: async () => null,
+      },
+    ]),
+  ) as never;
+
+const SIZES = [10, 100];
+const reusedToolkits = new Map(
+  SIZES.map((size) => [size, new AISDKToolkit({ toolkit: makeToolkit(size) })]),
+);
+await Promise.all(
+  [...reusedToolkits.values()].map((toolkit) => toolkit.tools()),
+);
+
+describe("ai-sdk: reuse compiled AISDKToolkit definitions", () => {
+  for (const size of SIZES) {
+    bench(`${size} static tools`, async () => {
+      await reusedToolkits.get(size)!.tools();
+    });
+  }
+});
+
+describe("ai-sdk: compile a fresh AISDKToolkit", () => {
+  for (const size of SIZES) {
+    const definition = makeToolkit(size);
+
+    bench(`${size} static tools`, async () => {
+      await new AISDKToolkit({ toolkit: definition }).tools();
+    });
+  }
+});

--- a/packages/x-performance/lib/attribution.test.ts
+++ b/packages/x-performance/lib/attribution.test.ts
@@ -93,6 +93,12 @@ describe("against the real workspace", () => {
     expect(
       [...(graph.get("@assistant-ui/react-markdown") ?? [])].sort(),
     ).toEqual(["@assistant-ui/react"]);
+    expect([...(graph.get("@assistant-ui/ai-sdk") ?? [])].sort()).toEqual([
+      "@assistant-ui/core",
+      "@assistant-ui/store",
+      "@assistant-ui/tap",
+      "assistant-stream",
+    ]);
   });
 
   it("attributes each bench file to the dists it exercises", () => {
@@ -119,6 +125,13 @@ describe("against the real workspace", () => {
       "@assistant-ui/core",
       "@assistant-ui/react",
       "@assistant-ui/react-markdown",
+      "@assistant-ui/store",
+      "@assistant-ui/tap",
+      "assistant-stream",
+    ]);
+    expect(covers("bench/ai-sdk-toolkit.bench.ts")).toEqual([
+      "@assistant-ui/ai-sdk",
+      "@assistant-ui/core",
       "@assistant-ui/store",
       "@assistant-ui/tap",
       "assistant-stream",

--- a/packages/x-performance/lib/ref-packages.mjs
+++ b/packages/x-performance/lib/ref-packages.mjs
@@ -5,4 +5,5 @@ export const REF_PACKAGE_DIRS = {
   "assistant-stream": "packages/assistant-stream",
   "@assistant-ui/react": "packages/react",
   "@assistant-ui/react-markdown": "packages/react-markdown",
+  "@assistant-ui/ai-sdk": "packages/ai-sdk",
 };


### PR DESCRIPTION
## Problem

`AISDKToolkit.tools()` reconverts unchanged provider and backend parameter schemas on every request. For toolkits with many Zod or custom schemas, repeated `toJSONSchema()` work adds avoidable server latency even when the schema objects have not changed.

## Root cause

Provider and server tool sets are rebuilt on each call, and `parametersToInputSchema()` previously invoked `toJSONSchema()` every time. The expensive work is schema conversion rather than assembling the small AI SDK tool objects.

## Change

Cache converted parameter schemas in a `WeakMap` keyed by the `parameters` object. Tool definitions are still rebuilt on every call, so added, removed, disabled, and non-schema field edits remain visible; replacing a parameter schema object triggers conversion of the replacement. Returned top-level tool objects and AI SDK schema wrappers are fresh, while the underlying converted JSON Schema is intentionally shared and treated as read-only. Standard Schema definitions are treated as immutable values and cached by identity.

Frontend conversion, MCP discovery, collision checks, and merge precedence remain dynamic. The benchmark now compares reused schema objects with fresh schema objects, and the snapshot-lifecycle documentation has been removed because the toolkit itself is no longer snapshotted.

The performance wiring adds `@assistant-ui/ai-sdk` to the measured package set. Future PRs touching `packages/ai-sdk/**` will therefore build that package and run the informational performance lane.

## Verification

- `pnpm --filter @assistant-ui/ai-sdk test` - 25 files and 282 tests passed.
- `pnpm --filter @assistant-ui/ai-sdk exec vitest run src/tools/generativeTools.test.ts` - 36 tests passed after the final contracts.
- `pnpm --filter @assistant-ui/x-performance exec vitest run lib/attribution.test.ts` - 11 tests passed.
- `pnpm turbo build --filter=@assistant-ui/ai-sdk...` - passed.
- `pnpm --filter @assistant-ui/x-performance exec vitest bench --run bench/ai-sdk-toolkit.bench.ts` - reused schemas measured roughly 9-10x faster than fresh schema conversion locally.

## Public surface

- `@assistant-ui/ai-sdk`: internal runtime optimization and patch changeset.
- Documentation: backend tool docs now state the schema identity contract.
- No export, signature, API-reference, or template changes.

Closes #7134

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.lbgtzZjH6u6UjTESSbYMphNw1Kobi3xn3QEy3jRk1x5qA9vwx3APWDzlUSc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
