### PR TITLE
fix(core): release failed frame tool requests

### DIFF
--- a/.changeset/clean-frame-send-failures.md
+++ b/.changeset/clean-frame-send-failures.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: release frame tool request resources when sending the request fails

--- a/packages/core/src/model-context/frame/host.test.ts
+++ b/packages/core/src/model-context/frame/host.test.ts
@@ -133,6 +133,30 @@ describe("AssistantFrameHost", () => {
     host.dispose();
   });
 
+  it("cleans up tool calls when posting the request fails", async () => {
+    const { execute, host, postMessage } = createHost();
+    const error = new Error("postMessage failed");
+    const abortController = new AbortController();
+    const removeEventListener = vi.spyOn(
+      abortController.signal,
+      "removeEventListener",
+    );
+    postMessage.mockImplementation((data) => {
+      if (data.message.type === "tool-call") throw error;
+    });
+
+    await expect(
+      execute({}, { ...executionContext, abortSignal: abortController.signal }),
+    ).rejects.toBe(error);
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    );
+    host.dispose();
+  });
+
   it("rejects tool results that carry an empty error message", async () => {
     const { dispatchMessage, execute, getToolCallId, host } = createHost();
     const result = Promise.resolve(

--- a/packages/core/src/model-context/frame/host.ts
+++ b/packages/core/src/model-context/frame/host.ts
@@ -195,10 +195,16 @@ export class AssistantFrameHost implements ModelContextProvider {
       }, timeout);
       abortSignal?.addEventListener("abort", onAbort, { once: true });
 
-      this._iframeWindow.postMessage(
-        { channel: FRAME_MESSAGE_CHANNEL, message },
-        this._targetOrigin,
-      );
+      try {
+        this._iframeWindow.postMessage(
+          { channel: FRAME_MESSAGE_CHANNEL, message },
+          this._targetOrigin,
+        );
+      } catch (error) {
+        const pending = this._pendingRequests.get(message.id);
+        this._pendingRequests.delete(message.id);
+        pending?.reject(error);
+      }
     });
   }
 


### PR DESCRIPTION
## Problem

AssistantFrameHost registers a pending request, a 30-second timeout, and an abort listener before posting a tool call to its frame.

When postMessage throws synchronously, the tool Promise rejects but those request resources remain registered until a later timeout, abort, or host disposal. A failed send therefore retains unnecessary state and can trigger delayed cancellation work.

The regression test reproduces this on current main by making the tool-call post throw. Before the fix, the Promise rejects but one timer remains active.

## Root cause

The Promise constructor converts the synchronous postMessage exception into a rejection, but that path bypasses the cleanup wrapper stored for the pending request.

## Change

Catch synchronous failures at the request-send boundary, remove the pending entry, and reject through its existing wrapper. That wrapper clears the timeout and removes the abort listener.

Successful frame requests and the public API are unchanged.

## Verification

- Confirmed the new regression test fails on current main with one retained timer
- Confirmed the same test passes after the fix and observes abort-listener removal
- Full @assistant-ui/core suite: 169 files and 1,806 tests passed
- Focused frame-host suite: 14 tests passed
- @assistant-ui/core build passed
- Size check passed with no budget update required
- Changeset validation, semver validation, lint, formatting, and diff checks passed

## Public surface

@assistant-ui/core behavior only. No exports, API-reference output, docs, or templates change. Includes a patch changeset.

Closes #7164

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.HcbygLLRjvG9kQ5u3T8eBdzOIxtqylf82QafUi2NiF92dpA6JVTbqM_hRDE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->