### PR TITLE
ci(docs): reject partial repo-source route traces

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "pnpm generate:type-docs && pnpm generate:source-snapshot && next build",
+    "build": "pnpm generate:type-docs && pnpm generate:source-snapshot && next build && pnpm verify:repo-source-traces",
     "generate:type-docs": "tsx ./scripts/generate-type-docs.mts",
     "generate:api-reference": "tsx ./scripts/generate-api-reference.mts",
     "generate:source-snapshot": "tsx ./scripts/generate-source-snapshot.mts",
+    "verify:repo-source-traces": "tsx ./scripts/check-repo-source-traces.mts",
     "start": "next start",
     "test": "vitest run",
     "postinstall": "fumadocs-mdx"

--- a/apps/docs/scripts/check-repo-source-traces.mts
+++ b/apps/docs/scripts/check-repo-source-traces.mts
@@ -10,6 +10,8 @@ import {
 const DOCS_ROOT = process.cwd();
 const SOURCE_ROOT = path.join(DOCS_ROOT, "generated", ".repo-source");
 const SERVER_ROOT = path.join(DOCS_ROOT, ".next", "server");
+// This intentionally duplicates next.config.ts: deriving it from that config
+// would also remove the requirement when an include is accidentally deleted.
 const REQUIRED_REPO_SOURCE_ROUTE_TRACES = [
   "app/api/doc/chat/route.js.nft.json",
   "app/api/xulux/chat/route.js.nft.json",

--- a/apps/docs/scripts/check-repo-source-traces.mts
+++ b/apps/docs/scripts/check-repo-source-traces.mts
@@ -9,7 +9,15 @@ import {
 
 const DOCS_ROOT = process.cwd();
 const SOURCE_ROOT = path.join(DOCS_ROOT, "generated", ".repo-source");
-const ROUTES_ROOT = path.join(DOCS_ROOT, ".next", "server", "app");
+const SERVER_ROOT = path.join(DOCS_ROOT, ".next", "server");
+const REQUIRED_REPO_SOURCE_ROUTE_TRACES = [
+  "app/api/doc/chat/route.js.nft.json",
+  "app/api/xulux/chat/route.js.nft.json",
+  "app/api/xulux/demo-download/route.js.nft.json",
+  "app/api/xulux/learn/chat/route.js.nft.json",
+  "app/api/xulux/learn/download/route.js.nft.json",
+  "app/api/xulux/learn/source/route.js.nft.json",
+] as const;
 
 async function listFiles(directory: string): Promise<string[]> {
   const entries = await fs.readdir(directory, { withFileTypes: true });
@@ -38,38 +46,64 @@ async function readRouteTrace(filePath: string): Promise<RouteTrace> {
 }
 
 async function main() {
-  const [sourceFiles, routeTracePaths] = await Promise.all([
+  const [sourceFiles, serverTracePaths] = await Promise.all([
     listFiles(SOURCE_ROOT),
-    listFiles(ROUTES_ROOT).then((files) =>
-      files.filter((file) => file.endsWith(`${path.sep}route.js.nft.json`)),
+    listFiles(SERVER_ROOT).then((files) =>
+      files.filter((file) => file.endsWith(".js.nft.json")),
     ),
   ]);
 
   if (sourceFiles.length === 0) {
     throw new Error(`Generated repo source tree is empty: ${SOURCE_ROOT}`);
   }
-  if (routeTracePaths.length === 0) {
-    throw new Error(`No Next.js route traces found under ${ROUTES_ROOT}`);
+  if (serverTracePaths.length === 0) {
+    throw new Error(`No Next.js server traces found under ${SERVER_ROOT}`);
   }
 
-  const routeTraces = await Promise.all(routeTracePaths.map(readRouteTrace));
+  const requiredTracePaths = new Set(
+    REQUIRED_REPO_SOURCE_ROUTE_TRACES.map((file) =>
+      path.join(SERVER_ROOT, file),
+    ),
+  );
+  const emittedTracePaths = new Set(serverTracePaths);
+  const missingRequiredTracePaths = [...requiredTracePaths].filter(
+    (file) => !emittedTracePaths.has(file),
+  );
+
+  if (missingRequiredTracePaths.length > 0) {
+    console.error(
+      [
+        "Required repo-source route traces were not emitted:",
+        ...missingRequiredTracePaths.map((file) =>
+          path.relative(SERVER_ROOT, file),
+        ),
+      ].join("\n"),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const routeTraces = await Promise.all(serverTracePaths.map(readRouteTrace));
   const incomplete = findIncompleteRouteTraces(
     SOURCE_ROOT,
     sourceFiles,
     routeTraces,
+    requiredTracePaths,
   );
 
   if (incomplete.length > 0) {
-    throw new Error(
+    console.error(
       formatIncompleteRouteTraces(SOURCE_ROOT, sourceFiles.length, incomplete),
     );
+    process.exitCode = 1;
+    return;
   }
 
   const tracedRouteCount = routeTraces.filter(
     (trace) => getTracedSourceFiles(SOURCE_ROOT, trace).size > 0,
   ).length;
   console.log(
-    `Verified ${routeTraces.length} route bundles: ${tracedRouteCount} trace all ${sourceFiles.length} repo-source files and ${routeTraces.length - tracedRouteCount} trace none.`,
+    `Verified ${routeTraces.length} server bundles: ${tracedRouteCount} trace all ${sourceFiles.length} repo-source files and ${routeTraces.length - tracedRouteCount} trace none.`,
   );
 }
 

--- a/apps/docs/scripts/check-repo-source-traces.mts
+++ b/apps/docs/scripts/check-repo-source-traces.mts
@@ -1,0 +1,76 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  findIncompleteRouteTraces,
+  formatIncompleteRouteTraces,
+  getTracedSourceFiles,
+  type RouteTrace,
+} from "./repo-source-traces.mts";
+
+const DOCS_ROOT = process.cwd();
+const SOURCE_ROOT = path.join(DOCS_ROOT, "generated", ".repo-source");
+const ROUTES_ROOT = path.join(DOCS_ROOT, ".next", "server", "app");
+
+async function listFiles(directory: string): Promise<string[]> {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const filePath = path.join(directory, entry.name);
+      return entry.isDirectory() ? listFiles(filePath) : [filePath];
+    }),
+  );
+  return files.flat();
+}
+
+async function readRouteTrace(filePath: string): Promise<RouteTrace> {
+  const parsed: unknown = JSON.parse(await fs.readFile(filePath, "utf-8"));
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    !("files" in parsed) ||
+    !Array.isArray(parsed.files) ||
+    parsed.files.some((file) => typeof file !== "string")
+  ) {
+    throw new Error(`Invalid Next.js trace file: ${filePath}`);
+  }
+
+  return { filePath, files: parsed.files as string[] };
+}
+
+async function main() {
+  const [sourceFiles, routeTracePaths] = await Promise.all([
+    listFiles(SOURCE_ROOT),
+    listFiles(ROUTES_ROOT).then((files) =>
+      files.filter((file) => file.endsWith(`${path.sep}route.js.nft.json`)),
+    ),
+  ]);
+
+  if (sourceFiles.length === 0) {
+    throw new Error(`Generated repo source tree is empty: ${SOURCE_ROOT}`);
+  }
+  if (routeTracePaths.length === 0) {
+    throw new Error(`No Next.js route traces found under ${ROUTES_ROOT}`);
+  }
+
+  const routeTraces = await Promise.all(routeTracePaths.map(readRouteTrace));
+  const incomplete = findIncompleteRouteTraces(
+    SOURCE_ROOT,
+    sourceFiles,
+    routeTraces,
+  );
+
+  if (incomplete.length > 0) {
+    throw new Error(
+      formatIncompleteRouteTraces(SOURCE_ROOT, sourceFiles.length, incomplete),
+    );
+  }
+
+  const tracedRouteCount = routeTraces.filter(
+    (trace) => getTracedSourceFiles(SOURCE_ROOT, trace).size > 0,
+  ).length;
+  console.log(
+    `Verified ${routeTraces.length} route bundles: ${tracedRouteCount} trace all ${sourceFiles.length} repo-source files and ${routeTraces.length - tracedRouteCount} trace none.`,
+  );
+}
+
+await main();

--- a/apps/docs/scripts/repo-source-traces.mts
+++ b/apps/docs/scripts/repo-source-traces.mts
@@ -1,0 +1,87 @@
+import path from "node:path";
+
+export type RouteTrace = {
+  readonly filePath: string;
+  readonly files: readonly string[];
+};
+
+export type IncompleteRouteTrace = {
+  readonly filePath: string;
+  readonly tracedFileCount: number;
+  readonly missingFiles: readonly string[];
+  readonly unexpectedFiles: readonly string[];
+};
+
+const isWithin = (root: string, candidate: string) =>
+  candidate === root || candidate.startsWith(`${root}${path.sep}`);
+
+export function getTracedSourceFiles(
+  sourceRoot: string,
+  trace: RouteTrace,
+): Set<string> {
+  const resolvedRoot = path.resolve(sourceRoot);
+  return new Set(
+    trace.files
+      .map((file) => path.resolve(path.dirname(trace.filePath), file))
+      .filter((file) => isWithin(resolvedRoot, file)),
+  );
+}
+
+export function findIncompleteRouteTraces(
+  sourceRoot: string,
+  sourceFiles: readonly string[],
+  routeTraces: readonly RouteTrace[],
+): IncompleteRouteTrace[] {
+  const sourceSet = new Set(sourceFiles.map((file) => path.resolve(file)));
+
+  return routeTraces.flatMap((trace) => {
+    const tracedSourceFiles = getTracedSourceFiles(sourceRoot, trace);
+
+    if (tracedSourceFiles.size === 0) return [];
+
+    const missingFiles = [...sourceSet]
+      .filter((file) => !tracedSourceFiles.has(file))
+      .sort();
+    const unexpectedFiles = [...tracedSourceFiles]
+      .filter((file) => !sourceSet.has(file))
+      .sort();
+
+    if (missingFiles.length === 0 && unexpectedFiles.length === 0) return [];
+
+    return [
+      {
+        filePath: trace.filePath,
+        tracedFileCount: tracedSourceFiles.size,
+        missingFiles,
+        unexpectedFiles,
+      },
+    ];
+  });
+}
+
+const formatSample = (label: string, files: readonly string[], root: string) =>
+  files.length === 0
+    ? []
+    : [
+        `${label} (${files.length}):`,
+        ...files.slice(0, 5).map((file) => `  ${path.relative(root, file)}`),
+        ...(files.length > 5 ? [`  ...and ${files.length - 5} more`] : []),
+      ];
+
+export function formatIncompleteRouteTraces(
+  sourceRoot: string,
+  sourceFileCount: number,
+  incomplete: readonly IncompleteRouteTrace[],
+) {
+  return [
+    `Found ${incomplete.length} route bundle${incomplete.length === 1 ? "" : "s"} with a partial repo-source trace.`,
+    "Each route must trace either the complete generated repo source tree or none of it.",
+    "",
+    ...incomplete.flatMap((trace, index) => [
+      ...(index === 0 ? [] : [""]),
+      `${trace.filePath}: traced ${trace.tracedFileCount} of ${sourceFileCount} source files`,
+      ...formatSample("Missing", trace.missingFiles, sourceRoot),
+      ...formatSample("Unexpected", trace.unexpectedFiles, sourceRoot),
+    ]),
+  ].join("\n");
+}

--- a/apps/docs/scripts/repo-source-traces.mts
+++ b/apps/docs/scripts/repo-source-traces.mts
@@ -31,13 +31,22 @@ export function findIncompleteRouteTraces(
   sourceRoot: string,
   sourceFiles: readonly string[],
   routeTraces: readonly RouteTrace[],
+  requiredTracePaths: ReadonlySet<string> = new Set(),
 ): IncompleteRouteTrace[] {
   const sourceSet = new Set(sourceFiles.map((file) => path.resolve(file)));
+  const requiredTraceSet = new Set(
+    [...requiredTracePaths].map((file) => path.resolve(file)),
+  );
 
   return routeTraces.flatMap((trace) => {
     const tracedSourceFiles = getTracedSourceFiles(sourceRoot, trace);
 
-    if (tracedSourceFiles.size === 0) return [];
+    if (
+      tracedSourceFiles.size === 0 &&
+      !requiredTraceSet.has(path.resolve(trace.filePath))
+    ) {
+      return [];
+    }
 
     const missingFiles = [...sourceSet]
       .filter((file) => !tracedSourceFiles.has(file))
@@ -74,8 +83,8 @@ export function formatIncompleteRouteTraces(
   incomplete: readonly IncompleteRouteTrace[],
 ) {
   return [
-    `Found ${incomplete.length} route bundle${incomplete.length === 1 ? "" : "s"} with a partial repo-source trace.`,
-    "Each route must trace either the complete generated repo source tree or none of it.",
+    `Found ${incomplete.length} server bundle${incomplete.length === 1 ? "" : "s"} with an incomplete repo-source trace.`,
+    "Required routes must trace the complete generated repo source tree; every other bundle must trace all or none of it.",
     "",
     ...incomplete.flatMap((trace, index) => [
       ...(index === 0 ? [] : [""]),

--- a/apps/docs/scripts/repo-source-traces.test.ts
+++ b/apps/docs/scripts/repo-source-traces.test.ts
@@ -1,0 +1,78 @@
+import path from "node:path";
+import {
+  findIncompleteRouteTraces,
+  formatIncompleteRouteTraces,
+  type RouteTrace,
+} from "./repo-source-traces.mts";
+
+const sourceRoot = path.resolve("/workspace/apps/docs/generated/.repo-source");
+const sourceFiles = ["a.ts", "nested/b.ts"].map((file) =>
+  path.join(sourceRoot, file),
+);
+
+const trace = (name: string, files: readonly string[]): RouteTrace => {
+  const filePath = path.resolve(
+    `/workspace/apps/docs/.next/server/app/api/${name}/route.js.nft.json`,
+  );
+  return {
+    filePath,
+    files: files.map((file) => path.relative(path.dirname(filePath), file)),
+  };
+};
+
+describe("findIncompleteRouteTraces", () => {
+  it("accepts route bundles that trace the complete source tree or none of it", () => {
+    const routeTraces = [
+      trace("full", [...sourceFiles, ...sourceFiles]),
+      trace("empty", [path.resolve("/workspace/apps/docs/package.json")]),
+    ];
+
+    expect(
+      findIncompleteRouteTraces(sourceRoot, sourceFiles, routeTraces),
+    ).toEqual([]);
+  });
+
+  it("reports a route bundle that traces only part of the source tree", () => {
+    const filePath = trace("partial", [sourceFiles[0]!]).filePath;
+
+    expect(
+      findIncompleteRouteTraces(sourceRoot, sourceFiles, [
+        trace("partial", [sourceFiles[0]!]),
+      ]),
+    ).toEqual([
+      {
+        filePath,
+        tracedFileCount: 1,
+        missingFiles: [sourceFiles[1]!],
+        unexpectedFiles: [],
+      },
+    ]);
+  });
+
+  it("reports stale traced files that are not in the generated tree", () => {
+    const staleFile = path.join(sourceRoot, "deleted.ts");
+    const result = findIncompleteRouteTraces(sourceRoot, sourceFiles, [
+      trace("stale", [...sourceFiles, staleFile]),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.unexpectedFiles).toEqual([staleFile]);
+  });
+});
+
+describe("formatIncompleteRouteTraces", () => {
+  it("explains the invariant and lists missing files", () => {
+    const incomplete = findIncompleteRouteTraces(sourceRoot, sourceFiles, [
+      trace("partial", [sourceFiles[0]!]),
+    ]);
+    const output = formatIncompleteRouteTraces(
+      sourceRoot,
+      sourceFiles.length,
+      incomplete,
+    );
+
+    expect(output).toContain("partial repo-source trace");
+    expect(output).toContain("traced 1 of 2 source files");
+    expect(output).toContain(`Missing (1):\n  nested${path.sep}b.ts`);
+  });
+});

--- a/apps/docs/scripts/repo-source-traces.test.ts
+++ b/apps/docs/scripts/repo-source-traces.test.ts
@@ -49,6 +49,28 @@ describe("findIncompleteRouteTraces", () => {
     ]);
   });
 
+  it("reports a required route bundle that traces none of the source tree", () => {
+    const emptyTrace = trace("required", [
+      path.resolve("/workspace/apps/docs/package.json"),
+    ]);
+
+    expect(
+      findIncompleteRouteTraces(
+        sourceRoot,
+        sourceFiles,
+        [emptyTrace],
+        new Set([emptyTrace.filePath]),
+      ),
+    ).toEqual([
+      {
+        filePath: emptyTrace.filePath,
+        tracedFileCount: 0,
+        missingFiles: sourceFiles,
+        unexpectedFiles: [],
+      },
+    ]);
+  });
+
   it("reports stale traced files that are not in the generated tree", () => {
     const staleFile = path.join(sourceRoot, "deleted.ts");
     const result = findIncompleteRouteTraces(sourceRoot, sourceFiles, [
@@ -71,7 +93,7 @@ describe("formatIncompleteRouteTraces", () => {
       incomplete,
     );
 
-    expect(output).toContain("partial repo-source trace");
+    expect(output).toContain("incomplete repo-source trace");
     expect(output).toContain("traced 1 of 2 source files");
     expect(output).toContain(`Missing (1):\n  nested${path.sep}b.ts`);
   });


### PR DESCRIPTION
## Problem

The docs assistant reads `generated/.repo-source` through a runtime filesystem path that Next.js cannot trace statically. The routes that need the tree are listed manually in `outputFileTracingIncludes`; if that list drifts, a route can ship only the subset discovered through its module graph while `next build` still succeeds.

Closes #6751.

## Root cause

Nothing inspected the emitted `.next/server/**/*.js.nft.json` files after a build, and no independent contract required the six repo-reading routes to carry the source tree.

## Change

Run a repo-source trace verifier after every docs build. It inspects every emitted server trace, resolves and deduplicates its paths, and requires each bundle to include either every generated source file or none of them. The six routes that read repo source are explicitly required to include the complete tree, so a missing config entry cannot pass as an empty trace.

A missing required trace, partial trace, or stale trace fails with a focused diagnostic and a bounded list of missing or unexpected files.

## Verification

- `pnpm -C apps/docs build` - passed; 105 server bundles checked, six traced all 5,298 source files and 99 traced none
- `pnpm -C apps/docs exec vitest run --maxWorkers=1` - 850 tests passed, seven skipped
- `pnpm -C apps/docs exec vitest run scripts/repo-source-traces.test.ts` - five tests passed
- `pnpm -C apps/docs exec tsc --noEmit -p scripts/tsconfig.json`
- scoped oxlint and oxfmt checks
- `git diff --check`

## Public surface

None. `@assistant-ui/docs` is private; exports, API-reference output, templates, and changesets are unaffected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.RqrDVYDLvuuQsHpT4iYYtCPRRHGbtPH2BNTzjoxe46G0UcxIC870I2-mWF0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->