### PR TITLE
fix(core): finish provider cleanup after unsubscribe errors

### DIFF
--- a/.changeset/clean-context-provider-unregister.md
+++ b/.changeset/clean-context-provider-unregister.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: complete context provider cleanup when unsubscribe throws

--- a/packages/core/src/utils/composite-context-provider.test.ts
+++ b/packages/core/src/utils/composite-context-provider.test.ts
@@ -114,6 +114,31 @@ describe("CompositeContextProvider", () => {
     expect(composite.getModelContext().system).toBeUndefined();
   });
 
+  it("finishes unregistering when the provider cleanup throws", () => {
+    const composite = new CompositeContextProvider();
+    const cleanupError = new Error("cleanup failed");
+    const subscriber = vi.fn();
+    const unsubscribe = vi.fn(() => {
+      throw cleanupError;
+    });
+
+    composite.subscribe(subscriber);
+    const unregister = composite.registerModelContextProvider({
+      getModelContext: () => ({ system: "provider instructions" }),
+      subscribe: () => unsubscribe,
+    });
+    subscriber.mockClear();
+
+    expect(() => unregister()).toThrow(cleanupError);
+    expect(composite.getModelContext().system).toBeUndefined();
+    expect(subscriber).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+
+    expect(() => unregister()).not.toThrow();
+    expect(subscriber).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
   it("notifies every subscriber and rethrows on provider updates", () => {
     const composite = new CompositeContextProvider();
     const error = new Error("subscriber failed");

--- a/packages/core/src/utils/composite-context-provider.ts
+++ b/packages/core/src/utils/composite-context-provider.ts
@@ -32,12 +32,33 @@ export class CompositeContextProvider implements ModelContextProvider {
     }
     this._providerUnsubscribes.set(id, unsubscribe);
     this.notifySubscribers();
+    let released = false;
     return () => {
+      if (released) return;
+      released = true;
       this._providers.delete(id);
       const unsubscribe = this._providerUnsubscribes.get(id);
-      unsubscribe?.();
       this._providerUnsubscribes.delete(id);
-      this.notifySubscribers();
+
+      let cleanupFailed = false;
+      let cleanupError: unknown;
+      const runCleanup = (cleanup: () => void) => {
+        try {
+          cleanup();
+        } catch (error) {
+          if (cleanupFailed) {
+            console.error(error);
+          } else {
+            cleanupFailed = true;
+            cleanupError = error;
+          }
+        }
+      };
+
+      if (unsubscribe) runCleanup(unsubscribe);
+      runCleanup(() => this.notifySubscribers());
+
+      if (cleanupFailed) throw cleanupError;
     };
   }
 


### PR DESCRIPTION
## Problem

Unregistering a model-context provider removed it from the merged context before calling the provider's unsubscribe callback. If that callback threw, cleanup stopped before deleting its bookkeeping entry or notifying subscribers.

Minimal reproduction on current main:

1. Register a provider whose unsubscribe callback throws.
2. Subscribe to the composite provider.
3. Call the returned unregister function.
4. Observe that the provider is gone, but the subscriber is never notified.

## Root cause

The unregister path ran external cleanup in the middle of internal state cleanup. A synchronous exception therefore left the composite provider only partially cleaned up.

## Change

- Make unregister idempotent.
- Remove provider and unsubscribe bookkeeping before invoking external code.
- Run provider unsubscribe and subscriber notification independently.
- Preserve and rethrow the first cleanup error after both steps complete.
- Add regression coverage for notification, error preservation, bookkeeping cleanup, and repeated unregister.

## Verification

- Confirmed the new regression fails on unmodified current main.
- `vitest run src/utils/composite-context-provider.test.ts` with 7 tests passing
- Full `@assistant-ui/core` suite with 1,807 tests passing
- Focused Oxlint and Oxfmt checks
- Changeset and semver checks
- `aui-build` in `packages/core`

## Public surface

`@assistant-ui/core` receives a patch changeset. No exports or type signatures changed. The unregister behavior now leaves state consistent before rethrowing cleanup failures.

Fixes #7169


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.D21wUPV1Zi-9LJgQiVjg6-hEFP8bre77xBidR576HyDqLFtkYhNDl7-Rg8M?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->