### PR TITLE
fix(react-google-adk): preserve prototype-named deltas

### DIFF
--- a/.changeset/google-adk-prototype-keys.md
+++ b/.changeset/google-adk-prototype-keys.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: preserve prototype-named session and artifact delta keys

--- a/packages/react-google-adk/src/AdkEventAccumulator.test.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.test.ts
@@ -838,6 +838,27 @@ describe("AdkEventAccumulator - actions tracking", () => {
     expect(acc.getArtifactDelta()).toEqual({ "file.txt": 1 });
   });
 
+  it("preserves prototype-named state and artifact keys", () => {
+    const acc = new AdkEventAccumulator();
+    acc.processEvent(
+      makeEvent({
+        actions: {
+          stateDelta: JSON.parse('{"__proto__":"session"}'),
+          artifactDelta: JSON.parse('{"__proto__":1}'),
+        },
+        author: "agent",
+        content: { parts: [{ text: "x" }] },
+      }),
+    );
+
+    const stateDelta = acc.getStateDelta();
+    const artifactDelta = acc.getArtifactDelta();
+    expect(Object.hasOwn(stateDelta, "__proto__")).toBe(true);
+    expect(stateDelta["__proto__"]).toBe("session");
+    expect(Object.hasOwn(artifactDelta, "__proto__")).toBe(true);
+    expect(artifactDelta["__proto__"]).toBe(1);
+  });
+
   it("tracks escalation flag", () => {
     const acc = new AdkEventAccumulator();
     expect(acc.isEscalated()).toBe(false);

--- a/packages/react-google-adk/src/AdkEventAccumulator.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.ts
@@ -194,8 +194,9 @@ export class AdkEventAccumulator {
   private finalTextReplacedThisEvent = false;
   private finalReasoningReplacedThisEvent = false;
   private partialReasoningBuffer = "";
-  private accumulatedStateDelta: Record<string, unknown> = {};
-  private accumulatedArtifactDelta: Record<string, number> = {};
+  private accumulatedStateDelta: Record<string, unknown> = Object.create(null);
+  private accumulatedArtifactDelta: Record<string, number> =
+    Object.create(null);
   private lastAgentInfo: {
     name?: string | undefined;
     branch?: string | undefined;


### PR DESCRIPTION
## Problem

Google ADK session-state and artifact deltas can contain arbitrary string keys. On current main, a parsed own `__proto__` key disappears while events are accumulated, so consumers receive incomplete state or artifact metadata.

## Root cause

`AdkEventAccumulator` merged deltas with `Object.assign()` into ordinary objects. Assigning `__proto__` invokes the inherited prototype setter instead of creating an own data property.

## Change

Use null-prototype records for the two internal delta accumulators. Existing getters continue returning copied records, while prototype-named keys are retained as own properties.

## Verification

- Added a regression test for parsed `__proto__` state and artifact keys; it fails on main and passes with the fix.
- `pnpm --filter @assistant-ui/react-google-adk exec vitest run src/AdkEventAccumulator.test.ts` (75 tests)
- `pnpm --filter @assistant-ui/react-google-adk... build`
- Focused oxlint and `pnpm changesets:check`

## Public surface

`@assistant-ui/react-google-adk` behavior changes only. No exports or API signatures change. Includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.XRzvgdKEU5tnR2sOP9rAvBGLKUCS_-NDvCtNrdvdJAfSHjlokdeA4PC7GX4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->