### PR TITLE
chore(core): refresh store internal size budget

### DIFF
--- a/size-budgets.json
+++ b/size-budgets.json
@@ -29,8 +29,8 @@
       "gzip": 32602
     },
     "./store/internal": {
-      "min": 23573,
-      "gzip": 8788
+      "min": 24070,
+      "gzip": 9036
     }
   },
   "@assistant-ui/eve": {

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -30,7 +30,7 @@
     },
     "./store/internal": {
       "min": 24070,
-      "gzip": 9036
+      "gzip": 9047
     }
   },
   "@assistant-ui/eve": {


### PR DESCRIPTION
## Problem

Fresh Linux builds measure `@assistant-ui/core/store/internal` at 9,047 gzip bytes. The current 8,788-byte baseline allows 256 bytes of movement, so the measured bundle exceeds the gate by three bytes and blocks every PR that builds core or one of its dependents.

This is reproducible in the package-build jobs for #7184, #7185, and #7189.

## Root cause

The recently introduced baseline does not reproduce against the current dependency lock and build output. This entry is the first one whose drift crosses the size gate's 256-byte floor.

## Change

Refresh only the affected `@assistant-ui/core/store/internal` entry from one clean Linux CI build.

## Verification

- Clean Linux `aui-build` in `packages/core`
- One Linux measurement pair: 24,070 minified bytes and 9,047 gzip bytes
- `pnpm size:check` passes with the refreshed pair

## Public surface

None. No package code, exports, APIs, or release metadata change, so no changeset is needed.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ismd5f-N-n9Emb3S0PPYbu2zKYEpo00Tnf19D4F3NauBJ3gPWomBFpruax8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->