### PR TITLE
fix(react-langgraph): ignore malformed message content

### DIFF
--- a/.changeset/curvy-pandas-smile.md
+++ b/.changeset/curvy-pandas-smile.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-langgraph": patch
 ---
 
-fix: ignore malformed non-array message content
+fix: ignore malformed non-array message content and normalize system content blocks

--- a/.changeset/curvy-pandas-smile.md
+++ b/.changeset/curvy-pandas-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: ignore malformed non-array message content

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -65,6 +65,23 @@ describe("appendLangChainChunk content-less chunks", () => {
       expect.objectContaining({ id: "call-1", name: "search" }),
     ]);
   });
+
+  it("ignores malformed content before a valid continuation", () => {
+    const first = append(undefined, {
+      type: "AIMessageChunk",
+      id: "ai-1",
+      content: { text: "not an array" },
+    } as unknown as LangChainMessageChunk);
+
+    const merged = append(first, {
+      type: "AIMessageChunk",
+      id: "ai-1",
+      content: "hello",
+    });
+
+    expect(first.content).toEqual([]);
+    expect(merged.content).toEqual([{ type: "text", text: "hello" }]);
+  });
 });
 
 describe("appendLangChainChunk continuation content", () => {

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -125,7 +125,7 @@ export const appendLangChainChunk = (
       const toolCalls = (curr.tool_call_chunks ?? []).map(chunkToToolCall);
       return {
         ...prev,
-        content: curr.content ?? [],
+        content: typeof curr.content === "string" ? curr.content : [],
         ...(toolCalls.length > 0 && { tool_calls: toolCalls }),
       };
     }
@@ -134,7 +134,9 @@ export const appendLangChainChunk = (
   const newContent =
     typeof prev.content === "string"
       ? [{ type: "text" as const, text: prev.content }]
-      : [...(prev.content ?? [])];
+      : Array.isArray(prev.content)
+        ? [...prev.content]
+        : [];
 
   if (typeof curr?.content === "string") {
     const lastIndex = newContent.length - 1;

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -119,6 +119,35 @@ describe("convertLangChainMessages content-less messages", () => {
     expect(result.role).toBe("user");
     expect(result.content).toEqual([{ type: "text", text: "kept" }]);
   });
+
+  it("ignores non-array human message content", () => {
+    const result = convertLangChainMessages({
+      type: "human",
+      id: "h-3",
+      content: 42,
+    } as unknown as LangChainMessage);
+
+    expect(result.role).toBe("user");
+    expect(result.content).toEqual([]);
+  });
+
+  it("ignores non-array ai message content", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-2",
+      content: { text: "invalid" },
+      tool_calls: [{ id: "call-2", name: "search", args: { q: 1 } }],
+    } as unknown as LangChainMessage);
+
+    expect(result.role).toBe("assistant");
+    expect(result.content).toMatchObject([
+      {
+        type: "tool-call",
+        toolCallId: "call-2",
+        toolName: "search",
+      },
+    ]);
+  });
 });
 
 describe("convertLangChainMessages metadata", () => {

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -149,7 +149,7 @@ describe("convertLangChainMessages content-less messages", () => {
     ]);
   });
 
-  it("warns once in development about non-array content", () => {
+  it("warns once per malformed content type in development", () => {
     vi.stubEnv("NODE_ENV", "development");
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
@@ -161,9 +161,20 @@ describe("convertLangChainMessages content-less messages", () => {
       convertLangChainMessages(message);
       convertLangChainMessages(message);
 
-      expect(warn).toHaveBeenCalledTimes(1);
+      const aiMessage = {
+        type: "ai",
+        id: "ai-3",
+        content: { text: "invalid" },
+      } as unknown as LangChainMessage;
+      convertLangChainMessages(aiMessage);
+      convertLangChainMessages(aiMessage);
+
+      expect(warn).toHaveBeenCalledTimes(2);
       expect(warn).toHaveBeenCalledWith(
         "Ignoring message content that is neither a string nor an array: number",
+      );
+      expect(warn).toHaveBeenCalledWith(
+        "Ignoring message content that is neither a string nor an array: object",
       );
     } finally {
       warn.mockRestore();

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -148,6 +148,41 @@ describe("convertLangChainMessages content-less messages", () => {
       },
     ]);
   });
+
+  it("warns once in development about non-array content", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const message = {
+        type: "human",
+        id: "h-4",
+        content: 42,
+      } as unknown as LangChainMessage;
+      convertLangChainMessages(message);
+      convertLangChainMessages(message);
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        "Ignoring message content that is neither a string nor an array: number",
+      );
+    } finally {
+      warn.mockRestore();
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("joins text blocks in system message content", () => {
+    const result = convertLangChainMessages({
+      type: "system",
+      id: "system-1",
+      content: [
+        { type: "text", text: "first" },
+        { type: "text_delta", text: " second" },
+      ],
+    } as unknown as LangChainMessage);
+
+    expect(result.content).toEqual([{ type: "text", text: "first second" }]);
+  });
 });
 
 describe("convertLangChainMessages metadata", () => {

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -95,42 +95,40 @@ const resolveToolCallArgs = ({
   return { args, argsText };
 };
 
-const warnedMessagePartTypes = new Set<string>();
-const warnForUnknownMessagePartType = (type: string) => {
+const warnedDevelopmentMessages = new Set<string>();
+const warnOnceInDevelopment = (message: string) => {
   if (
     typeof process === "undefined" ||
     process?.env?.NODE_ENV !== "development"
   )
     return;
-  if (warnedMessagePartTypes.has(type)) return;
-  warnedMessagePartTypes.add(type);
-  console.warn(`Unknown message part type: ${type}`);
+  if (warnedDevelopmentMessages.has(message)) return;
+  warnedDevelopmentMessages.add(message);
+  console.warn(message);
 };
 
-const warnedMessageTypes = new Set<string>();
-const warnForUnknownMessageType = (type: string) => {
-  if (
-    typeof process === "undefined" ||
-    process?.env?.NODE_ENV !== "development"
-  )
-    return;
-  if (warnedMessageTypes.has(type)) return;
-  warnedMessageTypes.add(type);
-  console.warn(`Unknown message type: ${type}`);
-};
+const warnForUnknownMessagePartType = (type: string) =>
+  warnOnceInDevelopment(`Unknown message part type: ${type}`);
 
-const warnedMalformedMessageContentTypes = new Set<string>();
-const warnForMalformedMessageContent = (content: unknown) => {
-  if (
-    typeof process === "undefined" ||
-    process?.env?.NODE_ENV !== "development"
-  )
-    return;
-  const type = typeof content;
-  if (warnedMalformedMessageContentTypes.has(type)) return;
-  warnedMalformedMessageContentTypes.add(type);
-  console.warn(
-    `Ignoring message content that is neither a string nor an array: ${type}`,
+const warnForUnknownMessageType = (type: string) =>
+  warnOnceInDevelopment(`Unknown message type: ${type}`);
+
+const warnForMalformedMessageContent = (content: unknown) =>
+  warnOnceInDevelopment(
+    `Ignoring message content that is neither a string nor an array: ${typeof content}`,
+  );
+
+const contentBlocks = (
+  content: LangChainMessage["content"],
+): LangChainMessageContentBlock[] => {
+  if (content == null || typeof content === "string") return [];
+  if (!Array.isArray(content)) {
+    warnForMalformedMessageContent(content);
+    return [];
+  }
+  return content.filter(
+    (part): part is LangChainMessageContentBlock =>
+      typeof part === "object" && part !== null,
   );
 };
 
@@ -142,15 +140,7 @@ const contentToParts = (
   if (content == null) return [];
   if (typeof content === "string")
     return [{ type: "text" as const, text: content }];
-  if (!Array.isArray(content)) {
-    warnForMalformedMessageContent(content);
-    return [];
-  }
-  return content
-    .filter(
-      (part): part is LangChainMessageContentBlock =>
-        typeof part === "object" && part !== null,
-    )
+  return contentBlocks(content)
     .map(
       (
         part,
@@ -185,11 +175,7 @@ const contentToParts = (
 
 const getStringContent = (content: LangChainMessage["content"]): string => {
   if (typeof content === "string") return content;
-  if (!Array.isArray(content)) {
-    warnForMalformedMessageContent(content);
-    return "";
-  }
-  return content
+  return contentBlocks(content)
     .filter(
       (part): part is { type: "text" | "text_delta"; text: string } =>
         typeof part === "object" &&
@@ -321,9 +307,7 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
       const normalizedContent =
         typeof message.content === "string"
           ? [{ type: "text" as const, text: message.content }]
-          : Array.isArray(message.content)
-            ? message.content
-            : [];
+          : contentBlocks(message.content);
 
       const allContent = [
         message.additional_kwargs?.reasoning,

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -39,6 +39,11 @@ type LangGraphMessageConverterMetadata =
     attachmentsByMessageId?: Map<string, readonly CompleteAttachment[]>;
   };
 
+type LangChainMessageContentBlock = Exclude<
+  LangChainMessage["content"],
+  string
+>[number];
+
 const getToolArgsCacheKey = (
   messageId: string | undefined,
   kind: "tool" | "computer",
@@ -114,17 +119,38 @@ const warnForUnknownMessageType = (type: string) => {
   console.warn(`Unknown message type: ${type}`);
 };
 
+const warnedMalformedMessageContentTypes = new Set<string>();
+const warnForMalformedMessageContent = (content: unknown) => {
+  if (
+    typeof process === "undefined" ||
+    process?.env?.NODE_ENV !== "development"
+  )
+    return;
+  const type = typeof content;
+  if (warnedMalformedMessageContentTypes.has(type)) return;
+  warnedMalformedMessageContentTypes.add(type);
+  console.warn(
+    `Ignoring message content that is neither a string nor an array: ${type}`,
+  );
+};
+
 const contentToParts = (
-  content: unknown,
+  content: LangChainMessage["content"],
   metadata: LangGraphMessageConverterMetadata,
   messageId: string | undefined,
 ) => {
   if (content == null) return [];
   if (typeof content === "string")
     return [{ type: "text" as const, text: content }];
-  if (!Array.isArray(content)) return [];
+  if (!Array.isArray(content)) {
+    warnForMalformedMessageContent(content);
+    return [];
+  }
   return content
-    .filter((part) => typeof part === "object" && part !== null)
+    .filter(
+      (part): part is LangChainMessageContentBlock =>
+        typeof part === "object" && part !== null,
+    )
     .map(
       (
         part,
@@ -155,6 +181,24 @@ const contentToParts = (
       },
     )
     .filter((a) => a !== null);
+};
+
+const getStringContent = (content: LangChainMessage["content"]): string => {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) {
+    warnForMalformedMessageContent(content);
+    return "";
+  }
+  return content
+    .filter(
+      (part): part is { type: "text" | "text_delta"; text: string } =>
+        typeof part === "object" &&
+        part !== null &&
+        (part.type === "text" || part.type === "text_delta") &&
+        typeof part.text === "string",
+    )
+    .map((part) => part.text)
+    .join("");
 };
 
 const normalizePayload = (value: string) => parseDataUrl(value)?.data ?? value;
@@ -215,7 +259,7 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
       return {
         role: "system",
         id: message.id,
-        content: [{ type: "text", text: message.content }],
+        content: [{ type: "text", text: getStringContent(message.content) }],
         metadata: { custom: getCustomMetadata(message.additional_kwargs) },
       };
     case "human": {

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -115,13 +115,14 @@ const warnForUnknownMessageType = (type: string) => {
 };
 
 const contentToParts = (
-  content: LangChainMessage["content"],
+  content: unknown,
   metadata: LangGraphMessageConverterMetadata,
   messageId: string | undefined,
 ) => {
   if (content == null) return [];
   if (typeof content === "string")
     return [{ type: "text" as const, text: content }];
+  if (!Array.isArray(content)) return [];
   return content
     .filter((part) => typeof part === "object" && part !== null)
     .map(
@@ -276,7 +277,9 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
       const normalizedContent =
         typeof message.content === "string"
           ? [{ type: "text" as const, text: message.content }]
-          : (message.content ?? []);
+          : Array.isArray(message.content)
+            ? message.content
+            : [];
 
       const allContent = [
         message.additional_kwargs?.reasoning,


### PR DESCRIPTION
## Problem

LangGraph message content comes from provider payloads, so malformed values can reach the runtime despite the TypeScript types. Non-array human content crashed the converter, non-array AI content could crash both conversion and later chunk accumulation, and array-valued system content produced a non-renderable text value.

This is reproducible on current main.

## Root cause

The converter and streaming accumulator treated every non-string content value as an iterable array. The converter guard also widened array elements to any, which removed type checking inside the mapper.

## Change

- treat non-string, non-array content as empty while preserving valid text, structured content, tool calls, and metadata
- keep content-block mapper inputs strictly typed after runtime validation
- normalize malformed streamed content before later chunks are accumulated
- join text blocks from array-valued system messages
- emit one development warning per malformed content type, matching the sibling LangChain adapter

## Verification

- the human, AI, and streaming malformed-content regressions fail before the fix and pass after it
- focused converter and accumulator tests: 121 passed
- full react-langgraph test suite: 327 passed
- aui-build
- oxfmt and oxlint on changed files
- changeset and changeset-semver checks

## Public surface

- affected package: @assistant-ui/react-langgraph
- exports: None
- documentation, API reference, and templates: None
- includes a patch changeset



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.vHXO_lUNx50ZNXoMSNVAgQtQbrX7jbdm41G02PxCKpgKBMHteS8KX8GlM_U?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->