### PR TITLE
fix(cloud): avoid caching malformed rotated tokens

### DIFF
--- a/.changeset/calm-tokens-rotate.md
+++ b/.changeset/calm-tokens-rotate.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: avoid caching malformed rotated JWTs

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -160,8 +160,9 @@ export class AssistantCloudJWTAuthStrategy implements AssistantCloudAuthStrategy
     const token = await this.#authTokenCallback();
     if (!token) return false;
 
+    const tokenExpiry = getJwtExpiry(token);
     this.cachedToken = token;
-    this.tokenExpiry = getJwtExpiry(token);
+    this.tokenExpiry = tokenExpiry;
 
     return { Authorization: `Bearer ${token}` };
   }
@@ -175,8 +176,9 @@ export class AssistantCloudJWTAuthStrategy implements AssistantCloudAuthStrategy
       throw new Error("Invalid auth header received");
     }
 
+    const tokenExpiry = getJwtExpiry(token);
     this.cachedToken = token;
-    this.tokenExpiry = getJwtExpiry(token);
+    this.tokenExpiry = tokenExpiry;
   }
 }
 

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -950,4 +950,26 @@ describe("AssistantCloudJWTAuthStrategy", () => {
     });
     expect(authToken).toHaveBeenCalledTimes(2);
   });
+
+  it("does not cache a malformed rotated token", async () => {
+    const authToken = vi
+      .fn<() => Promise<string | null>>()
+      .mockResolvedValue(accessToken);
+    const strategy = new AssistantCloudJWTAuthStrategy(authToken);
+
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${accessToken}`,
+    });
+
+    expect(() =>
+      strategy.readAuthHeaders(
+        new Headers({ Authorization: "Bearer malformed" }),
+      ),
+    ).toThrow("Unable to determine the token expiry");
+
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${accessToken}`,
+    });
+    expect(authToken).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Problem

AssistantCloudJWTAuthStrategy accepts rotated bearer tokens through readAuthHeaders(). On the current implementation, a malformed rotated token throws during expiry decoding but is assigned to the cache first. A later getAuthHeaders() can therefore return the malformed token using the previous valid token expiry.

Reproduction: cache a valid JWT, call readAuthHeaders() with Bearer malformed, catch the validation error, then request auth headers again. Before this change the strategy returned Bearer malformed.

## Root cause

Both token-ingress paths assigned cachedToken before getJwtExpiry() completed, so expiry validation was not atomic with the cache update.

## Change

Decode and validate the expiry into a local value first, then update cachedToken and tokenExpiry together. A failed rotation leaves the last valid cached token intact.

## Verification

- Added a regression proving a malformed rotation throws without replacing the valid cached token.
- Confirmed the regression fails before the implementation change by returning Bearer malformed.
- Ran all assistant-cloud tests: 193 passed.
- Built assistant-cloud and passed focused lint, changeset, diff, and size-budget checks.

## Public surface

No API changes. Affects assistant-cloud runtime behavior and includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2e2udkOunkr2XeUQfqAyUKCrTALSWtFONfVz6jwWzVq5_ofXgFK_O00f-3c?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->