### PR TITLE
fix(react-a2a): wait for agent capabilities before sending

### DIFF
--- a/.changeset/calm-badgers-wait.md
+++ b/.changeset/calm-badgers-wait.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: wait for agent capabilities before choosing the first A2A send method

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { A2AThreadRuntimeCore } from "./A2AThreadRuntimeCore";
 import type { A2AClient } from "./A2AClient";
-import type { A2AMessage, A2AStreamEvent, A2ATask } from "./types";
+import type {
+  A2AAgentCard,
+  A2AMessage,
+  A2AStreamEvent,
+  A2ATask,
+} from "./types";
 import type { AppendMessage, ThreadMessage } from "@assistant-ui/core";
 
 // --- Mock client factory ---
@@ -791,6 +796,53 @@ describe("A2AThreadRuntimeCore", () => {
   // --- Sync (non-streaming) fallback ---
 
   describe("sync fallback", () => {
+    it("waits for agent capabilities before choosing the first send method", async () => {
+      let resolveAgentCard!: (value: A2AAgentCard) => void;
+      const getAgentCard = vi.fn(
+        () =>
+          new Promise<A2AAgentCard>((resolve) => {
+            resolveAgentCard = resolve;
+          }),
+      );
+      const sendMessage = vi.fn().mockResolvedValue({
+        id: "t1",
+        status: { state: "completed" },
+      } satisfies A2ATask);
+      const streamMessage = vi.fn();
+      const core = createCore({ getAgentCard, sendMessage, streamMessage });
+
+      const run = core.append(createUserAppendMessage("Hello"));
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(streamMessage).not.toHaveBeenCalled();
+
+      resolveAgentCard({
+        name: "Agent",
+        capabilities: { streaming: false },
+      } as A2AAgentCard);
+      await run;
+
+      expect(getAgentCard).toHaveBeenCalledOnce();
+      expect(sendMessage).toHaveBeenCalledOnce();
+      expect(streamMessage).not.toHaveBeenCalled();
+    });
+
+    it("stops waiting for agent capabilities when the run is cancelled", async () => {
+      const getAgentCard = vi.fn(() => new Promise<A2AAgentCard>(() => {}));
+      const sendMessage = vi.fn();
+      const streamMessage = vi.fn();
+      const core = createCore({ getAgentCard, sendMessage, streamMessage });
+
+      const run = core.append(createUserAppendMessage("Hello"));
+      expect(core.isRunning()).toBe(true);
+
+      await core.cancel();
+      await run;
+
+      expect(core.isRunning()).toBe(false);
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(streamMessage).not.toHaveBeenCalled();
+    });
+
     it("uses sendMessage when streaming is false in agent card", async () => {
       const sendMessage = vi.fn().mockResolvedValue({
         id: "t1",

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -197,8 +197,7 @@ export class A2AThreadRuntimeCore {
     return this._isLoading;
   }
 
-  __internal_load(): Promise<void> {
-    this._loadRequested = true;
+  private loadAgentCard(): Promise<void> {
     this._agentCardPromise ??= this.client
       .getAgentCard()
       .then((agentCard) => {
@@ -206,15 +205,40 @@ export class A2AThreadRuntimeCore {
         this.notifyUpdate();
       })
       .catch(() => undefined);
+    return this._agentCardPromise;
+  }
+
+  private async waitForAgentCard(signal: AbortSignal): Promise<boolean> {
+    const load = this.loadAgentCard();
+    if (signal.aborted) return false;
+
+    let onAbort: (() => void) | undefined;
+    const abort = new Promise<void>((resolve) => {
+      onAbort = resolve;
+      signal.addEventListener("abort", onAbort, { once: true });
+      if (signal.aborted) resolve();
+    });
+
+    try {
+      await Promise.race([load, abort]);
+    } finally {
+      if (onAbort) signal.removeEventListener("abort", onAbort);
+    }
+    return !signal.aborted;
+  }
+
+  __internal_load(): Promise<void> {
+    this._loadRequested = true;
+    const agentCardPromise = this.loadAgentCard();
 
     if (this._loadPromise) return this._loadPromise;
-    if (!this.history) return this._agentCardPromise;
+    if (!this.history) return agentCardPromise;
 
     this._isLoading = true;
 
     const historyPromise = this.history.load();
 
-    this._loadPromise = Promise.all([historyPromise, this._agentCardPromise])
+    this._loadPromise = Promise.all([historyPromise, agentCardPromise])
       .then(([repo]) => {
         if (repo) {
           this.session.applyExternalMessageRepository(repo);
@@ -407,11 +431,11 @@ export class A2AThreadRuntimeCore {
 
     this.setRunning(true);
 
-    // Check if agent supports streaming; fall back to sync sendMessage if not
-    const supportsStreaming =
-      this.agentCardValue?.capabilities?.streaming !== false;
-
     try {
+      if (!(await this.waitForAgentCard(abortController.signal))) return;
+
+      const supportsStreaming =
+        this.agentCardValue?.capabilities?.streaming !== false;
       if (supportsStreaming) {
         await this.runStreaming(a2aMessage, assistantId, abortController);
       } else {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -212,17 +212,16 @@ export class A2AThreadRuntimeCore {
     const load = this.loadAgentCard();
     if (signal.aborted) return false;
 
-    let onAbort: (() => void) | undefined;
+    let onAbort!: () => void;
     const abort = new Promise<void>((resolve) => {
       onAbort = resolve;
       signal.addEventListener("abort", onAbort, { once: true });
-      if (signal.aborted) resolve();
     });
 
     try {
       await Promise.race([load, abort]);
     } finally {
-      if (onAbort) signal.removeEventListener("abort", onAbort);
+      signal.removeEventListener("abort", onAbort);
     }
     return !signal.aborted;
   }


### PR DESCRIPTION
## Problem

The first A2A message can be sent before agent-card discovery finishes. For an agent that declares `capabilities.streaming: false`, the runtime then calls the streaming endpoint and the first run fails instead of using `message:send`.

This reproduces by holding agent-card discovery pending, starting a message, and then resolving the card as non-streaming. Before this change, `streamMessage()` is selected before the card resolves.

## Root cause

The runtime starts agent-card discovery during loading, but `startRun()` chooses between streaming and synchronous sends from the current card value without waiting for the in-flight discovery promise.

## Change

Centralize the cached agent-card load and wait for it before choosing the send method. Cancellation stops an individual run from waiting while leaving the shared discovery request available to the runtime.

Discovery failures retain the existing streaming fallback behavior.

## Verification

- `vitest run packages/react-a2a/src/A2AThreadRuntimeCore.test.ts` (69 tests)
- `aui-build` in `packages/react-a2a`
- `oxlint`
- focused `oxfmt` check
- `node scripts/check-changeset-semver.mjs`
- Regression test fails before the fix and passes after it.

## Public surface

- Affected package: `@assistant-ui/react-a2a`
- Exports/API changes: None
- Changeset: patch


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.oubCGX-OXLJpCSdFoe4_xfCkiyaTY8vkj_Xr-r2MXhHlvpI3jUoNUB_ynF8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->