### PR TITLE
fix(core): preserve prototype-named interactable fields

### DIFF
--- a/.changeset/fair-dodos-own.md
+++ b/.changeset/fair-dodos-own.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve prototype-named fields in interactable updates and snapshots

--- a/packages/core/src/model-context/interactable-composer-metadata.test.ts
+++ b/packages/core/src/model-context/interactable-composer-metadata.test.ts
@@ -104,6 +104,18 @@ describe("interactableToolName", () => {
 });
 
 describe("shallowMergeInteractableState", () => {
+  it("adds prototype-named fields as own properties", () => {
+    const value = { enabled: true };
+    const result = shallowMergeInteractableState(
+      { title: "Example" },
+      Object.fromEntries([["__proto__", value]]),
+    ) as Record<string, unknown>;
+
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(Object.hasOwn(result, "__proto__")).toBe(true);
+    expect(result["__proto__"]).toBe(value);
+  });
+
   it("applies array operations from a baseline", () => {
     const prev = {
       tasks: [
@@ -451,6 +463,21 @@ describe("gateInteractableComposerMetadata", () => {
     const history = [userMsg([entry("a", { v: 1, title: "draft" })])];
     const gated = gateInteractableComposerMetadata(meta, history);
     expect(gated?.interactables).toEqual([entry("a", { v: 1 })]);
+  });
+
+  it("treats a removed prototype-named field as a full snapshot", () => {
+    const known = Object.fromEntries([
+      ["__proto__", { enabled: true }],
+      ["title", "draft"],
+      ["stable", true],
+    ]);
+    const current = { title: "edited", stable: true };
+    const meta = { interactables: [entry("a", current)] };
+    const history = [userMsg([entry("a", known)])];
+
+    const gated = gateInteractableComposerMetadata(meta, history);
+
+    expect(gated?.interactables).toEqual([entry("a", current)]);
   });
 
   it("omits an interactable the model already knows via its own update_* call", () => {

--- a/packages/core/src/model-context/interactable-composer-metadata.test.ts
+++ b/packages/core/src/model-context/interactable-composer-metadata.test.ts
@@ -465,20 +465,23 @@ describe("gateInteractableComposerMetadata", () => {
     expect(gated?.interactables).toEqual([entry("a", { v: 1 })]);
   });
 
-  it("treats a removed prototype-named field as a full snapshot", () => {
-    const known = Object.fromEntries([
-      ["__proto__", { enabled: true }],
-      ["title", "draft"],
-      ["stable", true],
-    ]);
-    const current = { title: "edited", stable: true };
-    const meta = { interactables: [entry("a", current)] };
-    const history = [userMsg([entry("a", known)])];
+  it.each(["__proto__", "toString"])(
+    "treats a removed prototype-named field %s as a full snapshot",
+    (field) => {
+      const known = Object.fromEntries([
+        [field, { enabled: true }],
+        ["title", "draft"],
+        ["stable", true],
+      ]);
+      const current = { title: "edited", stable: true };
+      const meta = { interactables: [entry("a", current)] };
+      const history = [userMsg([entry("a", known)])];
 
-    const gated = gateInteractableComposerMetadata(meta, history);
+      const gated = gateInteractableComposerMetadata(meta, history);
 
-    expect(gated?.interactables).toEqual([entry("a", current)]);
-  });
+      expect(gated?.interactables).toEqual([entry("a", current)]);
+    },
+  );
 
   it("omits an interactable the model already knows via its own update_* call", () => {
     const meta = { interactables: [entry("a", { v: 2 }, "note")] };

--- a/packages/core/src/model-context/interactable-composer-metadata.ts
+++ b/packages/core/src/model-context/interactable-composer-metadata.ts
@@ -1,19 +1,6 @@
 import { isJSONValueEqual } from "../utils/json/is-json-equal";
 import { isJSONValue, isRecord } from "../utils/json/is-json";
 
-const setOwnProperty = (
-  target: Record<string, unknown>,
-  key: string,
-  value: unknown,
-) => {
-  Object.defineProperty(target, key, {
-    value,
-    enumerable: true,
-    configurable: true,
-    writable: true,
-  });
-};
-
 /**
  * Unstable / Experimental — the interactables API is still evolving and may change in any release.
  * @deprecated Unstable / Experimental (not actually removed).
@@ -162,7 +149,7 @@ export function shallowMergeInteractableState(
   const baseline = isRecord(options?.arrayBaseline)
     ? options.arrayBaseline
     : prev;
-  const next = { ...prev };
+  const next = Object.entries(prev);
   for (const [key, value] of Object.entries(partial)) {
     const baseValue = baseline[key];
     if (Array.isArray(baseValue) && isRecord(value)) {
@@ -171,12 +158,12 @@ export function shallowMergeInteractableState(
         (options.idKeyedFields === undefined || options.idKeyedFields.has(key))
           ? () => options.idFactory?.(key)
           : undefined;
-      setOwnProperty(next, key, applyArrayUpdate(baseValue, value, mintId));
+      next.push([key, applyArrayUpdate(baseValue, value, mintId)]);
     } else {
-      setOwnProperty(next, key, value);
+      next.push([key, value]);
     }
   }
-  return next;
+  return Object.fromEntries(next);
 }
 
 /**
@@ -194,15 +181,15 @@ function shallowDiffInteractableState(
   for (const key of Object.keys(known)) {
     if (!Object.hasOwn(next, key)) return undefined;
   }
-  const diff: Record<string, unknown> = {};
+  const diff: [string, unknown][] = [];
   for (const [key, value] of Object.entries(next)) {
     if (!Object.hasOwn(known, key) || !isJSONValueEqual(known[key], value)) {
-      setOwnProperty(diff, key, value);
+      diff.push([key, value]);
     }
   }
-  const changed = Object.keys(diff).length;
+  const changed = diff.length;
   if (changed === 0 || changed === Object.keys(next).length) return undefined;
-  return diff;
+  return Object.fromEntries(diff);
 }
 
 type ToolCallLikePart = {

--- a/packages/core/src/model-context/interactable-composer-metadata.ts
+++ b/packages/core/src/model-context/interactable-composer-metadata.ts
@@ -1,6 +1,19 @@
 import { isJSONValueEqual } from "../utils/json/is-json-equal";
 import { isJSONValue, isRecord } from "../utils/json/is-json";
 
+const setOwnProperty = (
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+) => {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+};
+
 /**
  * Unstable / Experimental — the interactables API is still evolving and may change in any release.
  * @deprecated Unstable / Experimental (not actually removed).
@@ -158,9 +171,9 @@ export function shallowMergeInteractableState(
         (options.idKeyedFields === undefined || options.idKeyedFields.has(key))
           ? () => options.idFactory?.(key)
           : undefined;
-      next[key] = applyArrayUpdate(baseValue, value, mintId);
+      setOwnProperty(next, key, applyArrayUpdate(baseValue, value, mintId));
     } else {
-      next[key] = value;
+      setOwnProperty(next, key, value);
     }
   }
   return next;
@@ -179,12 +192,12 @@ function shallowDiffInteractableState(
 ): Record<string, unknown> | undefined {
   if (!isRecord(known) || !isRecord(next)) return undefined;
   for (const key of Object.keys(known)) {
-    if (!(key in next)) return undefined;
+    if (!Object.hasOwn(next, key)) return undefined;
   }
   const diff: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(next)) {
-    if (!(key in known) || !isJSONValueEqual(known[key], value)) {
-      diff[key] = value;
+    if (!Object.hasOwn(known, key) || !isJSONValueEqual(known[key], value)) {
+      setOwnProperty(diff, key, value);
     }
   }
   const changed = Object.keys(diff).length;

--- a/packages/core/src/react/client/interactable-model-context.test.ts
+++ b/packages/core/src/react/client/interactable-model-context.test.ts
@@ -241,6 +241,44 @@ describe("buildInteractableModelContext", () => {
       expect(mockGenerateId).toHaveBeenCalledOnce();
     });
 
+    it("mints ids for items in a prototype-named array field", async () => {
+      const itemSchema = {
+        type: "object" as const,
+        properties: {
+          id: { type: "string" as const },
+          title: { type: "string" as const },
+        },
+        required: ["id", "title"],
+      };
+      const schema = {
+        type: "object" as const,
+        properties: Object.fromEntries([
+          ["__proto__", { type: "array" as const, items: itemSchema }],
+        ]),
+      };
+      const state = Object.fromEntries([["__proto__", []]]);
+      const defs = { b1: def("b1", "taskBoard", state) };
+      const { ctx } = build(defs, new Map([["b1", schema]]));
+      const args = Object.fromEntries([
+        ["id", "b1"],
+        ["__proto__", { add: [{ title: "Write tests" }] }],
+      ]);
+
+      const result = (await ctx!.tools["update_taskBoard"]!.execute!(
+        args,
+        {} as never,
+      )) as {
+        addedItemIds: Record<string, string[]>;
+      };
+
+      expect(Object.hasOwn(result.addedItemIds, "__proto__")).toBe(true);
+      expect(result.addedItemIds["__proto__"]).toEqual(["generated-id"]);
+      expect(Object.hasOwn(defs.b1.state as object, "__proto__")).toBe(true);
+      expect((defs.b1.state as Record<string, unknown>)["__proto__"]).toEqual([
+        { title: "Write tests", id: "generated-id" },
+      ]);
+    });
+
     it("rejects an unknown id and lists valid ids", async () => {
       const defs = { n1: def("n1", "note"), n2: def("n2", "note") };
       const { ctx, setDefState } = build(defs);

--- a/packages/core/src/react/client/interactable-model-context.test.ts
+++ b/packages/core/src/react/client/interactable-model-context.test.ts
@@ -241,44 +241,49 @@ describe("buildInteractableModelContext", () => {
       expect(mockGenerateId).toHaveBeenCalledOnce();
     });
 
-    it("mints ids for items in a prototype-named array field", async () => {
-      const itemSchema = {
-        type: "object" as const,
-        properties: {
-          id: { type: "string" as const },
-          title: { type: "string" as const },
-        },
-        required: ["id", "title"],
-      };
-      const schema = {
-        type: "object" as const,
-        properties: Object.fromEntries([
-          ["__proto__", { type: "array" as const, items: itemSchema }],
-        ]),
-      };
-      const state = Object.fromEntries([["__proto__", []]]);
-      const defs = { b1: def("b1", "taskBoard", state) };
-      const { ctx } = build(defs, new Map([["b1", schema]]));
-      const args = Object.fromEntries([
-        ["id", "b1"],
-        ["__proto__", { add: [{ title: "Write tests" }] }],
-      ]);
+    it.each(["__proto__", "toString"])(
+      "mints ids for items in a prototype-named array field %s",
+      async (field) => {
+        const itemSchema = {
+          type: "object" as const,
+          properties: {
+            id: { type: "string" as const },
+            title: { type: "string" as const },
+          },
+          required: ["id", "title"],
+        };
+        const schema = {
+          type: "object" as const,
+          properties: Object.fromEntries([
+            [field, { type: "array" as const, items: itemSchema }],
+          ]),
+        };
+        const state = Object.fromEntries([[field, []]]);
+        const defs = { b1: def("b1", "taskBoard", state) };
+        const { ctx } = build(defs, new Map([["b1", schema]]));
+        const args = Object.fromEntries([
+          ["id", "b1"],
+          [field, { add: [{ title: "Write tests" }] }],
+        ]);
 
-      const result = (await ctx!.tools["update_taskBoard"]!.execute!(
-        args,
-        {} as never,
-      )) as {
-        addedItemIds: Record<string, string[]>;
-      };
+        const result = (await ctx!.tools["update_taskBoard"]!.execute!(
+          args,
+          {} as never,
+        )) as {
+          addedItemIds: Record<string, string[]>;
+        };
 
-      expect(Object.getPrototypeOf(result.addedItemIds)).toBe(Object.prototype);
-      expect(Object.hasOwn(result.addedItemIds, "__proto__")).toBe(true);
-      expect(result.addedItemIds["__proto__"]).toEqual(["generated-id"]);
-      expect(Object.hasOwn(defs.b1.state as object, "__proto__")).toBe(true);
-      expect((defs.b1.state as Record<string, unknown>)["__proto__"]).toEqual([
-        { title: "Write tests", id: "generated-id" },
-      ]);
-    });
+        expect(Object.getPrototypeOf(result.addedItemIds)).toBe(
+          Object.prototype,
+        );
+        expect(Object.hasOwn(result.addedItemIds, field)).toBe(true);
+        expect(result.addedItemIds[field]).toEqual(["generated-id"]);
+        expect(Object.hasOwn(defs.b1.state as object, field)).toBe(true);
+        expect((defs.b1.state as Record<string, unknown>)[field]).toEqual([
+          { title: "Write tests", id: "generated-id" },
+        ]);
+      },
+    );
 
     it("rejects an unknown id and lists valid ids", async () => {
       const defs = { n1: def("n1", "note"), n2: def("n2", "note") };

--- a/packages/core/src/react/client/interactable-model-context.test.ts
+++ b/packages/core/src/react/client/interactable-model-context.test.ts
@@ -271,6 +271,7 @@ describe("buildInteractableModelContext", () => {
         addedItemIds: Record<string, string[]>;
       };
 
+      expect(Object.getPrototypeOf(result.addedItemIds)).toBe(Object.prototype);
       expect(Object.hasOwn(result.addedItemIds, "__proto__")).toBe(true);
       expect(result.addedItemIds["__proto__"]).toEqual(["generated-id"]);
       expect(Object.hasOwn(defs.b1.state as object, "__proto__")).toBe(true);

--- a/packages/core/src/react/client/interactable-model-context.ts
+++ b/packages/core/src/react/client/interactable-model-context.ts
@@ -8,6 +8,7 @@ import {
 } from "../../model-context/interactable-composer-metadata";
 import { generateId } from "../../utils/id";
 import { isRecord } from "../../utils/json/is-json";
+import { nullProtoRecord } from "../../utils/record";
 
 export type PartialJSONSchema = ReturnType<typeof toJSONSchema>;
 
@@ -243,7 +244,7 @@ export function buildInteractableModelContext(
         }
         const baseline = streamBaselines.get(toolCallId);
         streamBaselines.delete(toolCallId);
-        const addedItemIds: Record<string, string[]> = {};
+        const addedItemIds = nullProtoRecord<string[]>();
         setDefState(target.id, (prev) =>
           shallowMergeInteractableState(prev, partial, {
             arrayBaseline:

--- a/packages/core/src/react/client/interactable-model-context.ts
+++ b/packages/core/src/react/client/interactable-model-context.ts
@@ -265,7 +265,7 @@ export function buildInteractableModelContext(
           addedItemIds?: Record<string, string[]>;
         } = { success: true, id: target.id };
         if (Object.keys(addedItemIds).length > 0) {
-          result.addedItemIds = addedItemIds;
+          result.addedItemIds = { ...addedItemIds };
         }
         return result;
       },

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -14,7 +14,7 @@
   "@assistant-ui/core": {
     ".": {
       "min": 33252,
-      "gzip": 11156
+      "gzip": 11134
     },
     "./internal": {
       "min": 123266,

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -13,8 +13,8 @@
   },
   "@assistant-ui/core": {
     ".": {
-      "min": 32191,
-      "gzip": 10869
+      "min": 33252,
+      "gzip": 11156
     },
     "./internal": {
       "min": 123266,


### PR DESCRIPTION
## Problem

Interactable state fields that overlap `Object.prototype`, such as `__proto__` and `toString`, are valid JSON properties but are not handled reliably. Updates to `__proto__` can invoke inherited object behavior, while an id-keyed array named `toString` can crash with `TypeError: addedItemIds[field].push is not a function`.

Removing a prototype-named field can also be missed by the shallow diff, leaving stale model-known state.

## Root cause

Dynamic assignments used ordinary objects, so `__proto__` reached the inherited setter. Presence checks used `in`, which treats inherited properties as present, and the generated-ID accumulator inherited all `Object.prototype` names.

## Change

Build merged and diffed records from entries so dynamic keys become own enumerable data properties, compare field presence with `Object.hasOwn()`, and use the existing null-prototype record helper internally for generated item IDs. The public result and interactable state remain ordinary objects.

## Verification

- `vitest run` from `packages/core`: 169 files and 1,815 tests passed
- Focused merge, diff, and id-minting regressions cover both `__proto__` and `toString`
- `aui-build` from `packages/core`
- Focused `oxlint` and `oxfmt --check`
- `node scripts/check-changeset-semver.mjs`
- CI measured the `@assistant-ui/core` public entry at 11,134 bytes gzip

The focused regressions fail on current main and pass with this change. The size-budget update also captures pre-existing core bundle drift accumulated on main; that larger baseline movement is not attributable solely to this fix. A repository-wide re-baseline is separate from this PR.

## Public surface

`@assistant-ui/core` behavior only. No exports, types, or documentation change. Includes a patch changeset.