### PR TITLE
fix(core): stop disposed frame provider broadcasts

### DIFF
--- a/.changeset/stop-disposed-frame-broadcast.md
+++ b/.changeset/stop-disposed-frame-broadcast.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: stop frame provider broadcasts after disposal

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -120,6 +120,42 @@ describe("AssistantFrameProvider", () => {
     await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
   });
 
+  it("does not broadcast from a disposed provider", async () => {
+    vi.useFakeTimers();
+
+    try {
+      AssistantFrameProvider.addModelContextProvider({
+        getModelContext: () => ({ system: "disposed context" }),
+      });
+      AssistantFrameProvider.dispose();
+
+      AssistantFrameProvider.addModelContextProvider({
+        getModelContext: () => ({ system: "current context" }),
+      });
+      vi.mocked(parentWindow.postMessage).mockClear();
+
+      await vi.runAllTimersAsync();
+
+      expect(parentWindow.postMessage).toHaveBeenCalledOnce();
+      expect(parentWindow.postMessage).toHaveBeenCalledWith(
+        {
+          channel: FRAME_MESSAGE_CHANNEL,
+          message: {
+            type: "model-context-update",
+            context: {
+              system: "current context",
+              tools: {},
+            },
+          },
+        },
+        window.location.origin,
+      );
+    } finally {
+      AssistantFrameProvider.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("reports a failure even when the thrown error has an empty message", async () => {
     const execute = vi.fn(async () => {
       throw new Error();

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -47,13 +47,18 @@ export class AssistantFrameProvider {
   private _targetOrigin: string;
   private _strictRegistrations = 0;
   private _wildcardRegistrations = 0;
+  private _startupTimer: ReturnType<typeof setTimeout> | undefined;
+  private _disposed = false;
 
   private constructor(targetOrigin: string = getDefaultTargetOrigin()) {
     this._targetOrigin = targetOrigin;
     this.handleMessage = this.handleMessage.bind(this);
     window.addEventListener("message", this.handleMessage);
 
-    setTimeout(() => this.broadcastUpdate(), 0);
+    this._startupTimer = setTimeout(() => {
+      this._startupTimer = undefined;
+      this.broadcastUpdate();
+    }, 0);
   }
 
   private static getInstance(targetOrigin?: string): AssistantFrameProvider {
@@ -263,6 +268,7 @@ export class AssistantFrameProvider {
   }
 
   private broadcastUpdate() {
+    if (this._disposed) return;
     if (window.parent && window.parent !== window) {
       const updateMessage: FrameMessage = {
         type: "model-context-update",
@@ -394,6 +400,11 @@ export class AssistantFrameProvider {
   static dispose() {
     if (AssistantFrameProvider._instance) {
       const instance = AssistantFrameProvider._instance;
+      instance._disposed = true;
+      if (instance._startupTimer !== undefined) {
+        clearTimeout(instance._startupTimer);
+        instance._startupTimer = undefined;
+      }
       window.removeEventListener("message", instance.handleMessage);
 
       let cleanupFailed = false;


### PR DESCRIPTION
## Problem

Creating the singleton `AssistantFrameProvider` schedules an initial model-context broadcast. Disposing the provider before that timer runs did not cancel it, so the retired instance could post stale context after a replacement provider was created.

Minimal reproduction on current main:

1. Create a provider under fake timers.
2. Dispose it before its startup timer runs.
3. Create a replacement provider with a different context.
4. Advance timers and observe broadcasts from both the retired and current instances.

## Root cause

The constructor did not retain its startup timer, and `broadcastUpdate()` had no lifecycle guard.

## Change

- Retain the pending startup timer on each provider instance.
- Mark the instance disposed before running teardown callbacks.
- Cancel the startup timer during disposal.
- Ignore later broadcast attempts from disposed instances.
- Keep direct disposal tool-result messages unchanged.
- Add a recreation regression that distinguishes stale and current context broadcasts.

## Verification

- Confirmed the new regression fails on unmodified current main.
- Focused frame provider suite with 30 tests passing
- Full `@assistant-ui/core` suite passing
- Focused Oxlint and Oxfmt checks
- Changeset validation
- `aui-build` in `packages/core`

## Public surface

`@assistant-ui/core` receives a patch changeset. No exports or type signatures changed. Disposed provider instances no longer broadcast model-context updates.

Fixes #7173

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.j6tRtqeK_XZUdv1YIgh2spk4ySLO2zwl9yQUORCDwSQXjCUf--OR6QtoToE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

