### PR TITLE
fix(react-hook-form): settle submissions when forms unmount

### DIFF
--- a/.changeset/tidy-forms-settle.md
+++ b/.changeset/tidy-forms-settle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-hook-form": patch
+---
+
+fix: settle pending assistant submissions when forms unmount

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -280,6 +280,40 @@ describe("useAssistantForm", () => {
     });
   });
 
+  it("settles a pending assistant submission when the form unmounts", async () => {
+    type FormValues = { name: string };
+    let validationStarted = false;
+    const resolver: Resolver<FormValues> = () => {
+      validationStarted = true;
+      return new Promise(() => {});
+    };
+
+    const Form = () => {
+      const form = useAssistantForm<FormValues>({ resolver });
+      return (
+        <form onSubmit={form.handleSubmit(vi.fn())}>
+          <input {...form.register("name")} />
+        </form>
+      );
+    };
+    const { unmount } = render(<Form />);
+
+    let settled = false;
+    const submission = executeSubmitForm().finally(() => {
+      settled = true;
+    });
+    await waitFor(() => expect(validationStarted).toBe(true));
+
+    unmount();
+    await act(() => Promise.resolve());
+
+    expect(settled).toBe(true);
+    await expect(submission).resolves.toEqual({
+      success: false,
+      message: "The form is no longer available.",
+    });
+  });
+
   it("reports when requestSubmit does not dispatch a submit event", async () => {
     const requestSubmit = vi
       .spyOn(HTMLFormElement.prototype, "requestSubmit")

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -305,7 +305,12 @@ describe("useAssistantForm", () => {
         </form>
       ) : null;
     };
-    render(<FormOwner />);
+    const host = document.createElement("div");
+    const shadowRoot = host.attachShadow({ mode: "open" });
+    const container = document.createElement("div");
+    shadowRoot.append(container);
+    document.body.append(host);
+    render(<FormOwner />, { container });
 
     const submission = executeSubmitForm();
     await waitFor(() => expect(validationStarted).toBe(true));
@@ -319,6 +324,38 @@ describe("useAssistantForm", () => {
 
     await act(() => resolveValidation({ values: { name: "Ada" }, errors: {} }));
     expect(onValid).not.toHaveBeenCalled();
+    host.remove();
+  });
+
+  it("suppresses a valid callback when validation disconnects the form", async () => {
+    type FormValues = { name: string };
+    let formElement: HTMLFormElement | null = null;
+    const resolver: Resolver<FormValues> = async () => {
+      formElement?.remove();
+      return { values: { name: "Ada" }, errors: {} };
+    };
+    const onValid = vi.fn();
+
+    const Form = () => {
+      const form = useAssistantForm<FormValues>({ resolver });
+      return (
+        <form
+          ref={(element) => {
+            formElement = element;
+          }}
+          onSubmit={form.handleSubmit(onValid)}
+        >
+          <input {...form.register("name")} />
+        </form>
+      );
+    };
+    render(<Form />);
+
+    await expect(executeSubmitForm()).resolves.toEqual({
+      success: false,
+      message: "The form is no longer available.",
+    });
+    expect(onValid).not.toHaveBeenCalled();
   });
 
   it("reports success when a valid submit handler unmounts the form", async () => {
@@ -331,14 +368,21 @@ describe("useAssistantForm", () => {
       const [visible, setVisible] = useState(true);
       hideForm = () => setVisible(false);
       return visible ? (
-        <form onSubmit={form.handleSubmit(hideForm)}>
+        <form
+          data-testid="handler-unmount-form"
+          onSubmit={form.handleSubmit(hideForm)}
+        >
           <input {...form.register("name", { required: true })} />
         </form>
       ) : null;
     };
-    render(<FormOwner />);
+    const { queryByTestId } = render(<FormOwner />);
 
+    expect(queryByTestId("handler-unmount-form")).not.toBeNull();
     await expect(executeSubmitForm()).resolves.toEqual({ success: true });
+    await waitFor(() =>
+      expect(queryByTestId("handler-unmount-form")).toBeNull(),
+    );
   });
 
   it("reports when requestSubmit does not dispatch a submit event", async () => {

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -7,7 +7,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import type { ModelContext } from "@assistant-ui/core";
-import type { FormEvent, ReactNode } from "react";
+import { type FormEvent, type ReactNode, useState } from "react";
 import type { Resolver, ResolverResult } from "react-hook-form";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -280,38 +280,66 @@ describe("useAssistantForm", () => {
     });
   });
 
-  it("settles a pending assistant submission when the form unmounts", async () => {
+  it("settles when the form unmounts but the hook owner remains", async () => {
     type FormValues = { name: string };
     let validationStarted = false;
+    let resolveValidation: (result: ResolverResult<FormValues>) => void =
+      () => {};
     const resolver: Resolver<FormValues> = () => {
       validationStarted = true;
-      return new Promise(() => {});
+      return new Promise((resolve) => {
+        resolveValidation = resolve;
+      });
     };
+    const onValid = vi.fn();
+    let hideForm = () => {};
 
-    const Form = () => {
+    const FormOwner = () => {
       const form = useAssistantForm<FormValues>({ resolver });
-      return (
-        <form onSubmit={form.handleSubmit(vi.fn())}>
+      const [visible, setVisible] = useState(true);
+      hideForm = () => setVisible(false);
+      return visible ? (
+        <form onSubmit={form.handleSubmit(onValid)}>
           <input {...form.register("name")} />
         </form>
-      );
+      ) : null;
     };
-    const { unmount } = render(<Form />);
+    render(<FormOwner />);
 
-    let settled = false;
-    const submission = executeSubmitForm().finally(() => {
-      settled = true;
-    });
+    const submission = executeSubmitForm();
     await waitFor(() => expect(validationStarted).toBe(true));
 
-    unmount();
-    await act(() => Promise.resolve());
+    act(() => hideForm());
 
-    expect(settled).toBe(true);
     await expect(submission).resolves.toEqual({
       success: false,
       message: "The form is no longer available.",
     });
+
+    await act(() =>
+      resolveValidation({ values: { name: "Ada" }, errors: {} }),
+    );
+    expect(onValid).not.toHaveBeenCalled();
+  });
+
+  it("reports success when a valid submit handler unmounts the form", async () => {
+    let hideForm = () => {};
+
+    const FormOwner = () => {
+      const form = useAssistantForm<{ name: string }>({
+        defaultValues: { name: "Ada" },
+      });
+      const [visible, setVisible] = useState(true);
+      hideForm = () => setVisible(false);
+      return visible ? (
+        <form onSubmit={form.handleSubmit(hideForm)}>
+          <input {...form.register("name", { required: true })} />
+        </form>
+      ) : null;
+    };
+    render(<FormOwner />);
+
+    await expect(executeSubmitForm()).resolves.toEqual({ success: true });
   });
 
   it("reports when requestSubmit does not dispatch a submit event", async () => {

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -283,8 +283,9 @@ describe("useAssistantForm", () => {
   it("settles when the form unmounts but the hook owner remains", async () => {
     type FormValues = { name: string };
     let validationStarted = false;
-    let resolveValidation: (result: ResolverResult<FormValues>) => void =
-      () => {};
+    let resolveValidation: (
+      result: ResolverResult<FormValues>,
+    ) => void = () => {};
     const resolver: Resolver<FormValues> = () => {
       validationStarted = true;
       return new Promise((resolve) => {
@@ -316,9 +317,7 @@ describe("useAssistantForm", () => {
       message: "The form is no longer available.",
     });
 
-    await act(() =>
-      resolveValidation({ values: { name: "Ada" }, errors: {} }),
-    );
+    await act(() => resolveValidation({ values: { name: "Ada" }, errors: {} }));
     expect(onValid).not.toHaveBeenCalled();
   });
 

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -323,11 +323,11 @@ describe("useAssistantForm", () => {
     });
 
     await act(() => resolveValidation({ values: { name: "Ada" }, errors: {} }));
-    expect(onValid).not.toHaveBeenCalled();
+    expect(onValid).toHaveBeenCalledOnce();
     host.remove();
   });
 
-  it("suppresses a valid callback when validation disconnects the form", async () => {
+  it("invokes a valid callback when validation disconnects the form", async () => {
     type FormValues = { name: string };
     let formElement: HTMLFormElement | null = null;
     const resolver: Resolver<FormValues> = async () => {
@@ -355,7 +355,7 @@ describe("useAssistantForm", () => {
       success: false,
       message: "The form is no longer available.",
     });
-    expect(onValid).not.toHaveBeenCalled();
+    expect(onValid).toHaveBeenCalledOnce();
   });
 
   it("reports success when a valid submit handler unmounts the form", async () => {

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -310,21 +310,26 @@ describe("useAssistantForm", () => {
     const container = document.createElement("div");
     shadowRoot.append(container);
     document.body.append(host);
-    render(<FormOwner />, { container });
+    try {
+      render(<FormOwner />, { container });
 
-    const submission = executeSubmitForm();
-    await waitFor(() => expect(validationStarted).toBe(true));
+      const submission = executeSubmitForm();
+      await waitFor(() => expect(validationStarted).toBe(true));
 
-    act(() => hideForm());
+      act(() => hideForm());
 
-    await expect(submission).resolves.toEqual({
-      success: false,
-      message: "The form is no longer available.",
-    });
+      await expect(submission).resolves.toEqual({
+        success: false,
+        message: "The form is no longer available.",
+      });
 
-    await act(() => resolveValidation({ values: { name: "Ada" }, errors: {} }));
-    expect(onValid).toHaveBeenCalledOnce();
-    host.remove();
+      await act(() =>
+        resolveValidation({ values: { name: "Ada" }, errors: {} }),
+      );
+      expect(onValid).toHaveBeenCalledOnce();
+    } finally {
+      host.remove();
+    }
   });
 
   it("invokes a valid callback when validation disconnects the form", async () => {

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -141,7 +141,6 @@ export const useAssistantForm = <
           if (assistantSubmit && !assistantSubmit.form.isConnected) {
             assistantSubmit.cancel();
           }
-          if (assistantSubmit?.unavailable) return undefined;
           if (assistantSubmit) assistantSubmit.outcome = true;
           return onValid(...args);
         },
@@ -150,7 +149,6 @@ export const useAssistantForm = <
           if (assistantSubmit && !assistantSubmit.form.isConnected) {
             assistantSubmit.cancel();
           }
-          if (assistantSubmit?.unavailable) return undefined;
           if (assistantSubmit) assistantSubmit.outcome = false;
           return onInvalid?.(...args);
         },

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -19,13 +19,15 @@ import type { z } from "zod";
 import { formTools } from "./formTools";
 
 type PendingAssistantSubmit = {
+  cancel: () => void;
+  dispose: () => void;
   dispatching: boolean;
   event: unknown;
-  formUnavailable: boolean;
   handlerInvoked: boolean;
   outcome: boolean | undefined;
   resolve: (outcome: boolean) => void;
   reject: (error: unknown) => void;
+  unavailable: boolean;
 };
 
 export type UseAssistantFormProps<
@@ -98,6 +100,7 @@ export const useAssistantForm = <
     if (!pending) return;
 
     pendingAssistantSubmitRef.current = null;
+    pending.dispose();
     pending.resolve(outcome);
   }, []);
   const rejectAssistantSubmit = useCallback((error: unknown) => {
@@ -105,34 +108,43 @@ export const useAssistantForm = <
     if (!pending) return;
 
     pendingAssistantSubmitRef.current = null;
+    pending.dispose();
     pending.reject(error);
   }, []);
   useEffect(
     () => () => {
-      const pending = pendingAssistantSubmitRef.current;
-      if (!pending) return;
-
-      pending.formUnavailable = true;
-      settleAssistantSubmit(false);
+      pendingAssistantSubmitRef.current?.cancel();
     },
-    [settleAssistantSubmit],
+    [],
   );
 
   const handleSubmit = useCallback<
     UseFormReturn<TFieldValues, TContext, TTransformedValues>["handleSubmit"]
   >(
     (onValid, onInvalid) => {
+      const assistantSubmitsByEvent = new WeakMap<
+        object,
+        PendingAssistantSubmit
+      >();
+      const getAssistantSubmit = (event: unknown) => {
+        const nativeEvent = (event as { nativeEvent?: unknown } | undefined)
+          ?.nativeEvent;
+        const key = nativeEvent ?? event;
+        return typeof key === "object" && key !== null
+          ? assistantSubmitsByEvent.get(key)
+          : undefined;
+      };
       const submit = baseHandleSubmit(
         (...args) => {
-          const pending = pendingAssistantSubmitRef.current;
-          const event = args[1]?.nativeEvent ?? args[1];
-          if (pending && pending.event === event) pending.outcome = true;
+          const assistantSubmit = getAssistantSubmit(args[1]);
+          if (assistantSubmit?.unavailable) return undefined;
+          if (assistantSubmit) assistantSubmit.outcome = true;
           return onValid(...args);
         },
         (...args) => {
-          const pending = pendingAssistantSubmitRef.current;
-          const event = args[1]?.nativeEvent ?? args[1];
-          if (pending && pending.event === event) pending.outcome = false;
+          const assistantSubmit = getAssistantSubmit(args[1]);
+          if (assistantSubmit?.unavailable) return undefined;
+          if (assistantSubmit) assistantSubmit.outcome = false;
           return onInvalid?.(...args);
         },
       );
@@ -152,6 +164,13 @@ export const useAssistantForm = <
           assistantSubmit.event = nativeEvent;
           assistantSubmit.handlerInvoked = true;
         }
+        const eventKey =
+          typeof nativeEvent === "object" && nativeEvent !== null
+            ? nativeEvent
+            : null;
+        if (assistantSubmit && eventKey) {
+          assistantSubmitsByEvent.set(eventKey, assistantSubmit);
+        }
 
         try {
           const result = await submit(event);
@@ -167,6 +186,8 @@ export const useAssistantForm = <
             rejectAssistantSubmit(error);
           }
           throw error;
+        } finally {
+          if (eventKey) assistantSubmitsByEvent.delete(eventKey);
         }
       }) as typeof submit;
     },
@@ -243,16 +264,43 @@ export const useAssistantForm = <
                   rejectSubmission = reject;
                 },
               );
+              let observer: MutationObserver | undefined;
               const assistantSubmit: PendingAssistantSubmit = {
+                cancel: () => {
+                  if (
+                    pendingAssistantSubmitRef.current !== assistantSubmit ||
+                    assistantSubmit.outcome !== undefined
+                  ) {
+                    return;
+                  }
+                  pendingAssistantSubmitRef.current = null;
+                  assistantSubmit.unavailable = true;
+                  assistantSubmit.dispose();
+                  assistantSubmit.resolve(false);
+                },
+                dispose: () => observer?.disconnect(),
                 dispatching: true,
                 event: undefined,
-                formUnavailable: false,
                 handlerInvoked: false,
                 outcome: undefined,
                 resolve: resolveSubmission,
                 reject: rejectSubmission,
+                unavailable: false,
               };
               pendingAssistantSubmitRef.current = assistantSubmit;
+              const MutationObserverImpl =
+                formElement.ownerDocument.defaultView?.MutationObserver;
+              if (MutationObserverImpl) {
+                observer = new MutationObserverImpl(() => {
+                  if (!formElement.isConnected) {
+                    assistantSubmit.cancel();
+                  }
+                });
+                observer.observe(formElement.ownerDocument, {
+                  childList: true,
+                  subtree: true,
+                });
+              }
               const onSubmit = (event: SubmitEvent) => {
                 if (
                   pendingAssistantSubmitRef.current === assistantSubmit &&
@@ -287,7 +335,7 @@ export const useAssistantForm = <
               }
 
               const submitted = await submissionResult;
-              if (assistantSubmit.formUnavailable) {
+              if (assistantSubmit.unavailable) {
                 return {
                   success: false,
                   message: "The form is no longer available.",

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -21,6 +21,7 @@ import { formTools } from "./formTools";
 type PendingAssistantSubmit = {
   dispatching: boolean;
   event: unknown;
+  formUnavailable: boolean;
   handlerInvoked: boolean;
   outcome: boolean | undefined;
   resolve: (outcome: boolean) => void;
@@ -106,6 +107,16 @@ export const useAssistantForm = <
     pendingAssistantSubmitRef.current = null;
     pending.reject(error);
   }, []);
+  useEffect(
+    () => () => {
+      const pending = pendingAssistantSubmitRef.current;
+      if (!pending) return;
+
+      pending.formUnavailable = true;
+      settleAssistantSubmit(false);
+    },
+    [settleAssistantSubmit],
+  );
 
   const handleSubmit = useCallback<
     UseFormReturn<TFieldValues, TContext, TTransformedValues>["handleSubmit"]
@@ -235,6 +246,7 @@ export const useAssistantForm = <
               const assistantSubmit: PendingAssistantSubmit = {
                 dispatching: true,
                 event: undefined,
+                formUnavailable: false,
                 handlerInvoked: false,
                 outcome: undefined,
                 resolve: resolveSubmission,
@@ -274,7 +286,14 @@ export const useAssistantForm = <
                 settleAssistantSubmit(false);
               }
 
-              if (await submissionResult) return { success: true };
+              const submitted = await submissionResult;
+              if (assistantSubmit.formUnavailable) {
+                return {
+                  success: false,
+                  message: "The form is no longer available.",
+                };
+              }
+              if (submitted) return { success: true };
               return {
                 success: false,
                 message: dispatched

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -22,6 +22,7 @@ type PendingAssistantSubmit = {
   cancel: () => void;
   dispose: () => void;
   dispatching: boolean;
+  form: HTMLFormElement;
   event: unknown;
   handlerInvoked: boolean;
   outcome: boolean | undefined;
@@ -137,12 +138,18 @@ export const useAssistantForm = <
       const submit = baseHandleSubmit(
         (...args) => {
           const assistantSubmit = getAssistantSubmit(args[1]);
+          if (assistantSubmit && !assistantSubmit.form.isConnected) {
+            assistantSubmit.cancel();
+          }
           if (assistantSubmit?.unavailable) return undefined;
           if (assistantSubmit) assistantSubmit.outcome = true;
           return onValid(...args);
         },
         (...args) => {
           const assistantSubmit = getAssistantSubmit(args[1]);
+          if (assistantSubmit && !assistantSubmit.form.isConnected) {
+            assistantSubmit.cancel();
+          }
           if (assistantSubmit?.unavailable) return undefined;
           if (assistantSubmit) assistantSubmit.outcome = false;
           return onInvalid?.(...args);
@@ -280,6 +287,7 @@ export const useAssistantForm = <
                 },
                 dispose: () => observer?.disconnect(),
                 dispatching: true,
+                form: formElement,
                 event: undefined,
                 handlerInvoked: false,
                 outcome: undefined,
@@ -296,10 +304,17 @@ export const useAssistantForm = <
                     assistantSubmit.cancel();
                   }
                 });
-                observer.observe(formElement.ownerDocument, {
+                const root = formElement.getRootNode();
+                observer.observe(root, {
                   childList: true,
                   subtree: true,
                 });
+                if (root !== formElement.ownerDocument) {
+                  observer.observe(formElement.ownerDocument, {
+                    childList: true,
+                    subtree: true,
+                  });
+                }
               }
               const onSubmit = (event: SubmitEvent) => {
                 if (

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -109,8 +109,8 @@
   },
   "@assistant-ui/react-hook-form": {
     ".": {
-      "min": 3380,
-      "gzip": 1428
+      "min": 4107,
+      "gzip": 1712
     }
   },
   "@assistant-ui/react-ink": {


### PR DESCRIPTION
## Problem

An assistant-triggered form submission waits for React Hook Form validation to settle. If the submitted form element disappears while an async resolver is pending, the submit_form tool promise never resolves, leaving the tool call and model run waiting indefinitely. The hook owner can remain mounted while a child form is replaced, so hook teardown alone is not sufficient.

Reproduction: start submit_form against a form with a pending async resolver, remove only the form subtree, and keep the useAssistantForm owner mounted. On the current implementation the submission remains unsettled.

## Root cause

Pending assistant submissions are settled by wrapped valid/invalid handlers and requestSubmit fallbacks, but there was no lifecycle signal for a submitted form element that disappeared before validation completed.

## Change

Observe both the submitted form root and its owner document while an assistant submission is pending, then settle it as unavailable when that element disconnects before a validation outcome exists. The callback boundary also checks connectivity synchronously, covering removal before MutationObserver delivery. Hook teardown remains a fallback.

Associate the assistant submission with its exact submit event so only the matching validation can settle the pending tool result and concurrent user submissions cannot affect it. If the submitted form disappears, the tool settles as unavailable, while React Hook Form still invokes the application callback when validation later completes. If a valid handler itself removes the form, its already-recorded successful outcome is preserved.

## Verification

- Added a real-hook ShadowRoot regression where the form subtree unmounts while the hook owner remains mounted.
- Added a resolver regression that disconnects the form immediately before the valid callback boundary.
- Confirmed late successful resolvers still invoke user callbacks after the assistant tool has settled as unavailable.
- Added an explicit DOM assertion proving a valid submit handler removes the form while the tool still reports success.
- Ran all @assistant-ui/react-hook-form tests: 17 passed.
- Built the package and passed focused lint, changeset, API-surface, diff, and updated size-budget checks.

## Public surface

No API changes. Affects @assistant-ui/react-hook-form runtime behavior and includes a patch changeset plus the measured package size-budget update.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.VlA3FnsMhRWHv52t13vqS2AwF5BZWx8V6abxUQzXwPd5VR3cEmoq5ZCB6T0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->