### PR TITLE
fix(assistant-stream): handle deeply nested gorp paths

### DIFF
--- a/.changeset/gorp-deep-paths.md
+++ b/.changeset/gorp-deep-paths.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: apply deeply nested GORP paths without overflowing the stack

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts
@@ -7,6 +7,19 @@ afterEach(() => {
 });
 
 describe("GorpStreamAccumulator", () => {
+  it("applies deeply nested paths without overflowing the stack", () => {
+    const path = Array.from({ length: 20_000 }, (_, index) => `level-${index}`);
+    const acc = new GorpStreamAccumulator({});
+
+    acc.append([{ type: "set", path, value: true }]);
+
+    let current = acc.state;
+    for (const key of path) {
+      current = (current as Record<string, typeof current>)[key]!;
+    }
+    expect(current).toBe(true);
+  });
+
   it("rejects unsafe path segments", () => {
     for (const path of [
       ["__proto__", "polluted"],

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
@@ -90,7 +90,8 @@ export class GorpStreamAccumulator {
       assertSafePathSegment(key);
       if (Array.isArray(current)) {
         let index = Number(key);
-        // Numeric wire segments are tolerated, but string indices must be canonical.
+        // The wire can deliver numeric segments (op.path is only type-checked,
+        // not runtime-validated), so canonicality is compared via String(key).
         if (!Number.isInteger(index) || String(index) !== String(key)) {
           throw new Error(
             `Expected array index at [${path.slice(depth).join(", ")}]`,
@@ -111,8 +112,9 @@ export class GorpStreamAccumulator {
         frames.push({ kind: "array", state: current, key: index });
         current = Object.hasOwn(current, index) ? current[index] : undefined;
       } else {
-        frames.push({ kind: "object", state: current, key });
-        current = Object.hasOwn(current, key) ? current[key] : undefined;
+        const object = current as ReadonlyJSONObject;
+        frames.push({ kind: "object", state: object, key });
+        current = Object.hasOwn(object, key) ? object[key] : undefined;
       }
     }
 

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
@@ -1,6 +1,14 @@
-import type { ReadonlyJSONValue, ReadonlyJSONObject } from "../../utils";
+import type {
+  ReadonlyJSONArray,
+  ReadonlyJSONValue,
+  ReadonlyJSONObject,
+} from "../../utils";
 import { assertSafePathSegment } from "./changeTree";
 import type { GorpStreamOperation } from "./types";
+
+type PathFrame =
+  | { kind: "array"; state: ReadonlyJSONArray; key: number }
+  | { kind: "object"; state: ReadonlyJSONObject; key: string };
 
 export class GorpStreamAccumulator {
   private _state: ReadonlyJSONValue;
@@ -69,50 +77,58 @@ export class GorpStreamAccumulator {
   ): ReadonlyJSONValue {
     if (path.length === 0) return updater(state);
 
-    // Initialize state as empty object if it's null and we're trying to set a property
-    state ??= {};
+    const frames: PathFrame[] = [];
+    let current = state;
 
-    if (typeof state !== "object") {
-      throw new Error(`Invalid path: [${path.join(", ")}]`);
-    }
-
-    const [key, ...rest] = path as [string, ...(readonly string[])];
-    assertSafePathSegment(key);
-    if (Array.isArray(state)) {
-      let idx = Number(key);
-      // The wire can deliver numeric segments (op.path is only type-checked,
-      // not runtime-validated), so canonicality is compared via String(key).
-      if (!Number.isInteger(idx) || String(idx) !== String(key))
-        throw new Error(`Expected array index at [${path.join(", ")}]`);
-      if (idx < 0) throw new Error(`Insert array index out of bounds`);
-      if (idx > state.length) {
-        if (this._strict) throw new Error(`Insert array index out of bounds`);
-        if (!this._warnedClamp) {
-          this._warnedClamp = true;
-          console.warn(
-            `Clamped out-of-bounds gorp array index ${idx} to ${state.length}`,
-          );
-        }
-        idx = Math.min(idx, state.length);
+    for (let depth = 0; depth < path.length; depth++) {
+      current ??= {};
+      if (typeof current !== "object") {
+        throw new Error(`Invalid path: [${path.slice(depth).join(", ")}]`);
       }
 
-      const nextState = [...state];
-      nextState[idx] = this.updatePath(
-        Object.hasOwn(nextState, idx) ? nextState[idx] : undefined,
-        rest,
-        updater,
-      );
+      const key = path[depth]!;
+      assertSafePathSegment(key);
+      if (Array.isArray(current)) {
+        let index = Number(key);
+        // Numeric wire segments are tolerated, but string indices must be canonical.
+        if (!Number.isInteger(index) || String(index) !== String(key)) {
+          throw new Error(
+            `Expected array index at [${path.slice(depth).join(", ")}]`,
+          );
+        }
+        if (index < 0) throw new Error(`Insert array index out of bounds`);
+        if (index > current.length) {
+          if (this._strict) throw new Error(`Insert array index out of bounds`);
+          if (!this._warnedClamp) {
+            this._warnedClamp = true;
+            console.warn(
+              `Clamped out-of-bounds gorp array index ${index} to ${current.length}`,
+            );
+          }
+          index = current.length;
+        }
 
-      return nextState;
+        frames.push({ kind: "array", state: current, key: index });
+        current = Object.hasOwn(current, index) ? current[index] : undefined;
+      } else {
+        frames.push({ kind: "object", state: current, key });
+        current = Object.hasOwn(current, key) ? current[key] : undefined;
+      }
     }
 
-    const nextState = { ...(state as ReadonlyJSONObject) };
-    nextState[key] = this.updatePath(
-      Object.hasOwn(nextState, key) ? nextState[key] : undefined,
-      rest,
-      updater,
-    );
-
-    return nextState;
+    let updated = updater(current);
+    for (let index = frames.length - 1; index >= 0; index--) {
+      const frame = frames[index]!;
+      if (frame.kind === "array") {
+        const next = [...frame.state];
+        next[frame.key] = updated;
+        updated = next;
+      } else {
+        const next = { ...frame.state };
+        next[frame.key] = updated;
+        updated = next;
+      }
+    }
+    return updated;
   }
 }


### PR DESCRIPTION
## Problem

On current main (`assistant-stream` 0.3.41), a deeply nested GORP state operation overflows the JavaScript call stack. GORP operations can arrive from streamed transport data, so a malformed or unusually deep path can fail the whole assistant stream.

Minimal reproduction:

```ts
const accumulator = new GorpStreamAccumulator({});
accumulator.append([{
  type: "set",
  path: Array(20_000).fill("level"),
  value: true,
}]);
```

This throws `RangeError: Maximum call stack size exceeded` on main.

## Root cause

`updatePath()` recursively called itself once per path segment and copied the remaining path at every level. Path depth was therefore limited by the JavaScript stack.

## Change

Traverse the path iteratively, record the visited containers, apply the leaf update, and rebuild the immutable containers from the leaf back to the root. Existing validation, strict behavior, array clamping, and structural sharing semantics remain intact.

## Verification

- `pnpm --filter assistant-stream exec vitest run src/core/gorp/GorpStreamAccumulator.test.ts`
- `pnpm exec oxlint packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts`
- `pnpm --filter assistant-stream build`
- `pnpm changesets:check`

All 13 accumulator tests pass, including a 20,000-segment regression that fails on main.

## Public surface

`assistant-stream` receives a patch changeset. No exports, types, or wire formats change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.kxRwqkzJa6W4z9FpAsALzmL-GrqCnPVKsf54z_-kBZRoBJTEs50xsYwY9Fs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->