### PR TITLE
fix(react): stop disposed MCP App bridge activity

### DIFF
--- a/.changeset/stop-disposed-mcp-bridge.md
+++ b/.changeset/stop-disposed-mcp-bridge.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: stop MCP App bridge messages after disposal

--- a/packages/react/src/mcp-apps/bridge.test.ts
+++ b/packages/react/src/mcp-apps/bridge.test.ts
@@ -92,6 +92,37 @@ describe("createMcpAppBridge", () => {
     expect(captured).toEqual([]);
   });
 
+  it("does not report an async error after disposal", async () => {
+    const { frame, captured } = makeFrame();
+    let rejectCall!: (reason?: unknown) => void;
+    const callTool = vi.fn(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectCall = reject;
+        }),
+    );
+    const onError = vi.fn();
+    const bridge = createMcpAppBridge({
+      frame,
+      handlers: { callTool, onError },
+    });
+
+    deliver(bridge, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "search" },
+    });
+    expect(callTool).toHaveBeenCalledOnce();
+
+    bridge.dispose();
+    rejectCall(new Error("tool failed"));
+    await flush();
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(captured).toEqual([]);
+  });
+
   it("does not send host notifications after disposal", () => {
     const { frame, captured } = makeFrame();
     const bridge = createMcpAppBridge({ frame });

--- a/packages/react/src/mcp-apps/bridge.test.ts
+++ b/packages/react/src/mcp-apps/bridge.test.ts
@@ -37,6 +37,73 @@ async function flush() {
 }
 
 describe("createMcpAppBridge", () => {
+  it("ignores requests and notifications after disposal", async () => {
+    const { frame, captured } = makeFrame();
+    const callTool = vi.fn().mockResolvedValue({ ok: true });
+    const onInitialized = vi.fn();
+    const bridge = createMcpAppBridge({
+      frame,
+      handlers: { callTool, onInitialized },
+    });
+
+    bridge.dispose();
+    expect(() => bridge.dispose()).not.toThrow();
+
+    deliver(bridge, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "search" },
+    });
+    deliver(bridge, {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+    await flush();
+
+    expect(callTool).not.toHaveBeenCalled();
+    expect(onInitialized).not.toHaveBeenCalled();
+    expect(captured).toEqual([]);
+  });
+
+  it("does not send a response after disposal", async () => {
+    const { frame, captured } = makeFrame();
+    let resolveCall!: (value: unknown) => void;
+    const callTool = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveCall = resolve;
+        }),
+    );
+    const bridge = createMcpAppBridge({ frame, handlers: { callTool } });
+
+    deliver(bridge, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "search" },
+    });
+    expect(callTool).toHaveBeenCalledOnce();
+
+    bridge.dispose();
+    resolveCall({ ok: true });
+    await flush();
+
+    expect(captured).toEqual([]);
+  });
+
+  it("does not send host notifications after disposal", () => {
+    const { frame, captured } = makeFrame();
+    const bridge = createMcpAppBridge({ frame });
+
+    bridge.dispose();
+    bridge.notifyToolInput({ query: "hello" });
+    bridge.notifyToolResult({ answer: "world" });
+    bridge.notifyHostContextChanged({ theme: "dark" });
+
+    expect(captured).toEqual([]);
+  });
+
   it("responds to ui/initialize with host info, version, and capabilities", async () => {
     const { frame, captured } = makeFrame();
     const bridge = createMcpAppBridge({

--- a/packages/react/src/mcp-apps/bridge.ts
+++ b/packages/react/src/mcp-apps/bridge.ts
@@ -90,8 +90,10 @@ export function createMcpAppBridge(
     hostInfo = DEFAULT_HOST_INFO,
     hostContext = {},
   } = opts;
+  let disposed = false;
 
   const post = (msg: McpAppJsonRpcMessage) => {
+    if (disposed) return;
     frame.sendMessage(msg);
   };
 
@@ -435,6 +437,7 @@ export function createMcpAppBridge(
   // The host applies the cross-origin guard before delegating; this only
   // validates the JSON-RPC envelope.
   const onMessage = (event: MessageEvent) => {
+    if (disposed) return;
     if (!isJsonRpcMessage(event.data)) return;
 
     const msg = event.data;
@@ -447,7 +450,9 @@ export function createMcpAppBridge(
 
   return {
     onMessage,
-    dispose: () => {},
+    dispose: () => {
+      disposed = true;
+    },
     notifyToolInput: (input: unknown) => {
       post({
         jsonrpc: "2.0",

--- a/packages/react/src/mcp-apps/bridge.ts
+++ b/packages/react/src/mcp-apps/bridge.ts
@@ -127,6 +127,7 @@ export function createMcpAppBridge(
   };
 
   const reportError = (error: Error) => {
+    if (disposed) return;
     invokeUserCallback(
       "assistant-ui",
       "MCP App onError",


### PR DESCRIPTION
## Problem

`createMcpAppBridge` remained active after `dispose()`. A request already in flight could resolve after its sandbox was removed and send a JSON-RPC response into the retired frame. New requests, notifications, host notifications, and late error callbacks also remained active.

Minimal reproduction on current main:

1. Start a `tools/call` whose handler returns a pending promise.
2. Dispose the bridge.
3. Resolve or reject the handler.
4. Observe the retired bridge send a response or invoke the consumer's `onError`.

## Root cause

The bridge returned an empty `dispose()` function, and its inbound dispatch, shared outbound path, and error-reporting path did not track lifecycle state.

## Change

- Mark the bridge disposed idempotently.
- Ignore inbound requests and notifications after disposal.
- Suppress late async responses and host notifications through the shared `post` path.
- Suppress late consumer error callbacks through the shared `reportError` path.
- Keep already-started user handler work uncancelled because the handler API has no cancellation contract.
- Add separate regression tests for inbound messages, late responses, late errors, outbound notifications, and repeated disposal.

## Verification

- Confirmed the initial three regression tests fail on unmodified current main.
- `vitest run src/mcp-apps/bridge.test.ts` with 24 tests passing
- Focused Oxlint and Oxfmt checks
- `node scripts/check-changesets.mjs`
- `node scripts/check-changeset-semver.mjs`
- `aui-build` in `packages/react`

## Public surface

`@assistant-ui/react` receives a patch changeset. No exported types, handler signatures, docs, API reference, or templates changed.

Fixes #7168

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.hnvIs3NJd-IE2AyV1cqvD6U4-RN-x97OfxEP7BeEdDNOI7RbhE-bllzXn9c?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->