### PR TITLE
fix(react-a2a): validate nested message parts

### DIFF
--- a/.changeset/calm-a2a-parts.md
+++ b/.changeset/calm-a2a-parts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix(react-a2a): validate nested message part fields

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -529,6 +529,34 @@ describe("A2AClient", () => {
     });
 
     it.each([
+      [
+        "status message",
+        {
+          status: {
+            state: "completed",
+            message: { parts: [{ text: { invalid: true } }] },
+          },
+        },
+      ],
+      ["history message", { history: [{ parts: [{ raw: 42 }] }] }],
+      ["artifact", { artifacts: [{ parts: [{ metadata: [] }] }] }],
+    ])("rejects a task with malformed %s parts", async (_name, nested) => {
+      fetchMock.mockResolvedValue(
+        mockFetchResponse({
+          task: {
+            id: "t1",
+            status: { state: "completed" },
+            ...nested,
+          },
+        }),
+      );
+
+      await expect(client.sendMessage(userMessage)).rejects.toThrow(
+        "Invalid A2A message:send response: expected a valid task or message payload.",
+      );
+    });
+
+    it.each([
       ["task", { id: "t1", status: { state: "completed" } }],
       [
         "message",
@@ -1137,6 +1165,25 @@ describe("A2AClient", () => {
             artifact: {
               artifact_id: "a1",
               parts: [{ url: 42 }],
+            },
+          },
+        },
+        {
+          status_update: {
+            task_id: "t1",
+            context_id: "c1",
+            status: {
+              state: "TASK_STATE_WORKING",
+              message: { parts: [{ text: { invalid: true } }] },
+            },
+          },
+        },
+        {
+          task: {
+            id: "t1",
+            status: {
+              state: "TASK_STATE_WORKING",
+              message: { parts: [{ text: { invalid: true } }] },
             },
           },
         },

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -480,6 +480,55 @@ describe("A2AClient", () => {
     });
 
     it.each([
+      ["text", { invalid: true }],
+      ["raw", 42],
+      ["url", false],
+      ["filename", []],
+      ["mediaType", {}],
+      ["metadata", []],
+    ])("rejects a message part with malformed %s", async (field, value) => {
+      fetchMock.mockResolvedValue(
+        mockFetchResponse({
+          message: {
+            messageId: "m2",
+            role: "agent",
+            parts: [{ [field]: value }],
+          },
+        }),
+      );
+
+      await expect(client.sendMessage(userMessage)).rejects.toThrow(
+        "Invalid A2A message:send response: expected a valid task or message payload.",
+      );
+    });
+
+    it("normalizes null optional message-part fields", async () => {
+      fetchMock.mockResolvedValue(
+        mockFetchResponse({
+          message: {
+            messageId: "m2",
+            role: "agent",
+            parts: [
+              {
+                text: null,
+                raw: null,
+                url: null,
+                data: null,
+                metadata: null,
+                filename: null,
+                mediaType: null,
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await client.sendMessage(userMessage);
+
+      expect((result as A2AMessage).parts).toEqual([{ data: null }]);
+    });
+
+    it.each([
       ["task", { id: "t1", status: { state: "completed" } }],
       [
         "message",
@@ -1054,6 +1103,41 @@ describe("A2AClient", () => {
             task_id: { nested: "object" },
             role: "ROLE_AGENT",
             parts: [{ text: "hi" }],
+          },
+        },
+      ];
+
+      for (const frame of frames) {
+        fetchMock.mockResolvedValue(
+          mockSSEResponse([`data: ${JSON.stringify(frame)}`, "", ""]),
+        );
+
+        const events: A2AStreamEvent[] = [];
+        for await (const event of client.streamMessage(userMessage)) {
+          events.push(event);
+        }
+
+        expect(events).toEqual([]);
+      }
+    });
+
+    it("drops wrapped messages and artifact updates with malformed parts", async () => {
+      const frames = [
+        {
+          message: {
+            message_id: "m1",
+            role: "ROLE_AGENT",
+            parts: [{ text: { invalid: true } }],
+          },
+        },
+        {
+          artifact_update: {
+            task_id: "t1",
+            context_id: "c1",
+            artifact: {
+              artifact_id: "a1",
+              parts: [{ url: 42 }],
+            },
           },
         },
       ];

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -70,14 +70,15 @@ const JSONRPC_STATE_MAP: Record<string, string> = {
   unknown: "unspecified",
 };
 
-const NULLABLE_PART_FIELDS = [
+const PART_STRING_FIELDS = [
   "text",
   "raw",
   "url",
-  "metadata",
   "filename",
   "mediaType",
 ] as const;
+
+const NULLABLE_PART_FIELDS = [...PART_STRING_FIELDS, "metadata"] as const;
 
 function normalizePartNulls(
   part: Record<string, unknown>,
@@ -302,14 +303,14 @@ const hasOptionalStringFields = (
 
 const isPart = (value: unknown): value is A2APart =>
   isRecord(value) &&
-  hasOptionalStringFields(value, [
-    "text",
-    "raw",
-    "url",
-    "filename",
-    "mediaType",
-  ]) &&
+  hasOptionalStringFields(value, PART_STRING_FIELDS) &&
   (value.metadata === undefined || isRecord(value.metadata));
+
+const hasValidNestedParts = (value: unknown): boolean =>
+  !isRecord(value) || !Array.isArray(value.parts) || value.parts.every(isPart);
+
+const hasValidNestedPartsInCollection = (value: unknown): boolean =>
+  !Array.isArray(value) || value.every(hasValidNestedParts);
 
 const isTask = (value: unknown): value is A2ATask =>
   isRecord(value) &&
@@ -317,7 +318,10 @@ const isTask = (value: unknown): value is A2ATask =>
   value.id.length > 0 &&
   hasOptionalStringIds(value, ["contextId"]) &&
   isRecord(value.status) &&
-  isTaskState(value.status.state);
+  isTaskState(value.status.state) &&
+  hasValidNestedParts(value.status.message) &&
+  hasValidNestedPartsInCollection(value.artifacts) &&
+  hasValidNestedPartsInCollection(value.history);
 
 const isMessage = (value: unknown): value is A2AMessage =>
   isRecord(value) &&
@@ -385,7 +389,8 @@ const isStatusUpdate = (
   (allowEmptyTaskId || value.taskId.length > 0) &&
   hasOptionalStringIds(value, ["contextId"]) &&
   isRecord(value.status) &&
-  isTaskState(value.status.state);
+  isTaskState(value.status.state) &&
+  hasValidNestedParts(value.status.message);
 
 const toWrappedStatusUpdate = (
   value: unknown,

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -7,6 +7,7 @@ import type {
   A2AListTasksRequest,
   A2AListTasksResponse,
   A2AMessage,
+  A2APart,
   A2ARole,
   A2ASendMessageConfiguration,
   A2AStreamEvent,
@@ -69,6 +70,25 @@ const JSONRPC_STATE_MAP: Record<string, string> = {
   unknown: "unspecified",
 };
 
+const NULLABLE_PART_FIELDS = [
+  "text",
+  "raw",
+  "url",
+  "metadata",
+  "filename",
+  "mediaType",
+] as const;
+
+function normalizePartNulls(
+  part: Record<string, unknown>,
+): Record<string, unknown> {
+  const normalized = { ...part };
+  for (const field of NULLABLE_PART_FIELDS) {
+    if (normalized[field] === null) delete normalized[field];
+  }
+  return normalized;
+}
+
 // JSON-RPC file parts nest the payload under `file`; the internal A2APart is
 // flat, so the nested fields map onto url/raw/mediaType/filename.
 function normalizeParts(value: unknown[]): unknown[] {
@@ -76,8 +96,8 @@ function normalizeParts(value: unknown[]): unknown[] {
     const part = normalizeKeys(raw, false);
     if (part === null || typeof part !== "object" || Array.isArray(part))
       return part;
-    const record = part as Record<string, unknown>;
-    if (record.kind === undefined) return part;
+    const record = normalizePartNulls(part as Record<string, unknown>);
+    if (record.kind === undefined) return record;
     const { kind, ...rest } = record;
     const file = rest.file;
     if (kind !== "file" || file === null || typeof file !== "object")
@@ -86,10 +106,10 @@ function normalizeParts(value: unknown[]): unknown[] {
     const nested = file as Record<string, unknown>;
     return {
       ...others,
-      ...(nested.uri !== undefined ? { url: nested.uri } : {}),
-      ...(nested.bytes !== undefined ? { raw: nested.bytes } : {}),
-      ...(nested.mimeType !== undefined ? { mediaType: nested.mimeType } : {}),
-      ...(nested.name !== undefined ? { filename: nested.name } : {}),
+      ...(nested.uri != null ? { url: nested.uri } : {}),
+      ...(nested.bytes != null ? { raw: nested.bytes } : {}),
+      ...(nested.mimeType != null ? { mediaType: nested.mimeType } : {}),
+      ...(nested.name != null ? { filename: nested.name } : {}),
     };
   });
 }
@@ -272,6 +292,25 @@ const hasOptionalStringIds = (
 ): boolean =>
   keys.every((key) => value[key] == null || typeof value[key] === "string");
 
+const hasOptionalStringFields = (
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): boolean =>
+  keys.every(
+    (key) => value[key] === undefined || typeof value[key] === "string",
+  );
+
+const isPart = (value: unknown): value is A2APart =>
+  isRecord(value) &&
+  hasOptionalStringFields(value, [
+    "text",
+    "raw",
+    "url",
+    "filename",
+    "mediaType",
+  ]) &&
+  (value.metadata === undefined || isRecord(value.metadata));
+
 const isTask = (value: unknown): value is A2ATask =>
   isRecord(value) &&
   typeof value.id === "string" &&
@@ -287,7 +326,7 @@ const isMessage = (value: unknown): value is A2AMessage =>
   hasOptionalStringIds(value, ["contextId", "taskId"]) &&
   isRole(value.role) &&
   Array.isArray(value.parts) &&
-  value.parts.every(isRecord);
+  value.parts.every(isPart);
 
 // Legacy wrappers use ProtoJSON, where omitted and null fields decode to proto
 // defaults. Normalize those defaults before enforcing semantic requirements.
@@ -369,7 +408,7 @@ const isArtifact = (value: unknown): value is Record<string, unknown> =>
   isRecord(value) &&
   typeof value.artifactId === "string" &&
   Array.isArray(value.parts) &&
-  value.parts.every(isRecord);
+  value.parts.every(isPart);
 
 const isArtifactUpdate = (value: unknown): value is Record<string, unknown> =>
   isRecord(value) &&


### PR DESCRIPTION
## Problem

A successful A2A response can contain an object-shaped part whose typed fields have invalid values. On current main (`0b1c5a12c`), a wrapped message with `parts: [{ text: { invalid: true } }]` passes validation and resolves as an `A2AMessage`, allowing an object to reach a field declared and consumed as a string. The same shallow check affects streamed messages, task/status envelopes, and artifacts.

## Root cause

The wire guards checked only that direct message and artifact parts were objects, and task/status envelopes did not inspect concrete nested part arrays. Known string fields and metadata shapes inside each part were not validated.

## Change

Validate known `A2APart` fields in direct messages and artifacts, plus concrete part arrays nested in task status messages, history, artifacts, and status updates. The intentionally tolerant behavior from #5967 remains for absent or malformed collection containers. Protocol-style null optional fields are normalized to absence so emitted values match the public type, while opaque `data` and unknown fields remain accepted for forward compatibility.

## Verification

- The focused regression test failed before the fix because `sendMessage()` resolved the malformed nested text value; it passes after the fix.
- `pnpm --filter @assistant-ui/react-a2a exec vitest run src/A2AClient.test.ts` (129 tests)
- `pnpm --filter @assistant-ui/react-a2a test` (293 tests)
- `pnpm --filter @assistant-ui/react-a2a build`
- `pnpm exec oxlint packages/react-a2a/src/A2AClient.ts packages/react-a2a/src/A2AClient.test.ts`
- `pnpm exec oxfmt --check packages/react-a2a/src/A2AClient.ts packages/react-a2a/src/A2AClient.test.ts`
- `pnpm changesets:check`

## Public surface

Affected package: `@assistant-ui/react-a2a`. No exports, API reference, templates, or documentation change. Includes a patch changeset.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5uEJg9NZxs1Z545ePjw0oXbn6qUrQ6tgR3qUfnf38TwekIqiukKk1sTp1-o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->