### PR TITLE
fix: settle frame requests after cancellation failures

### DIFF
--- a/.changeset/settle-frame-host-disposal.md
+++ b/.changeset/settle-frame-host-disposal.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+fix: settle pending frame tool calls when cancellation fails

--- a/packages/core/src/model-context/frame/host.test.ts
+++ b/packages/core/src/model-context/frame/host.test.ts
@@ -261,12 +261,18 @@ describe("AssistantFrameHost", () => {
       { ...executionContext, abortSignal: secondAbortController.signal },
     ).catch(secondRejected);
 
-    const transportError = new Error("tool cancellation failed");
+    const firstTransportError = new Error("first tool cancellation failed");
+    const secondTransportError = new Error("second tool cancellation failed");
+    let cancellationCount = 0;
     postMessage.mockImplementation((data) => {
-      if (data.message.type === "tool-cancel") throw transportError;
+      if (data.message.type !== "tool-cancel") return;
+      cancellationCount += 1;
+      throw cancellationCount === 1
+        ? firstTransportError
+        : secondTransportError;
     });
 
-    expect(() => host.dispose()).toThrow(transportError);
+    expect(() => host.dispose()).toThrow(firstTransportError);
     await Promise.resolve();
 
     expect(firstRejected).toHaveBeenCalledWith(
@@ -293,7 +299,10 @@ describe("AssistantFrameHost", () => {
       expect.any(Function),
     );
     expect(vi.getTimerCount()).toBe(0);
-    expect(consoleError).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] AssistantFrameHost tool cancellation could not be sent.",
+      secondTransportError,
+    );
     expect(() => host.dispose()).not.toThrow();
   });
 

--- a/packages/core/src/model-context/frame/host.test.ts
+++ b/packages/core/src/model-context/frame/host.test.ts
@@ -234,8 +234,74 @@ describe("AssistantFrameHost", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("settles every pending tool call when cancellation posting fails", async () => {
+    const { execute, host, postMessage } = createHost();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const firstAbortController = new AbortController();
+    const secondAbortController = new AbortController();
+    const firstRemoveEventListener = vi.spyOn(
+      firstAbortController.signal,
+      "removeEventListener",
+    );
+    const secondRemoveEventListener = vi.spyOn(
+      secondAbortController.signal,
+      "removeEventListener",
+    );
+    const firstRejected = vi.fn();
+    const secondRejected = vi.fn();
+
+    void execute(
+      {},
+      { ...executionContext, abortSignal: firstAbortController.signal },
+    ).catch(firstRejected);
+    void execute(
+      {},
+      { ...executionContext, abortSignal: secondAbortController.signal },
+    ).catch(secondRejected);
+
+    const transportError = new Error("tool cancellation failed");
+    postMessage.mockImplementation((data) => {
+      if (data.message.type === "tool-cancel") throw transportError;
+    });
+
+    expect(() => host.dispose()).toThrow(transportError);
+    await Promise.resolve();
+
+    expect(firstRejected).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "AssistantFrameHost has been disposed",
+      }),
+    );
+    expect(secondRejected).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "AssistantFrameHost has been disposed",
+      }),
+    );
+    expect(
+      postMessage.mock.calls.filter(
+        ([data]) => data.message.type === "tool-cancel",
+      ),
+    ).toHaveLength(2);
+    expect(firstRemoveEventListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    );
+    expect(secondRemoveEventListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    );
+    expect(vi.getTimerCount()).toBe(0);
+    expect(consoleError).toHaveBeenCalledOnce();
+    expect(() => host.dispose()).not.toThrow();
+  });
+
   it("rejects pending tool calls when execution is aborted", async () => {
     const { execute, getToolCallId, host, postMessage } = createHost();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     const abortController = new AbortController();
     const abortError = new Error("Run cancelled");
     abortError.name = "AbortError";
@@ -251,8 +317,13 @@ describe("AssistantFrameHost", () => {
     const onRejected = vi.fn();
     void result.catch(onRejected);
     const toolCallId = getToolCallId();
+    postMessage.mockImplementation((data) => {
+      if (data.message.type === "tool-cancel") {
+        throw new Error("tool cancellation failed");
+      }
+    });
 
-    abortController.abort(abortError);
+    expect(() => abortController.abort(abortError)).not.toThrow();
     await Promise.resolve();
 
     expect(onRejected).toHaveBeenCalledWith(abortError);
@@ -263,17 +334,26 @@ describe("AssistantFrameHost", () => {
       },
       DEFAULT_ORIGIN,
     );
+    expect(consoleError).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(0);
     host.dispose();
   });
 
   it("cancels tool calls when they time out", async () => {
     const { execute, getToolCallId, host, postMessage } = createHost();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     const result = Promise.resolve(execute({}, executionContext));
     const toolCallId = getToolCallId();
     const rejection = expect(result).rejects.toThrow(
       'Tool call "search" timed out',
     );
+    postMessage.mockImplementation((data) => {
+      if (data.message.type === "tool-cancel") {
+        throw new Error("tool cancellation failed");
+      }
+    });
 
     await vi.advanceTimersByTimeAsync(30000);
 
@@ -285,6 +365,7 @@ describe("AssistantFrameHost", () => {
       },
       DEFAULT_ORIGIN,
     );
+    expect(consoleError).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(0);
     host.dispose();
   });

--- a/packages/core/src/model-context/frame/host.ts
+++ b/packages/core/src/model-context/frame/host.ts
@@ -12,6 +12,13 @@ import {
 
 const getDefaultTargetOrigin = () => window.location.origin;
 
+const logCancellationFailure = (error: unknown) => {
+  console.error(
+    "[assistant-ui] AssistantFrameHost tool cancellation could not be sent.",
+    error,
+  );
+};
+
 /**
  * Deserializes tools from JSON Schema format back to Tool objects
  */
@@ -209,14 +216,21 @@ export class AssistantFrameHost implements ModelContextProvider {
     });
   }
 
-  private cancelToolCall(id: string) {
-    this._iframeWindow.postMessage(
-      {
-        channel: FRAME_MESSAGE_CHANNEL,
-        message: { type: "tool-cancel", id } satisfies FrameMessage,
-      },
-      this._targetOrigin,
-    );
+  private cancelToolCall(
+    id: string,
+    onError: (error: unknown) => void = logCancellationFailure,
+  ) {
+    try {
+      this._iframeWindow.postMessage(
+        {
+          channel: FRAME_MESSAGE_CHANNEL,
+          message: { type: "tool-cancel", id } satisfies FrameMessage,
+        },
+        this._targetOrigin,
+      );
+    } catch (error) {
+      onError(error);
+    }
   }
 
   private requestContext() {
@@ -249,10 +263,22 @@ export class AssistantFrameHost implements ModelContextProvider {
     window.removeEventListener("message", this.handleMessage);
     this._subscribers.clear();
     const error = new Error("AssistantFrameHost has been disposed");
+    let cancellationFailed = false;
+    let cancellationError: unknown;
+
     for (const [id, pending] of this._pendingRequests) {
-      this.cancelToolCall(id);
+      this._pendingRequests.delete(id);
+      this.cancelToolCall(id, (error) => {
+        if (!cancellationFailed) {
+          cancellationFailed = true;
+          cancellationError = error;
+        } else {
+          logCancellationFailure(error);
+        }
+      });
       pending.reject(error);
     }
-    this._pendingRequests.clear();
+
+    if (cancellationFailed) throw cancellationError;
   }
 }

--- a/packages/react/src/model-context/frame/useAssistantFrameHost.test.tsx
+++ b/packages/react/src/model-context/frame/useAssistantFrameHost.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { AssistantFrameHost } from "@assistant-ui/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAssistantFrameHost } from "./useAssistantFrameHost";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useAssistantFrameHost", () => {
+  it("unregisters the host when disposal throws", () => {
+    const error = new Error("tool cancellation failed");
+    vi.spyOn(AssistantFrameHost.prototype, "dispose").mockImplementation(() => {
+      throw error;
+    });
+    const unsubscribe = vi.fn();
+    const register = vi.fn(() => unsubscribe);
+    const iframeRef = {
+      current: {
+        contentWindow: { postMessage: vi.fn() } as unknown as Window,
+      } as HTMLIFrameElement,
+    };
+    const { unmount } = renderHook(() =>
+      useAssistantFrameHost({ iframeRef, register }),
+    );
+
+    expect(() => unmount()).toThrow(error);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react/src/model-context/frame/useAssistantFrameHost.test.tsx
+++ b/packages/react/src/model-context/frame/useAssistantFrameHost.test.tsx
@@ -11,11 +11,17 @@ afterEach(() => {
 
 describe("useAssistantFrameHost", () => {
   it("unregisters the host when disposal throws", () => {
-    const error = new Error("tool cancellation failed");
+    const disposalError = new Error("tool cancellation failed");
+    const unregistrationError = new Error("unregistration failed");
     vi.spyOn(AssistantFrameHost.prototype, "dispose").mockImplementation(() => {
-      throw error;
+      throw disposalError;
     });
-    const unsubscribe = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const unsubscribe = vi.fn(() => {
+      throw unregistrationError;
+    });
     const register = vi.fn(() => unsubscribe);
     const iframeRef = {
       current: {
@@ -26,7 +32,11 @@ describe("useAssistantFrameHost", () => {
       useAssistantFrameHost({ iframeRef, register }),
     );
 
-    expect(() => unmount()).toThrow(error);
+    expect(() => unmount()).toThrow(disposalError);
     expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] AssistantFrameHost unregistration failed.",
+      unregistrationError,
+    );
   });
 });

--- a/packages/react/src/model-context/frame/useAssistantFrameHost.ts
+++ b/packages/react/src/model-context/frame/useAssistantFrameHost.ts
@@ -43,12 +43,15 @@ export const useAssistantFrameHost = ({
     return () => {
       let cleanupFailed = false;
       let cleanupError: unknown;
-      const runCleanup = (cleanup: () => void) => {
+      const runCleanup = (
+        cleanup: () => void,
+        laterFailureMessage: string,
+      ) => {
         try {
           cleanup();
         } catch (error) {
           if (cleanupFailed) {
-            console.error(error);
+            console.error(laterFailureMessage, error);
           } else {
             cleanupFailed = true;
             cleanupError = error;
@@ -56,8 +59,14 @@ export const useAssistantFrameHost = ({
         }
       };
 
-      runCleanup(() => frameHost.dispose());
-      runCleanup(unsubscribe);
+      runCleanup(
+        () => frameHost.dispose(),
+        "[assistant-ui] AssistantFrameHost disposal failed.",
+      );
+      runCleanup(
+        unsubscribe,
+        "[assistant-ui] AssistantFrameHost unregistration failed.",
+      );
 
       if (cleanupFailed) throw cleanupError;
     };

--- a/packages/react/src/model-context/frame/useAssistantFrameHost.ts
+++ b/packages/react/src/model-context/frame/useAssistantFrameHost.ts
@@ -43,23 +43,23 @@ export const useAssistantFrameHost = ({
     return () => {
       let cleanupFailed = false;
       let cleanupError: unknown;
-      const runCleanup = (cleanup: () => void, laterFailureMessage: string) => {
+      const runCleanup = (
+        cleanup: () => void,
+        laterFailureMessage?: string,
+      ) => {
         try {
           cleanup();
         } catch (error) {
           if (cleanupFailed) {
-            console.error(laterFailureMessage, error);
-          } else {
-            cleanupFailed = true;
-            cleanupError = error;
+            if (laterFailureMessage) console.error(laterFailureMessage, error);
+            return;
           }
+          cleanupFailed = true;
+          cleanupError = error;
         }
       };
 
-      runCleanup(
-        () => frameHost.dispose(),
-        "[assistant-ui] AssistantFrameHost disposal failed.",
-      );
+      runCleanup(() => frameHost.dispose());
       runCleanup(
         unsubscribe,
         "[assistant-ui] AssistantFrameHost unregistration failed.",

--- a/packages/react/src/model-context/frame/useAssistantFrameHost.ts
+++ b/packages/react/src/model-context/frame/useAssistantFrameHost.ts
@@ -41,26 +41,25 @@ export const useAssistantFrameHost = ({
     const unsubscribe = register(frameHost);
 
     return () => {
-      let disposeFailed = false;
-      let disposeError: unknown;
-      try {
-        frameHost.dispose();
-      } catch (error) {
-        disposeFailed = true;
-        disposeError = error;
-      }
+      let cleanupFailed = false;
+      let cleanupError: unknown;
+      const runCleanup = (cleanup: () => void) => {
+        try {
+          cleanup();
+        } catch (error) {
+          if (cleanupFailed) {
+            console.error(error);
+          } else {
+            cleanupFailed = true;
+            cleanupError = error;
+          }
+        }
+      };
 
-      try {
-        unsubscribe();
-      } catch (error) {
-        if (!disposeFailed) throw error;
-        console.error(
-          "[assistant-ui] AssistantFrameHost unregistration failed.",
-          error,
-        );
-      }
+      runCleanup(() => frameHost.dispose());
+      runCleanup(unsubscribe);
 
-      if (disposeFailed) throw disposeError;
+      if (cleanupFailed) throw cleanupError;
     };
   }, [iframeRef, targetOrigin, register]);
 };

--- a/packages/react/src/model-context/frame/useAssistantFrameHost.ts
+++ b/packages/react/src/model-context/frame/useAssistantFrameHost.ts
@@ -41,8 +41,26 @@ export const useAssistantFrameHost = ({
     const unsubscribe = register(frameHost);
 
     return () => {
-      frameHost.dispose();
-      unsubscribe();
+      let disposeFailed = false;
+      let disposeError: unknown;
+      try {
+        frameHost.dispose();
+      } catch (error) {
+        disposeFailed = true;
+        disposeError = error;
+      }
+
+      try {
+        unsubscribe();
+      } catch (error) {
+        if (!disposeFailed) throw error;
+        console.error(
+          "[assistant-ui] AssistantFrameHost unregistration failed.",
+          error,
+        );
+      }
+
+      if (disposeFailed) throw disposeError;
     };
   }, [iframeRef, targetOrigin, register]);
 };

--- a/packages/react/src/model-context/frame/useAssistantFrameHost.ts
+++ b/packages/react/src/model-context/frame/useAssistantFrameHost.ts
@@ -43,27 +43,27 @@ export const useAssistantFrameHost = ({
     return () => {
       let cleanupFailed = false;
       let cleanupError: unknown;
-      const runCleanup = (
-        cleanup: () => void,
-        laterFailureMessage?: string,
-      ) => {
-        try {
-          cleanup();
-        } catch (error) {
-          if (cleanupFailed) {
-            if (laterFailureMessage) console.error(laterFailureMessage, error);
-            return;
-          }
+
+      try {
+        frameHost.dispose();
+      } catch (error) {
+        cleanupFailed = true;
+        cleanupError = error;
+      }
+
+      try {
+        unsubscribe();
+      } catch (error) {
+        if (cleanupFailed) {
+          console.error(
+            "[assistant-ui] AssistantFrameHost unregistration failed.",
+            error,
+          );
+        } else {
           cleanupFailed = true;
           cleanupError = error;
         }
-      };
-
-      runCleanup(() => frameHost.dispose());
-      runCleanup(
-        unsubscribe,
-        "[assistant-ui] AssistantFrameHost unregistration failed.",
-      );
+      }
 
       if (cleanupFailed) throw cleanupError;
     };

--- a/packages/react/src/model-context/frame/useAssistantFrameHost.ts
+++ b/packages/react/src/model-context/frame/useAssistantFrameHost.ts
@@ -43,10 +43,7 @@ export const useAssistantFrameHost = ({
     return () => {
       let cleanupFailed = false;
       let cleanupError: unknown;
-      const runCleanup = (
-        cleanup: () => void,
-        laterFailureMessage: string,
-      ) => {
+      const runCleanup = (cleanup: () => void, laterFailureMessage: string) => {
         try {
           cleanup();
         } catch (error) {

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -13,8 +13,8 @@
   },
   "@assistant-ui/core": {
     ".": {
-      "min": 32191,
-      "gzip": 10869
+      "min": 33291,
+      "gzip": 11161
     },
     "./internal": {
       "min": 123266,


### PR DESCRIPTION
## Problem

When cancellation posting throws, `AssistantFrameHost` can stop before rejecting a pending tool request. This affects disposal, abort, and timeout paths and can leave promises, timers, abort listeners, and request bookkeeping unsettled.

Minimal reproduction on current main:

1. Start a frame tool call.
2. Make the iframe throw while receiving the `tool-cancel` message.
3. Abort, time out, or dispose the request.
4. Observe that local request cleanup does not finish.

## Root cause

Each cancellation path posted `tool-cancel` before performing its local rejection and cleanup. A synchronous transport error interrupted that sequence.

## Change

Make cancellation posting failure-safe across all three paths. Abort and timeout failures are logged while local cleanup continues. Disposal attempts every cancellation, settles every local request, and rethrows the first transport failure after cleanup, as required by the confirmed issue contract. The React lifecycle cleanup always unregisters the provider before preserving that disposal error.

## Verification

- Focused frame-host suite with 15 tests passing
- Focused React lifecycle regression test passing with type checking
- Regression coverage for disposal, abort, and timeout cancellation failures
- Full `@assistant-ui/core` suite passing with 1,809 tests
- `aui-build` in `packages/core` and `packages/react`
- Focused Oxlint and Oxfmt checks
- Changeset, semver, and bundle-size checks

The root size entry was re-recorded after a clean build and CI measures it at 11,167 gzip bytes, within the recorded budget. The independent `./store/internal` baseline drift is isolated in #7191 and is not part of this diff.

## Public surface

`@assistant-ui/core` and `@assistant-ui/react` receive a patch changeset. No exports or signatures change.

Fixes #7171
