### PR TITLE
fix(react): finish sandbox teardown after cleanup errors

### DIFF
--- a/.changeset/release-sandbox-frame-cleanup.md
+++ b/.changeset/release-sandbox-frame-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: finish sandbox teardown after bridge cleanup errors

--- a/packages/react/src/sandbox-host/SandboxHost.test.tsx
+++ b/packages/react/src/sandbox-host/SandboxHost.test.tsx
@@ -327,6 +327,46 @@ describe("SandboxHost", () => {
     expect(onMessage).not.toHaveBeenCalled();
   });
 
+  it("disposes the frame when bridge cleanup throws", async () => {
+    const rendered = fakeRendered();
+    renderHtmlMock.mockResolvedValue(rendered);
+    const cleanupError = new Error("bridge cleanup failed");
+    const onMessage = vi.fn();
+    const bridge: SandboxBridge = {
+      onMessage,
+      dispose: vi.fn(() => {
+        throw cleanupError;
+      }),
+    };
+
+    await act(async () => {
+      root.render(
+        <SandboxHost
+          content={{ html: "" }}
+          contentKey="k"
+          createBridge={() => bridge}
+        />,
+      );
+    });
+    await flush();
+
+    expect(() => {
+      act(() => root.unmount());
+    }).toThrow(cleanupError);
+
+    expect(bridge.dispose).toHaveBeenCalledOnce();
+    expect(rendered.dispose).toHaveBeenCalledOnce();
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: validData,
+        origin: rendered.origin,
+        source: rendered.iframe.contentWindow,
+      }),
+    );
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
   it("calls onError when rendering rejects", async () => {
     renderHtmlMock.mockRejectedValue(new Error("boom"));
     const onError = vi.fn();

--- a/packages/react/src/sandbox-host/SandboxHost.tsx
+++ b/packages/react/src/sandbox-host/SandboxHost.tsx
@@ -193,15 +193,35 @@ export function SandboxHost({
 
     return () => {
       cancelled = true;
+      let cleanupFailed = false;
+      let cleanupError: unknown;
+      const runCleanup = (cleanup: () => void) => {
+        try {
+          cleanup();
+        } catch (error) {
+          if (cleanupFailed) {
+            console.error(error);
+          } else {
+            cleanupFailed = true;
+            cleanupError = error;
+          }
+        }
+      };
+
       if (onMessage) {
-        window.removeEventListener("message", onMessage);
+        const listener = onMessage;
         onMessage = null;
+        runCleanup(() => window.removeEventListener("message", listener));
       }
-      bridge?.dispose();
+      const bridgeToDispose = bridge;
       bridge = null;
-      frame?.dispose();
+      if (bridgeToDispose) runCleanup(() => bridgeToDispose.dispose());
+      const frameToDispose = frame;
       frame = null;
-      setContentHeight(undefined);
+      if (frameToDispose) runCleanup(() => frameToDispose.dispose());
+      runCleanup(() => setContentHeight(undefined));
+
+      if (cleanupFailed) throw cleanupError;
     };
     // oxlint-disable-next-line react/exhaustive-deps -- re-init only on contentKey change; live values flow through liveRef
   }, [contentKey]);


### PR DESCRIPTION
## Problem

`SandboxHost` disposed its bridge before its rendered frame during effect cleanup. If a custom bridge's `dispose()` threw, React stopped that cleanup immediately and left the iframe frame undisposed.

Minimal reproduction on current main:

1. Render a sandbox with a bridge whose `dispose()` throws.
2. Unmount the host.
3. Observe the bridge error.
4. Observe that the rendered frame's `dispose()` was never called.

## Root cause

The effect cleanup performed teardown steps sequentially without failure isolation, so one external callback could prevent every later cleanup step.

## Change

- Keep bridge-before-frame disposal ordering.
- Clear listener, bridge, and frame references before invoking their external cleanup.
- Run listener removal, bridge disposal, frame disposal, and height reset independently.
- Preserve and rethrow the first cleanup error after teardown completes.
- Add a regression test proving the frame is disposed and the listener remains detached after a bridge cleanup failure.

## Verification

- Confirmed the new regression fails on unmodified current main.
- Focused `SandboxHost` suite with 16 tests passing
- Focused Oxlint and Oxfmt checks
- Changeset validation
- `aui-build` in `packages/react`

## Public surface

`@assistant-ui/react` receives a patch changeset. No exports or type signatures changed. Sandbox teardown now completes before surfacing cleanup failures.

Fixes #7172


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ZEGxvQ5pijQt1qUkW7c7eJTWJRAHEN1UkXmPiTom3g6owBlG5Tf30IeqK2g?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->