### PR TITLE
fix(react-google-adk): validate event content parts

### DIFF
--- a/.changeset/quiet-adk-events.md
+++ b/.changeset/quiet-adk-events.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix(react-google-adk): validate event content parts

--- a/packages/react-google-adk/src/AdkClient.test.ts
+++ b/packages/react-google-adk/src/AdkClient.test.ts
@@ -500,9 +500,12 @@ describe("createAdkStream - SSE parsing", () => {
     },
   );
 
-  it.each([{ content: null }, { content: { parts: null } }])(
+  it.each([
+    [{ id: "e1", content: null }, undefined],
+    [{ id: "e1", content: { role: "model", parts: null } }, { role: "model" }],
+  ])(
     "accepts null optional nested stream event content: %#",
-    async (event) => {
+    async (event, expectedContent) => {
       mockFetch.mockResolvedValueOnce(
         sseResponse(sseBody(`data: ${JSON.stringify(event)}\n\n`)),
       );
@@ -518,6 +521,7 @@ describe("createAdkStream - SSE parsing", () => {
       }
 
       expect(collected).toHaveLength(1);
+      expect(collected[0]!.content).toEqual(expectedContent);
     },
   );
 

--- a/packages/react-google-adk/src/AdkClient.test.ts
+++ b/packages/react-google-adk/src/AdkClient.test.ts
@@ -473,7 +473,6 @@ describe("createAdkStream - SSE parsing", () => {
   );
 
   it.each([
-    [{ content: null }, "content", "an object"],
     [{ content: [] }, "content", "an object"],
     [{ content: { parts: 42 } }, "content.parts", "an array of objects"],
     [{ content: { parts: [null] } }, "content.parts", "an array of objects"],
@@ -498,6 +497,27 @@ describe("createAdkStream - SSE parsing", () => {
       await expect(consume()).rejects.toThrow(
         `Invalid ADK stream event: expected "${field}" to be ${expectation} when present.`,
       );
+    },
+  );
+
+  it.each([{ content: null }, { content: { parts: null } }])(
+    "accepts null optional nested stream event content: %#",
+    async (event) => {
+      mockFetch.mockResolvedValueOnce(
+        sseResponse(sseBody(`data: ${JSON.stringify(event)}\n\n`)),
+      );
+
+      const stream = createAdkStream({ api: "/api/adk" });
+      const gen = await stream(
+        [{ id: "m1", type: "human", content: "Hi" }],
+        makeConfig(),
+      );
+      const collected: AdkEvent[] = [];
+      for await (const parsedEvent of gen) {
+        collected.push(parsedEvent);
+      }
+
+      expect(collected).toHaveLength(1);
     },
   );
 

--- a/packages/react-google-adk/src/AdkClient.test.ts
+++ b/packages/react-google-adk/src/AdkClient.test.ts
@@ -472,6 +472,35 @@ describe("createAdkStream - SSE parsing", () => {
     },
   );
 
+  it.each([
+    [{ content: null }, "content", "an object"],
+    [{ content: [] }, "content", "an object"],
+    [{ content: { parts: 42 } }, "content.parts", "an array of objects"],
+    [{ content: { parts: [null] } }, "content.parts", "an array of objects"],
+  ])(
+    "rejects malformed nested stream event content: %#",
+    async (event, field, expectation) => {
+      mockFetch.mockResolvedValueOnce(
+        sseResponse(sseBody(`data: ${JSON.stringify(event)}\n\n`)),
+      );
+
+      const stream = createAdkStream({ api: "/api/adk" });
+      const consume = async () => {
+        const gen = await stream(
+          [{ id: "m1", type: "human", content: "Hi" }],
+          makeConfig(),
+        );
+        for await (const _event of gen) {
+          void _event;
+        }
+      };
+
+      await expect(consume()).rejects.toThrow(
+        `Invalid ADK stream event: expected "${field}" to be ${expectation} when present.`,
+      );
+    },
+  );
+
   it("reports invalid JSON as an ADK stream event error", async () => {
     mockFetch.mockResolvedValueOnce(sseResponse(sseBody("data: not-json\n\n")));
 

--- a/packages/react-google-adk/src/parseAdkEvent.ts
+++ b/packages/react-google-adk/src/parseAdkEvent.ts
@@ -1,15 +1,20 @@
 import type { AdkEvent } from "./types";
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const invalidField = (
+  errorPrefix: string,
+  field: string,
+  expectation: string,
+): Error =>
+  new Error(`${errorPrefix}: expected "${field}" to be ${expectation}.`);
+
 export function parseAdkEventValue(
   value: unknown,
   errorPrefix: string,
 ): AdkEvent {
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    Array.isArray(value) ||
-    Object.keys(value).length === 0
-  ) {
+  if (!isRecord(value) || Object.keys(value).length === 0) {
     throw new Error(`${errorPrefix}: expected a non-empty object.`);
   }
 
@@ -22,6 +27,25 @@ export function parseAdkEventValue(
     throw new Error(
       `${errorPrefix}: expected "id" to be a string or finite number when present.`,
     );
+  }
+
+  const content = event.content;
+  if (content !== undefined) {
+    if (!isRecord(content)) {
+      throw invalidField(errorPrefix, "content", "an object when present");
+    }
+
+    const parts = content.parts;
+    if (
+      parts !== undefined &&
+      (!Array.isArray(parts) || !parts.every(isRecord))
+    ) {
+      throw invalidField(
+        errorPrefix,
+        "content.parts",
+        "an array of objects when present",
+      );
+    }
   }
 
   const errorMessage =

--- a/packages/react-google-adk/src/parseAdkEvent.ts
+++ b/packages/react-google-adk/src/parseAdkEvent.ts
@@ -16,7 +16,11 @@ export function parseAdkEventValue(
     throw new Error(`${errorPrefix}: expected a non-empty object.`);
   }
 
-  const { id: rawId, ...event } = value as Record<string, unknown>;
+  const {
+    id: rawId,
+    content: rawContent,
+    ...event
+  } = value as Record<string, unknown>;
   if (
     rawId != null &&
     typeof rawId !== "string" &&
@@ -27,13 +31,13 @@ export function parseAdkEventValue(
     );
   }
 
-  const content = event.content;
-  if (content != null) {
-    if (!isRecord(content)) {
+  let content: Record<string, unknown> | undefined;
+  if (rawContent != null) {
+    if (!isRecord(rawContent)) {
       throw invalidField(errorPrefix, "content", "an object when present");
     }
 
-    const parts = content.parts;
+    const { parts, ...contentFields } = rawContent;
     if (parts != null && (!Array.isArray(parts) || !parts.every(isRecord))) {
       throw invalidField(
         errorPrefix,
@@ -41,6 +45,11 @@ export function parseAdkEventValue(
         "an array of objects when present",
       );
     }
+
+    content = {
+      ...contentFields,
+      ...(parts != null && { parts }),
+    };
   }
 
   const errorMessage =
@@ -49,6 +58,7 @@ export function parseAdkEventValue(
       : undefined;
   return {
     ...event,
+    ...(content !== undefined && { content }),
     ...(rawId != null && { id: String(rawId) }),
     ...(errorMessage !== undefined &&
       !("errorMessage" in event) &&

--- a/packages/react-google-adk/src/parseAdkEvent.ts
+++ b/packages/react-google-adk/src/parseAdkEvent.ts
@@ -28,16 +28,13 @@ export function parseAdkEventValue(
   }
 
   const content = event.content;
-  if (content !== undefined) {
+  if (content != null) {
     if (!isRecord(content)) {
       throw invalidField(errorPrefix, "content", "an object when present");
     }
 
     const parts = content.parts;
-    if (
-      parts !== undefined &&
-      (!Array.isArray(parts) || !parts.every(isRecord))
-    ) {
+    if (parts != null && (!Array.isArray(parts) || !parts.every(isRecord))) {
       throw invalidField(
         errorPrefix,
         "content.parts",

--- a/packages/react-google-adk/src/parseAdkEvent.ts
+++ b/packages/react-google-adk/src/parseAdkEvent.ts
@@ -1,7 +1,5 @@
+import { isRecord } from "@assistant-ui/core/internal";
 import type { AdkEvent } from "./types";
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const invalidField = (
   errorPrefix: string,


### PR DESCRIPTION
## Problem

A successful Google ADK event can contain a malformed nested content shape. On current main, an SSE frame with `content.parts: 42` passes `parseAdkEventValue()` and later throws `TypeError: parts.map is not a function` in the accumulator.

## Root cause

The event parser validates only the outer object and optional ID. The accumulator assumes that a present `content` value is an object and that `content.parts` is an array of objects.

## Change

Validate the content container and part-array shape at the existing event parsing boundary. Unknown fields inside valid part objects remain accepted for forward compatibility with the ADK vocabulary.

## Verification

- `pnpm --filter @assistant-ui/react-google-adk... build`
- `pnpm --filter @assistant-ui/react-google-adk test` (338 tests)
- `pnpm exec oxlint packages/react-google-adk/src/parseAdkEvent.ts packages/react-google-adk/src/AdkClient.test.ts`
- `pnpm changesets:check`

The regression coverage includes the original `content.parts: 42` failure plus malformed content containers and part-array members.

## Public surface

Affected package: `@assistant-ui/react-google-adk`. No exports, API reference, templates, or documentation change. Includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Soo-PNcl8Aq4GWo-IWwmkGSnneY6ymiDOOhjVE6-ZewUgtqwLi8mQhpgvxw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->