### PR TITLE
fix(core): preserve prototype-named tool UI keys

### DIFF
--- a/.changeset/tool-ui-prototype-keys.md
+++ b/.changeset/tool-ui-prototype-keys.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve prototype-named tool UI registrations and argument statuses

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -45,7 +45,9 @@ const useTools = ({
   const mcpAppOutputs = useResources(mcpApp ? [withKey("mcpApp", mcpApp)] : []);
   const mcpAppOutput = mcpAppOutputs[0];
 
-  const [toolUIs, setToolUIs] = useState<ToolsState["toolUIs"]>(() => ({}));
+  const [toolUIs, setToolUIs] = useState<ToolsState["toolUIs"]>(() =>
+    nullProtoRecord(),
+  );
 
   const state = useMemo(
     (): ToolsState => ({
@@ -74,20 +76,25 @@ const useTools = ({
         standalone: options?.standalone ?? false,
       };
 
-      setToolUIs((prev) => ({
-        ...prev,
-        [toolName]: [...(prev[toolName] ?? []), registration],
-      }));
+      setToolUIs((prev) => {
+        const next = nullProtoRecord(prev);
+        next[toolName] = [...(next[toolName] ?? []), registration];
+        return next;
+      });
 
       return () => {
         setToolUIs((prev) => {
-          const next = prev[toolName]?.filter((r) => r !== registration) ?? [];
-          if (next.length > 0) return { ...prev, [toolName]: next };
+          const registrations =
+            prev[toolName]?.filter((r) => r !== registration) ?? [];
+          const next = nullProtoRecord(prev);
+          if (registrations.length > 0) {
+            next[toolName] = registrations;
+            return next;
+          }
           // Drop the key entirely so repeatedly mounted/unmounted tools
           // don't leave empty arrays accumulating across a long session.
-          const rest = { ...prev };
-          delete rest[toolName];
-          return rest;
+          delete next[toolName];
+          return next;
         });
       };
     },

--- a/packages/core/src/react/model-context/useToolArgsStatus.test.tsx
+++ b/packages/core/src/react/model-context/useToolArgsStatus.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const part = vi.hoisted(() => ({
+  type: "tool-call" as const,
+  status: { type: "complete" as const },
+  args: JSON.parse('{"__proto__":"value"}') as Record<string, unknown>,
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  return {
+    ...actual,
+    useAuiState: (selector: (state: { part: typeof part }) => unknown) =>
+      selector({ part }),
+  };
+});
+
+import { useToolArgsStatus } from "./useToolArgsStatus";
+
+describe("useToolArgsStatus", () => {
+  it("reports status for an argument named __proto__", () => {
+    const { result } = renderHook(() => useToolArgsStatus());
+
+    expect(Object.hasOwn(result.current.propStatus, "__proto__")).toBe(true);
+    expect(result.current.propStatus.__proto__).toBe("complete");
+  });
+});

--- a/packages/core/src/react/model-context/useToolArgsStatus.ts
+++ b/packages/core/src/react/model-context/useToolArgsStatus.ts
@@ -4,6 +4,7 @@ import {
   getPartialJsonObjectFieldState,
   getPartialJsonObjectMeta,
 } from "assistant-stream/utils";
+import { nullProtoRecord } from "../../utils/record";
 
 type PropFieldStatus = "streaming" | "complete";
 
@@ -60,7 +61,7 @@ export const useToolArgsStatus = <
     const isStreaming = statusType === "running";
     const args = part.args as Record<string, unknown>;
     const meta = getPartialJsonObjectMeta(args as Record<symbol, unknown>);
-    const propStatus: Partial<Record<string, PropFieldStatus>> = {};
+    const propStatus = nullProtoRecord<PropFieldStatus>();
 
     for (const key of Object.keys(args)) {
       if (meta) {

--- a/packages/core/src/tests/tools-scope-migration.test.tsx
+++ b/packages/core/src/tests/tools-scope-migration.test.tsx
@@ -23,6 +23,34 @@ afterEach(() => {
 });
 
 describe("Tools model-context registration", () => {
+  it("registers and removes a tool UI named __proto__", async () => {
+    let aui!: AnyClient;
+    const Harness = () => {
+      aui = useAui({ tools: Tools({}) } as never);
+      return null;
+    };
+    render(<Harness />);
+
+    let remove!: () => void;
+    await act(async () => {
+      remove = aui.tools().setToolUI("__proto__", () => null);
+      await vi.waitFor(() => {
+        const toolUIs = aui.tools().getState().toolUIs;
+        expect(Object.hasOwn(toolUIs, "__proto__")).toBe(true);
+        expect(toolUIs.__proto__).toHaveLength(1);
+      });
+    });
+
+    await act(async () => {
+      remove();
+      await vi.waitFor(() =>
+        expect(Object.hasOwn(aui.tools().getState().toolUIs, "__proto__")).toBe(
+          false,
+        ),
+      );
+    });
+  });
+
   it("migrates to a structurally replaced modelContext scope", async () => {
     let aui!: AnyClient;
     const Harness = ({ generation }: { generation: number }) => {


### PR DESCRIPTION
## Problem

On current main (`@assistant-ui/core` 0.3.17), registering a tool UI named `__proto__` throws because the registry reads `Object.prototype` as though it were the registration array. Per-argument status also drops a valid `__proto__` argument key.

Minimal reproduction:

```ts
aui.tools().setToolUI("__proto__", () => null);
```

This fails with `TypeError: ... is not iterable`.

## Root cause

Both dictionaries were initialized as ordinary objects. In the tool UI registry, reading `prev[toolName]` for `__proto__` returned the inherited prototype object before the computed-property update ran. In argument-status collection, assigning `propStatus["__proto__"]` invoked the inherited prototype setter instead of creating an own data property.

## Change

Build tool UI and argument-status dictionaries with the existing `nullProtoRecord` helper. Registration updates and cleanup preserve that representation.

## Verification

- `pnpm --filter @assistant-ui/core exec vitest run src/tests/tools-scope-migration.test.tsx src/react/model-context/useToolArgsStatus.test.tsx`
- `pnpm exec oxlint packages/core/src/react/client/Tools.ts packages/core/src/react/model-context/useToolArgsStatus.ts packages/core/src/react/model-context/useToolArgsStatus.test.tsx packages/core/src/tests/tools-scope-migration.test.tsx`
- `pnpm --filter @assistant-ui/core build`
- `pnpm changesets:check`

The new regressions fail on main and pass with this change.

## Public surface

`@assistant-ui/core` receives a patch changeset. No exports, types, or documented APIs change.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.bWiD3y4NWzYRt7DMQkKPLaDMzwg3TOxr3pS_8PH1U-3G5o-4E-v_p432hEo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->