### PR TITLE
fix(core): preserve messages after synchronous dispatch failures

### DIFF
--- a/.changeset/restore-failed-queue-dispatch.md
+++ b/.changeset/restore-failed-queue-dispatch.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: restore and pause queued messages after synchronous dispatch failures
+
+Failed work is retried before later sends. Work already accepted by a driver is not restored, and a failed move returns its item to the original position.

--- a/.changeset/restore-failed-queue-dispatch.md
+++ b/.changeset/restore-failed-queue-dispatch.md
@@ -4,4 +4,4 @@
 
 fix: restore and pause queued messages after synchronous dispatch failures
 
-Failed work is retried before later sends. Work already accepted by a driver is not restored, and a failed move returns its item to the original position.
+Failed work is retried before later sends. The next explicit send resumes draining; editing or removing an item does not resume a paused queue. Work already accepted by a driver is not restored, and a failed move returns its item to the original position.

--- a/packages/core/src/runtime/queue/message-queue.ts
+++ b/packages/core/src/runtime/queue/message-queue.ts
@@ -13,6 +13,11 @@ import type {
 } from "./external-thread-queue-adapter";
 
 export type MessageQueueDriver = {
+  /**
+   * A synchronous throw is treated as a run that never started and restores
+   * the message. A driver that already started work must call `notifyBusy`
+   * before throwing.
+   */
   run: (message: AppendMessage, options: { steer: boolean }) => void;
   /** When omitted, steering degrades to "process next" instead of interrupting. */
   cancel?: (() => void) | undefined;
@@ -37,6 +42,12 @@ export type MessageQueueController = {
 };
 
 type Lane = "queue" | "steer";
+
+type DispatchItem = {
+  id: string;
+  item: QueueItemState;
+  message: AppendMessage;
+};
 
 const getQueueItemParts = (
   message: AppendMessage,
@@ -83,6 +94,7 @@ export const createMessageQueue = (
   // settles from cancelled runs that must drop `running` without advancing
   let cancelSettles = 0;
   let interrupting = false;
+  let busyEdges = 0;
 
   const notify = () => {
     notifyEventListeners(subscribers, undefined, "Message queue");
@@ -101,6 +113,19 @@ export const createMessageQueue = (
     parts: getQueueItemParts(message),
   });
 
+  const restore = (lane: Lane, dispatch: DispatchItem, index = 0) => {
+    paused = true;
+    messages.set(dispatch.id, dispatch.message);
+    setLanes({
+      ...lanes,
+      [lane]: [
+        ...lanes[lane].slice(0, index),
+        dispatch.item,
+        ...lanes[lane].slice(index),
+      ],
+    });
+  };
+
   const laneOf = (queueItemId: string): Lane | undefined => {
     if (lanes.steer.some((item) => item.id === queueItemId)) return "steer";
     if (lanes.queue.some((item) => item.id === queueItemId)) return "queue";
@@ -116,27 +141,69 @@ export const createMessageQueue = (
     messages.delete(head.id);
     setLanes({ ...lanes, [lane]: lanes[lane].slice(1) });
     if (!message) return;
+    const dispatch = { id: head.id, item: head, message };
     running = true;
-    driver.run(dispatchTransform(message), { steer: false });
+    const busyEdgesBeforeRun = busyEdges;
+    try {
+      driver.run(dispatchTransform(message), { steer: false });
+    } catch (error) {
+      if (busyEdges === busyEdgesBeforeRun) {
+        running = false;
+        restore(lane, dispatch);
+      }
+      throw error;
+    }
   };
 
-  const interrupt = (message: AppendMessage) => {
+  const interrupt = (
+    dispatch: DispatchItem,
+    restoreLane: Lane = "steer",
+    restoreIndex = 0,
+  ) => {
     paused = false;
+    let transformed: AppendMessage;
+    try {
+      transformed = dispatchTransform(dispatch.message);
+    } catch (error) {
+      restore(restoreLane, dispatch, restoreIndex);
+      throw error;
+    }
+
     // the interrupted run settles exactly once, whether or not it was
     // already cancel-notified
     suppressIdle += Math.max(cancelSettles, 1);
     cancelSettles = 0;
+    const restoreInterrupted = (replacementStarted = false) => {
+      if (replacementStarted) return;
+      // The live count distinguishes an outstanding cancellation settle
+      // from one delivered synchronously by cancel().
+      const pendingSettles = suppressIdle;
+      suppressIdle = Math.max(pendingSettles - 1, 0);
+      cancelSettles = pendingSettles > 0 ? 1 : 0;
+      running = pendingSettles > 0;
+      restore(restoreLane, dispatch, restoreIndex);
+    };
     // a driver whose cancel routes through the runtime notifies this queue
     // back; the interrupt already accounted for that settle and is dispatching
     // in its place
     interrupting = true;
     try {
       driver.cancel!();
+    } catch (error) {
+      restoreInterrupted();
+      throw error;
     } finally {
       interrupting = false;
     }
     running = true;
-    driver.run(dispatchTransform(message), { steer: true });
+    const busyEdgesBeforeRun = busyEdges;
+    try {
+      driver.run(transformed, { steer: true });
+    } catch (error) {
+      const replacementStarted = busyEdges !== busyEdgesBeforeRun;
+      restoreInterrupted(replacementStarted);
+      throw error;
+    }
   };
 
   const push = (lane: Lane, message: AppendMessage) => {
@@ -153,7 +220,8 @@ export const createMessageQueue = (
 
   const steer = (message: AppendMessage) => {
     if (running && driver.cancel) {
-      interrupt(message);
+      const id = generateId();
+      interrupt({ id, item: toItem(id, message), message });
       return;
     }
     push("steer", message);
@@ -164,7 +232,8 @@ export const createMessageQueue = (
     if (!fromLane) throw new Error(`Unknown queue item "${queueItemId}".`);
     const toLane = placement.lane ?? fromLane;
 
-    const item = lanes[fromLane].find((i) => i.id === queueItemId)!;
+    const fromIndex = lanes[fromLane].findIndex((i) => i.id === queueItemId);
+    const item = lanes[fromLane][fromIndex]!;
     const dest = (toLane === fromLane ? lanes[fromLane] : lanes[toLane]).filter(
       (i) => i.id !== queueItemId,
     );
@@ -217,7 +286,7 @@ export const createMessageQueue = (
         queue: lanes.queue.filter((i) => i.id !== queueItemId),
         steer: lanes.steer,
       });
-      interrupt(message);
+      interrupt({ id: queueItemId, item, message }, fromLane, fromIndex);
       return;
     }
 
@@ -280,6 +349,7 @@ export const createMessageQueue = (
       suppressIdle += cancelSettles;
       cancelSettles = 0;
       running = true;
+      busyEdges++;
     },
     notifyIdle: () => {
       if (suppressIdle > 0) {

--- a/packages/core/src/runtime/queue/message-queue.ts
+++ b/packages/core/src/runtime/queue/message-queue.ts
@@ -161,14 +161,6 @@ export const createMessageQueue = (
     restoreIndex = 0,
   ) => {
     paused = false;
-    let transformed: AppendMessage;
-    try {
-      transformed = dispatchTransform(dispatch.message);
-    } catch (error) {
-      restore(restoreLane, dispatch, restoreIndex);
-      throw error;
-    }
-
     // the interrupted run settles exactly once, whether or not it was
     // already cancel-notified
     suppressIdle += Math.max(cancelSettles, 1);
@@ -198,7 +190,7 @@ export const createMessageQueue = (
     running = true;
     const busyEdgesBeforeRun = busyEdges;
     try {
-      driver.run(transformed, { steer: true });
+      driver.run(dispatchTransform(dispatch.message), { steer: true });
     } catch (error) {
       const replacementStarted = busyEdges !== busyEdgesBeforeRun;
       restoreInterrupted(replacementStarted);

--- a/packages/core/src/tests/message-queue.test.ts
+++ b/packages/core/src/tests/message-queue.test.ts
@@ -435,6 +435,259 @@ describe("createMessageQueue", () => {
     });
   });
 
+  describe("synchronous dispatch failures", () => {
+    it("restores a message when the driver throws", () => {
+      const error = new Error("dispatch failed");
+      const run = vi.fn(() => {
+        throw error;
+      });
+      const { adapter } = createMessageQueue({ run });
+
+      expect(() => adapter.enqueue(msg("first"))).toThrow(error);
+      expect(prompts(adapter.items)).toEqual(["first"]);
+
+      run.mockImplementation(() => undefined);
+      adapter.enqueue(msg("second"));
+
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run).toHaveBeenLastCalledWith(
+        expect.objectContaining({ content: [{ type: "text", text: "first" }] }),
+        { steer: false },
+      );
+      expect(prompts(adapter.items)).toEqual(["second"]);
+    });
+
+    it("does not restore work after the driver starts its run", () => {
+      const error = new Error("dispatch failed");
+      let fail = true;
+      let controller!: ReturnType<typeof createMessageQueue>;
+      const run = vi.fn(() => {
+        if (!fail) return;
+        controller.notifyBusy();
+        throw error;
+      });
+      controller = createMessageQueue({ run });
+
+      expect(() => controller.adapter.enqueue(msg("first"))).toThrow(error);
+      expect(prompts(controller.adapter.items)).toEqual([]);
+
+      fail = false;
+      controller.adapter.enqueue(msg("second"));
+      expect(run).toHaveBeenCalledOnce();
+
+      controller.notifyIdle();
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          content: [{ type: "text", text: "second" }],
+        }),
+        { steer: false },
+      );
+      expect(prompts(controller.adapter.items)).toEqual([]);
+    });
+
+    it("restores a message when its dispatch transform throws", () => {
+      const error = new Error("transform failed");
+      const run = vi.fn();
+      const { adapter } = createMessageQueue({ run });
+      adapter.__internal_setDispatchTransform(() => {
+        throw error;
+      });
+
+      expect(() => adapter.enqueue(msg("first"))).toThrow(error);
+      expect(run).not.toHaveBeenCalled();
+      expect(prompts(adapter.items)).toEqual(["first"]);
+
+      adapter.__internal_setDispatchTransform((message) => message);
+      adapter.enqueue(msg("second"));
+
+      expect(run).toHaveBeenCalledWith(
+        expect.objectContaining({ content: [{ type: "text", text: "first" }] }),
+        { steer: false },
+      );
+      expect(prompts(adapter.items)).toEqual(["second"]);
+    });
+
+    it("restores a steer when cancellation throws", () => {
+      const error = new Error("cancel failed");
+      const run = vi.fn();
+      const cancel = vi.fn(() => {
+        throw error;
+      });
+      const { adapter, notifyIdle } = createMessageQueue({ run, cancel });
+
+      adapter.enqueue(msg("active"));
+      expect(() => adapter.steer(msg("urgent"))).toThrow(error);
+      expect(prompts(adapter.steerItems)).toEqual(["urgent"]);
+
+      notifyIdle();
+      expect(run).toHaveBeenCalledOnce();
+
+      cancel.mockImplementation(() => undefined);
+      adapter.enqueue(msg("later"));
+      expect(run).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          content: [{ type: "text", text: "urgent" }],
+        }),
+        { steer: false },
+      );
+      expect(prompts(adapter.items)).toEqual(["later"]);
+    });
+
+    it("restores a steer when its dispatch transform throws", () => {
+      const error = new Error("transform failed");
+      const run = vi.fn();
+      const cancel = vi.fn();
+      const { adapter, notifyIdle } = createMessageQueue({ run, cancel });
+
+      adapter.enqueue(msg("active"));
+      adapter.__internal_setDispatchTransform(() => {
+        throw error;
+      });
+
+      expect(() => adapter.steer(msg("urgent"))).toThrow(error);
+      expect(cancel).not.toHaveBeenCalled();
+      expect(prompts(adapter.steerItems)).toEqual(["urgent"]);
+
+      notifyIdle();
+      adapter.__internal_setDispatchTransform((message) => message);
+      adapter.enqueue(msg("later"));
+
+      expect(run).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          content: [{ type: "text", text: "urgent" }],
+        }),
+        { steer: false },
+      );
+      expect(prompts(adapter.items)).toEqual(["later"]);
+    });
+
+    it("restores a steer when its replacement run throws", () => {
+      const error = new Error("steer failed");
+      let failSteer = true;
+      const run = vi.fn(
+        (_message: AppendMessage, options: { steer: boolean }) => {
+          if (options.steer && failSteer) throw error;
+        },
+      );
+      const { adapter, notifyIdle } = createMessageQueue({
+        run,
+        cancel: vi.fn(),
+      });
+
+      adapter.enqueue(msg("active"));
+      expect(() => adapter.steer(msg("urgent"))).toThrow(error);
+      expect(prompts(adapter.steerItems)).toEqual(["urgent"]);
+
+      failSteer = false;
+      notifyIdle();
+      expect(run).toHaveBeenCalledTimes(2);
+
+      adapter.enqueue(msg("later"));
+      expect(run).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          content: [{ type: "text", text: "urgent" }],
+        }),
+        { steer: false },
+      );
+      expect(prompts(adapter.items)).toEqual(["later"]);
+    });
+
+    it("recovers when cancellation settles before the replacement throws", () => {
+      const error = new Error("steer failed");
+      let failSteer = true;
+      let controller!: ReturnType<typeof createMessageQueue>;
+      controller = createMessageQueue({
+        run: (_message, options) => {
+          if (options.steer && failSteer) throw error;
+        },
+        cancel: () => controller.notifyIdle(),
+      });
+
+      controller.adapter.enqueue(msg("active"));
+      expect(() => controller.adapter.steer(msg("urgent"))).toThrow(error);
+      expect(prompts(controller.adapter.steerItems)).toEqual(["urgent"]);
+
+      failSteer = false;
+      controller.adapter.enqueue(msg("later"));
+
+      expect(prompts(controller.adapter.steerItems)).toEqual([]);
+      expect(prompts(controller.adapter.items)).toEqual(["later"]);
+    });
+
+    it("does not restore a steer after its replacement run starts", () => {
+      const error = new Error("steer failed");
+      let failSteer = true;
+      let controller!: ReturnType<typeof createMessageQueue>;
+      const run = vi.fn(
+        (_message: AppendMessage, options: { steer: boolean }) => {
+          if (!options.steer || !failSteer) return;
+          controller.notifyBusy();
+          throw error;
+        },
+      );
+      controller = createMessageQueue({
+        run,
+        cancel: () => controller.notifyIdle(),
+      });
+
+      controller.adapter.enqueue(msg("active"));
+      expect(() => controller.adapter.steer(msg("urgent"))).toThrow(error);
+      expect(prompts(controller.adapter.steerItems)).toEqual([]);
+
+      failSteer = false;
+      controller.adapter.enqueue(msg("later"));
+      expect(run).toHaveBeenCalledTimes(2);
+
+      controller.notifyIdle();
+      expect(run).toHaveBeenCalledTimes(3);
+      expect(run).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          content: [{ type: "text", text: "later" }],
+        }),
+        { steer: false },
+      );
+      expect(prompts(controller.adapter.items)).toEqual([]);
+    });
+
+    it("restores an unanchored move when its replacement run throws", () => {
+      const error = new Error("steer failed");
+      let failSteer = true;
+      const run = vi.fn(
+        (_message: AppendMessage, options: { steer: boolean }) => {
+          if (options.steer && failSteer) throw error;
+        },
+      );
+      const { adapter, notifyIdle } = createMessageQueue({
+        run,
+        cancel: vi.fn(),
+      });
+
+      adapter.enqueue(msg("active"));
+      adapter.enqueue(msg("first"));
+      adapter.enqueue(msg("second"));
+      adapter.enqueue(msg("moved"));
+      const movedId = adapter.items[2]!.id;
+
+      expect(() => adapter.move(movedId, { lane: "steer" })).toThrow(error);
+      expect(adapter.steerItems).toHaveLength(0);
+      expect(prompts(adapter.items)).toEqual(["first", "second", "moved"]);
+      expect(adapter.items[2]?.id).toBe(movedId);
+
+      failSteer = false;
+      notifyIdle();
+      adapter.enqueue(msg("later"));
+
+      expect(run).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          content: [{ type: "text", text: "first" }],
+        }),
+        { steer: false },
+      );
+      expect(prompts(adapter.items)).toEqual(["second", "moved", "later"]);
+    });
+  });
+
   it("notifyCancelled keeps items and pauses advance until the next send", () => {
     const run = vi.fn();
     const { adapter, notifyIdle, notifyCancelled } = createMessageQueue({

--- a/packages/core/src/tests/message-queue.test.ts
+++ b/packages/core/src/tests/message-queue.test.ts
@@ -546,7 +546,7 @@ describe("createMessageQueue", () => {
       });
 
       expect(() => adapter.steer(msg("urgent"))).toThrow(error);
-      expect(cancel).not.toHaveBeenCalled();
+      expect(cancel).toHaveBeenCalledOnce();
       expect(prompts(adapter.steerItems)).toEqual(["urgent"]);
 
       notifyIdle();

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -13,8 +13,8 @@
   },
   "@assistant-ui/core": {
     ".": {
-      "min": 33610,
-      "gzip": 11313
+      "min": 33626,
+      "gzip": 11310
     },
     "./internal": {
       "min": 123266,

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -13,8 +13,8 @@
   },
   "@assistant-ui/core": {
     ".": {
-      "min": 32191,
-      "gzip": 10869
+      "min": 33610,
+      "gzip": 11313
     },
     "./internal": {
       "min": 123266,


### PR DESCRIPTION
## Problem

The message queue removed work before calling its synchronous transform and driver hooks. If either hook threw, the item was lost. An interrupted steer or move could also disappear when cancellation or replacement dispatch failed.

Minimal reproduction on current main:

1. Queue a message while the driver is idle.
2. Make the dispatch transform or `driver.run` throw synchronously.
3. Observe that the message is no longer present in either queue lane.

## Root cause

Queue mutation happened before external synchronous work, but failure paths did not restore the removed item or preserve the queue's running and cancellation-settle bookkeeping.

## Change

Restore and pause work that fails before the driver accepts it, preserving retry order for a later explicit send. Once a driver signals that a run started, the item remains in flight and is not restored or duplicated. Interrupted steer and move failures follow the same rule, and a failed move returns the item to its exact original lane position.

## Verification

- Clean local `@assistant-ui/core` rebuild measured the root entry at 33,626 min / 11,310 gzip, compared with 32,191 / 10,869 on the base; `pnpm size:check` passes.
- Focused message-queue suite with 50 tests passing
- Full `@assistant-ui/core` suite with 169 files and 1,817 tests passing
- Regression coverage for transform, dispatch, cancellation, replacement, started-run, and move-order failures
- `aui-build` in `packages/core`
- Focused Oxlint and Oxfmt checks
- Bundle-size check passing locally

The root size entry records the queue implementation change. The independent `./store/internal` baseline drift is isolated in #7191 and is not part of this diff.

## Public surface

`@assistant-ui/core` receives a patch changeset. No exports or signatures change.

Fixes #7174
