### PR TITLE
fix(core): avoid frame listener leak on failed initialization

### DIFF
--- a/.changeset/rollback-frame-host-init.md
+++ b/.changeset/rollback-frame-host-init.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: avoid leaking a frame host message listener when initialization fails

--- a/packages/core/src/model-context/frame/host.test.ts
+++ b/packages/core/src/model-context/frame/host.test.ts
@@ -74,9 +74,31 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("AssistantFrameHost", () => {
+  it("does not install its message listener when initialization fails", () => {
+    const addEventListener = vi.fn();
+    const removeEventListener = vi.fn();
+    vi.stubGlobal("window", {
+      addEventListener,
+      removeEventListener,
+      location: { origin: DEFAULT_ORIGIN },
+    });
+    const error = new Error("postMessage failed");
+    const iframeWindow = {
+      postMessage: vi.fn(() => {
+        throw error;
+      }),
+    } as unknown as Window;
+
+    expect(() => new AssistantFrameHost(iframeWindow)).toThrow(error);
+
+    expect(addEventListener).not.toHaveBeenCalled();
+    expect(removeEventListener).not.toHaveBeenCalled();
+  });
+
   it("defaults to the current origin", () => {
     const { host, postMessage } = createHost();
 

--- a/packages/core/src/model-context/frame/host.ts
+++ b/packages/core/src/model-context/frame/host.ts
@@ -73,9 +73,10 @@ export class AssistantFrameHost implements ModelContextProvider {
     this._targetOrigin = targetOrigin;
 
     this.handleMessage = this.handleMessage.bind(this);
-    window.addEventListener("message", this.handleMessage);
-
+    // A posted message cannot be delivered before this constructor returns, so
+    // requesting first means a failed request leaves no listener to clean up.
     this.requestContext();
+    window.addEventListener("message", this.handleMessage);
   }
 
   private handleMessage(event: MessageEvent) {


### PR DESCRIPTION
## Problem

`AssistantFrameHost` installed its global message listener before sending the initial model-context request. If that request threw synchronously, construction failed and callers never received a host they could dispose, leaving the listener installed.

Minimal reproduction on current main:

1. Construct an `AssistantFrameHost` with an iframe window whose initial `postMessage` throws.
2. Observe that construction throws after `window.addEventListener` has already run.
3. The leaked listener cannot be removed because no host instance is returned.

## Root cause

The constructor performed the fallible initialization request after installing the long-lived listener.

## Change

Send the initial context request before installing the message listener. A failed request now exits without registering any listener, while successful initialization preserves the existing behavior.

## Verification

- Focused frame-host suite with 15 tests passing
- Regression coverage confirms neither listener installation nor rollback runs after a failed initial request
- Full `@assistant-ui/core` suite passing
- `aui-build` in `packages/core`
- Focused Oxlint and Oxfmt checks

The independent `./store/internal` baseline drift that can make the size check fail is isolated in #7191 and is not part of this diff.

## Public surface

`@assistant-ui/core` receives a patch changeset. No exports or signatures change.

Fixes #7170
