### PR TITLE
fix(cloud-ai-sdk): stop chats after final unmount

### DIFF
--- a/.changeset/calm-cloud-chats.md
+++ b/.changeset/calm-cloud-chats.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: stop owned chats after the Cloud chat runtime unmounts

--- a/.changeset/calm-cloud-chats.md
+++ b/.changeset/calm-cloud-chats.md
@@ -3,4 +3,4 @@
 ---
 
 fix: abort active chats after the Cloud chat runtime unmounts without
-recording teardown as a user stop or persisting a partial assistant response
+recording teardown as a user stop, while preserving content already streamed

--- a/.changeset/calm-cloud-chats.md
+++ b/.changeset/calm-cloud-chats.md
@@ -2,4 +2,5 @@
 "@assistant-ui/cloud-ai-sdk": patch
 ---
 
-fix: stop owned chats after the Cloud chat runtime unmounts
+fix: abort active chats after the Cloud chat runtime unmounts; partial
+assistant responses already received may remain in thread history

--- a/.changeset/calm-cloud-chats.md
+++ b/.changeset/calm-cloud-chats.md
@@ -2,5 +2,5 @@
 "@assistant-ui/cloud-ai-sdk": patch
 ---
 
-fix: abort active chats after the Cloud chat runtime unmounts; partial
-assistant responses already received may remain in thread history
+fix: abort active chats after the Cloud chat runtime unmounts without
+recording teardown as a user stop or persisting a partial assistant response

--- a/packages/cloud-ai-sdk/src/chat/ChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/ChatRegistry.test.ts
@@ -24,14 +24,16 @@ describe("ChatRegistry", () => {
     registry.getOrCreate("first");
     registry.getOrCreate("second");
 
+    const stopAll = registry.stopAll();
     let stopAllSettled = false;
-    const stopAll = registry.stopAll().then(() => {
+    void stopAll.then(() => {
       stopAllSettled = true;
     });
 
     expect(registry.isDisposed).toBe(true);
-    expect(registry.get("first")).toBeUndefined();
-    expect(registry.get("second")).toBeUndefined();
+    expect(registry.get("first")).toBeDefined();
+    expect(registry.get("second")).toBeDefined();
+    expect(registry.stopAll()).toBe(stopAll);
 
     await new Promise((resolve) => setTimeout(resolve, 0));
 

--- a/packages/cloud-ai-sdk/src/chat/ChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/ChatRegistry.test.ts
@@ -29,6 +29,10 @@ describe("ChatRegistry", () => {
       stopAllSettled = true;
     });
 
+    expect(registry.isDisposed).toBe(true);
+    expect(registry.get("first")).toBeUndefined();
+    expect(registry.get("second")).toBeUndefined();
+
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(firstStop).toHaveBeenCalledOnce();

--- a/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
@@ -6,6 +6,7 @@ export class ChatRegistry {
   private chatByKey = new Map<string, Chat<UIMessage>>();
   private metaByKey = new Map<string, ChatMeta>();
   private keyByThreadId = new Map<string, string>();
+  private disposed = false;
 
   private createChatFn: (chatKey: string) => Chat<UIMessage>;
 
@@ -74,12 +75,19 @@ export class ChatRegistry {
     return this.keyByThreadId.get(threadId);
   }
 
-  // The maps stay populated: stopping emits onFinish(isAbort) whose
-  // persistence path resolves this registry's meta, so the aborted partial
-  // run still saves through the scope it belongs to.
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
   async stopAll(): Promise<void> {
+    this.disposed = true;
+    const chats = [...this.chatByKey.values()];
+    this.chatByKey.clear();
+    this.metaByKey.clear();
+    this.keyByThreadId.clear();
+
     await Promise.allSettled(
-      [...this.chatByKey.values()].map(async (chat) => {
+      chats.map(async (chat) => {
         await chat.stop();
       }),
     );

--- a/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
@@ -7,6 +7,7 @@ export class ChatRegistry {
   private metaByKey = new Map<string, ChatMeta>();
   private keyByThreadId = new Map<string, string>();
   private disposed = false;
+  private stopAllPromise: Promise<void> | undefined;
 
   private createChatFn: (chatKey: string) => Chat<UIMessage>;
 
@@ -89,17 +90,15 @@ export class ChatRegistry {
     throw error;
   }
 
-  async stopAll(): Promise<void> {
+  stopAll(): Promise<void> {
+    if (this.stopAllPromise) return this.stopAllPromise;
+
     this.disposed = true;
     const chats = [...this.chatByKey.values()];
-    this.chatByKey.clear();
-    this.metaByKey.clear();
-    this.keyByThreadId.clear();
 
-    await Promise.allSettled(
-      chats.map(async (chat) => {
-        await chat.stop();
-      }),
-    );
+    this.stopAllPromise = Promise.allSettled(
+      chats.map(async (chat) => await chat.stop()),
+    ).then(() => undefined);
+    return this.stopAllPromise;
   }
 }

--- a/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
@@ -15,6 +15,7 @@ export class ChatRegistry {
   }
 
   getOrCreate(chatKey: string, threadId?: string | null): Chat<UIMessage> {
+    this.throwIfDisposed();
     const existing = this.chatByKey.get(chatKey);
     if (existing) {
       if (threadId) {
@@ -38,6 +39,7 @@ export class ChatRegistry {
     threadId: string | null,
     chat: Chat<UIMessage>,
   ): void {
+    this.throwIfDisposed();
     this.chatByKey.set(chatKey, chat);
     this.getOrCreateMeta(chatKey, threadId);
   }
@@ -47,6 +49,7 @@ export class ChatRegistry {
   }
 
   getOrCreateMeta(chatKey: string, threadId?: string | null): ChatMeta {
+    this.throwIfDisposed();
     const existing = this.metaByKey.get(chatKey);
     if (existing) {
       if (threadId && !existing.threadId) {
@@ -77,6 +80,13 @@ export class ChatRegistry {
 
   get isDisposed(): boolean {
     return this.disposed;
+  }
+
+  private throwIfDisposed(): void {
+    if (!this.disposed) return;
+    const error = new Error("Chat registry is disposed");
+    error.name = "AbortError";
+    throw error;
   }
 
   async stopAll(): Promise<void> {

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, render, renderHook } from "@testing-library/react";
-import { createElement, startTransition, Suspense } from "react";
+import { createElement, startTransition, StrictMode, Suspense } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { useChatRegistry } from "./useChatRegistry";
 
@@ -142,6 +142,37 @@ describe("useChatRegistry", () => {
     rerender();
 
     expect(stop).not.toHaveBeenCalled();
+  });
+
+  it("keeps owned chats running during Strict Mode effect replay", async () => {
+    const scope = {};
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const createChat = vi.fn().mockImplementation((chatKey: string) => ({
+      id: chatKey,
+      messages: [],
+      stop,
+    }));
+
+    const { unmount } = renderHook(
+      () =>
+        useChatRegistry({
+          scope,
+          threadId: "thread-1",
+          createChat: createChat as never,
+        }),
+      { wrapper: StrictMode },
+    );
+
+    await act(async () => {
+      await new Promise<void>((resolve) => queueMicrotask(resolve));
+    });
+    expect(stop).not.toHaveBeenCalled();
+
+    unmount();
+    await act(async () => {
+      await new Promise<void>((resolve) => queueMicrotask(resolve));
+    });
+    expect(stop).toHaveBeenCalledOnce();
   });
 
   it("does not register chats from abandoned renders", () => {

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
@@ -1,7 +1,14 @@
 // @vitest-environment jsdom
 
 import { act, render, renderHook } from "@testing-library/react";
-import { createElement, startTransition, StrictMode, Suspense } from "react";
+import {
+  Activity,
+  createElement,
+  startTransition,
+  StrictMode,
+  Suspense,
+  type ComponentProps,
+} from "react";
 import { describe, expect, it, vi } from "vitest";
 import { useChatRegistry } from "./useChatRegistry";
 
@@ -91,7 +98,7 @@ describe("useChatRegistry", () => {
     expect(result.current.activeChat.id).not.toBe(initialNewChatKey);
   });
 
-  it("creates a new registry and chat when the scope changes", () => {
+  it("creates a new registry and chat when the scope changes", async () => {
     const stop = vi.fn().mockResolvedValue(undefined);
     const createChat = vi.fn().mockImplementation((chatKey: string) => ({
       id: chatKey,
@@ -114,6 +121,8 @@ describe("useChatRegistry", () => {
     const chatA = result.current.activeChat;
 
     rerender({ scope: scopeB });
+
+    await act(async () => {});
 
     expect(result.current.registry).not.toBe(registryA);
     expect(result.current.activeChat).not.toBe(chatA);
@@ -172,6 +181,67 @@ describe("useChatRegistry", () => {
     await act(async () => {
       await new Promise<void>((resolve) => queueMicrotask(resolve));
     });
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("stops owned chats after a production unmount", async () => {
+    const scope = {};
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const createChat = vi.fn().mockImplementation((chatKey: string) => ({
+      id: chatKey,
+      messages: [],
+      stop,
+    }));
+
+    const { unmount } = renderHook(() =>
+      useChatRegistry({
+        scope,
+        threadId: "thread-1",
+        createChat: createChat as never,
+      }),
+    );
+
+    unmount();
+    await act(async () => {});
+
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("keeps owned chats running while an Activity is hidden", async () => {
+    const scope = {};
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const createChat = vi.fn().mockImplementation((chatKey: string) => ({
+      id: chatKey,
+      messages: [],
+      stop,
+    }));
+    const Probe = () => {
+      useChatRegistry({
+        scope,
+        threadId: "thread-1",
+        createChat: createChat as never,
+      });
+      return null;
+    };
+    const app = (mode: "visible" | "hidden") =>
+      createElement(
+        Activity,
+        { mode } as ComponentProps<typeof Activity>,
+        createElement(Probe),
+      );
+
+    const view = render(app("visible"));
+
+    view.rerender(app("hidden"));
+    await act(async () => {});
+    expect(stop).not.toHaveBeenCalled();
+
+    view.rerender(app("visible"));
+    await act(async () => {});
+    expect(stop).not.toHaveBeenCalled();
+
+    view.unmount();
+    await act(async () => {});
     expect(stop).toHaveBeenCalledOnce();
   });
 

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
@@ -129,7 +129,7 @@ describe("useChatRegistry", () => {
     expect(createChat).toHaveBeenCalledTimes(2);
     expect(stop).toHaveBeenCalledOnce();
     expect(registryA.isDisposed).toBe(true);
-    expect(registryA.get("thread-1")).toBeUndefined();
+    expect(registryA.get("thread-1")).toBe(chatA);
   });
 
   it("does not stop chats during ordinary rerenders", () => {

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
@@ -128,7 +128,8 @@ describe("useChatRegistry", () => {
     expect(result.current.activeChat).not.toBe(chatA);
     expect(createChat).toHaveBeenCalledTimes(2);
     expect(stop).toHaveBeenCalledOnce();
-    expect(registryA.get("thread-1")).toBe(chatA);
+    expect(registryA.isDisposed).toBe(true);
+    expect(registryA.get("thread-1")).toBeUndefined();
   });
 
   it("does not stop chats during ordinary rerenders", () => {

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
@@ -57,10 +57,10 @@ export function useChatRegistry({
     registry.register(activeChatKey, threadId, activeChat);
   }, [activeChat, activeChatKey, registry, threadId]);
 
-  // Insertion-effect cleanup runs only when React deletes the fiber, so a
-  // hidden <Activity> or a re-suspended boundary keeps chats alive; the stop
-  // is deferred because it notifies subscribers and React forbids scheduling
-  // updates from an insertion effect.
+  // This cleanup is not run when React merely hides or re-suspends the fiber,
+  // so chats survive those transitions. It runs for deletion and registry
+  // replacement; the stop is deferred because React forbids scheduling its
+  // subscriber updates from an insertion effect.
   useInsertionEffect(
     () => () => queueMicrotask(() => void registry.stopAll()),
     [registry],

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
@@ -57,6 +57,10 @@ export function useChatRegistry({
     registry.register(activeChatKey, threadId, activeChat);
   }, [activeChat, activeChatKey, registry, threadId]);
 
+  // Insertion-effect cleanup runs only when React deletes the fiber, so a
+  // hidden <Activity> or a re-suspended boundary keeps chats alive; the stop
+  // is deferred because it notifies subscribers and React forbids scheduling
+  // updates from an insertion effect.
   useInsertionEffect(
     () => () => queueMicrotask(() => void registry.stopAll()),
     [registry],

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
@@ -1,4 +1,4 @@
-import { useEffect, useInsertionEffect, useMemo, useRef } from "react";
+import { useInsertionEffect, useMemo } from "react";
 import type { Chat } from "@ai-sdk/react";
 import type { UIMessage } from "@ai-sdk/react";
 import { ChatRegistry } from "./ChatRegistry";
@@ -57,23 +57,10 @@ export function useChatRegistry({
     registry.register(activeChatKey, threadId, activeChat);
   }, [activeChat, activeChatKey, registry, threadId]);
 
-  const committedRegistryRef = useRef(registry);
-  const registryEffectGenerationRef = useRef(0);
-  useEffect(() => {
-    const generation = ++registryEffectGenerationRef.current;
-    const previousRegistry = committedRegistryRef.current;
-    committedRegistryRef.current = registry;
-    if (previousRegistry !== registry) {
-      void previousRegistry.stopAll();
-    }
-
-    return () => {
-      queueMicrotask(() => {
-        if (registryEffectGenerationRef.current !== generation) return;
-        void registry.stopAll();
-      });
-    };
-  }, [registry]);
+  useInsertionEffect(
+    () => () => queueMicrotask(() => void registry.stopAll()),
+    [registry],
+  );
 
   return { registry, activeChat };
 }

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
@@ -58,12 +58,21 @@ export function useChatRegistry({
   }, [activeChat, activeChatKey, registry, threadId]);
 
   const committedRegistryRef = useRef(registry);
+  const registryEffectGenerationRef = useRef(0);
   useEffect(() => {
+    const generation = ++registryEffectGenerationRef.current;
     const previousRegistry = committedRegistryRef.current;
     committedRegistryRef.current = registry;
     if (previousRegistry !== registry) {
       void previousRegistry.stopAll();
     }
+
+    return () => {
+      queueMicrotask(() => {
+        if (registryEffectGenerationRef.current !== generation) return;
+        void registry.stopAll();
+      });
+    };
   }, [registry]);
 
   return { registry, activeChat };

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -361,7 +361,7 @@ describe("CloudChatCore", () => {
 
     await expect(send).rejects.toMatchObject({ name: "AbortError" });
     expect(stop).toHaveBeenCalledOnce();
-    expect(chatRegistry.getMeta("chat-1")).toBeUndefined();
+    expect(chatRegistry.getMeta("chat-1")?.threadId).toBeNull();
     expect(chatRegistry.getChatKeyForThread("thread-1")).toBeUndefined();
     expect(selectThread).not.toHaveBeenCalled();
     expect(refresh).not.toHaveBeenCalled();
@@ -468,7 +468,7 @@ describe("CloudChatCore", () => {
     );
   });
 
-  it("skips Cloud finish effects after the chat registry is disposed", async () => {
+  it("persists streamed content without Cloud finish effects after disposal", async () => {
     const onFinish = vi.fn();
     const core = createCore({ chatConfig: { onFinish } });
     const messages = [{ id: "assistant-1", role: "assistant", parts: [] }];
@@ -478,6 +478,7 @@ describe("CloudChatCore", () => {
     const persistChatMessages = vi
       .spyOn(core, "persistChatMessages")
       .mockResolvedValue(undefined);
+    const persist = vi.spyOn(core, "persist").mockResolvedValue(undefined);
     const runStopped = vi.spyOn(core.engagementReporter, "runStopped");
 
     core.createChat("chat-1", chatRegistry);
@@ -494,6 +495,7 @@ describe("CloudChatCore", () => {
     expect(onFinish).toHaveBeenCalledOnce();
     expect(runStopped).not.toHaveBeenCalled();
     expect(persistChatMessages).not.toHaveBeenCalled();
+    expect(persist).toHaveBeenCalledWith("thread-1", messages);
   });
 
   it("reports finish persistence failures", async () => {

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatRegistry } from "../chat/ChatRegistry";
 import { CloudChatCore } from "./CloudChatCore";
 
 const {
@@ -415,6 +416,34 @@ describe("CloudChatCore", () => {
       expect.anything(),
       {},
     );
+  });
+
+  it("skips Cloud finish effects after the chat registry is disposed", async () => {
+    const onFinish = vi.fn();
+    const core = createCore({ chatConfig: { onFinish } });
+    const messages = [{ id: "assistant-1", role: "assistant", parts: [] }];
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const chatRegistry = new ChatRegistry(() => ({ messages, stop }) as never);
+    chatRegistry.getOrCreate("chat-1", "thread-1");
+    const persistChatMessages = vi
+      .spyOn(core, "persistChatMessages")
+      .mockResolvedValue(undefined);
+    const runStopped = vi.spyOn(core.engagementReporter, "runStopped");
+
+    core.createChat("chat-1", chatRegistry);
+    await chatRegistry.stopAll();
+    const wrappedOnFinish = chatOptionsRef.current?.onFinish;
+    expect(wrappedOnFinish).toBeTypeOf("function");
+    (wrappedOnFinish as (event: unknown) => void)({
+      isAbort: true,
+      isDisconnect: false,
+      isError: false,
+    });
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(onFinish).toHaveBeenCalledOnce();
+    expect(runStopped).not.toHaveBeenCalled();
+    expect(persistChatMessages).not.toHaveBeenCalled();
   });
 
   it("reports finish persistence failures", async () => {

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -319,6 +319,56 @@ describe("CloudChatCore", () => {
     await expect(stream.cancel(new Error("stopped"))).resolves.toBeUndefined();
   });
 
+  it("does not continue a new-thread send after registry disposal", async () => {
+    let resolveThread!: (value: { thread_id: string }) => void;
+    const createThread = vi.fn(
+      () =>
+        new Promise<{ thread_id: string }>((resolve) => {
+          resolveThread = resolve;
+        }),
+    );
+    const selectThread = vi.fn();
+    const refresh = vi.fn();
+    const sendMessages = vi.fn();
+    const core = new CloudChatCore(
+      {} as never,
+      {
+        threads: {
+          cloud: { threads: { create: createThread } },
+          selectThread,
+          refresh,
+        } as never,
+        chatConfig: {},
+      },
+      { sendMessages, reconnectToStream: vi.fn() },
+    );
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const chatRegistry = new ChatRegistry(
+      () => ({ messages: [], stop }) as never,
+    );
+    chatRegistry.getOrCreate("chat-1");
+    const persist = vi.spyOn(core, "persist").mockResolvedValue(undefined);
+
+    const send = core.createTransport("chat-1", chatRegistry).sendMessages({
+      trigger: "submit-message",
+      messages: [],
+      abortSignal: new AbortController().signal,
+    } as never);
+    await vi.waitFor(() => expect(createThread).toHaveBeenCalledOnce());
+
+    await chatRegistry.stopAll();
+    resolveThread({ thread_id: "thread-1" });
+
+    await expect(send).rejects.toMatchObject({ name: "AbortError" });
+    expect(stop).toHaveBeenCalledOnce();
+    expect(chatRegistry.getMeta("chat-1")).toBeUndefined();
+    expect(chatRegistry.getChatKeyForThread("thread-1")).toBeUndefined();
+    expect(selectThread).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+    expect(persist).not.toHaveBeenCalled();
+    expect(sendMessages).not.toHaveBeenCalled();
+  });
+
   it("reports message_sent for a user submission only", async () => {
     const sendMessages = vi.fn(() => Promise.resolve(new ReadableStream()));
     const core = createCore({

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -31,6 +31,13 @@ type ActiveTelemetryTiming = {
   error?: unknown;
 };
 
+const throwIfRegistryDisposed = (registry: ChatRegistry): void => {
+  if (!registry.isDisposed) return;
+  const error = new Error("Chat registry is disposed");
+  error.name = "AbortError";
+  throw error;
+};
+
 export class CloudChatCore {
   readonly cloud: AssistantCloud;
   readonly persistence: MessagePersistence;
@@ -199,7 +206,9 @@ export class CloudChatCore {
   ): ChatTransport<UIMessage> {
     return {
       sendMessages: async (opts) => {
+        throwIfRegistryDisposed(registry);
         const currentThreadId = await this.ensureThreadId(chatKey, registry);
+        throwIfRegistryDisposed(registry);
 
         if (!currentThreadId) {
           throw new Error("useCloudChat: Failed to resolve thread id");
@@ -212,6 +221,7 @@ export class CloudChatCore {
           roles: ["user"],
           strict: true,
         });
+        throwIfRegistryDisposed(registry);
         if (
           opts.trigger === "submit-message" &&
           opts.messages.at(-1)?.role === "user"

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -270,27 +270,29 @@ export class CloudChatCore {
               }
             : undefined;
           this.telemetryTimings.delete(chatKey);
-          const threadId = registry.getMeta(chatKey)?.threadId;
-          const chatInstance = registry.get(chatKey);
-          if (threadId && chatInstance) {
-            if (event.isAbort) this.engagementReporter.runStopped(threadId);
-            if (event.isError || event.finishReason === "error") {
-              this.engagementReporter.errorShown(
-                threadId,
-                chatInstance.messages,
-              );
+          if (!registry.isDisposed) {
+            const threadId = registry.getMeta(chatKey)?.threadId;
+            const chatInstance = registry.get(chatKey);
+            if (threadId && chatInstance) {
+              if (event.isAbort) this.engagementReporter.runStopped(threadId);
+              if (event.isError || event.finishReason === "error") {
+                this.engagementReporter.errorShown(
+                  threadId,
+                  chatInstance.messages,
+                );
+              }
             }
+            const finishEvent =
+              activeTiming?.error === undefined
+                ? event
+                : { ...event, error: activeTiming.error };
+            const persist = timing
+              ? this.persistChatMessages(chatKey, registry, finishEvent, timing)
+              : this.persistChatMessages(chatKey, registry, finishEvent);
+            void persist.catch((error) => {
+              this.handleSyncError(error);
+            });
           }
-          const finishEvent =
-            activeTiming?.error === undefined
-              ? event
-              : { ...event, error: activeTiming.error };
-          const persist = timing
-            ? this.persistChatMessages(chatKey, registry, finishEvent, timing)
-            : this.persistChatMessages(chatKey, registry, finishEvent);
-          void persist.catch((error) => {
-            this.handleSyncError(error);
-          });
         }
       },
       onError: (error) => {

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -292,17 +292,23 @@ export class CloudChatCore {
                 );
               }
             }
-            const finishEvent =
-              activeTiming?.error === undefined
-                ? event
-                : { ...event, error: activeTiming.error };
-            const persist = timing
+          }
+          const threadId = registry.getMeta(chatKey)?.threadId;
+          const chatInstance = registry.get(chatKey);
+          const finishEvent =
+            activeTiming?.error === undefined
+              ? event
+              : { ...event, error: activeTiming.error };
+          const persist = registry.isDisposed
+            ? threadId && chatInstance
+              ? this.persist(threadId, chatInstance.messages)
+              : Promise.resolve()
+            : timing
               ? this.persistChatMessages(chatKey, registry, finishEvent, timing)
               : this.persistChatMessages(chatKey, registry, finishEvent);
-            void persist.catch((error) => {
-              this.handleSyncError(error);
-            });
-          }
+          void persist.catch((error) => {
+            this.handleSyncError(error);
+          });
         }
       },
       onError: (error) => {

--- a/packages/cloud-ai-sdk/src/core/ThreadSessionManager.ts
+++ b/packages/cloud-ai-sdk/src/core/ThreadSessionManager.ts
@@ -16,10 +16,9 @@ export class ThreadSessionManager {
       meta.creatingThread = (async () => {
         try {
           const threadId = await createThread();
-          meta.threadId = threadId;
+          registry.setThreadId(chatKey, threadId);
           meta.loaded = true;
           meta.loading = null;
-          registry.setThreadId(chatKey, threadId);
           onCreated(threadId);
           return threadId;
         } finally {

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -7,8 +7,8 @@
   },
   "@assistant-ui/cloud-ai-sdk": {
     ".": {
-      "min": 21635,
-      "gzip": 7146
+      "min": 22244,
+      "gzip": 7446
     }
   },
   "@assistant-ui/core": {


### PR DESCRIPTION
## Problem

Unmounting the Cloud AI SDK chat runtime leaves its owned chats running. A focused regression on current main observed zero `stop()` calls after final unmount, so an abandoned response can continue network and model work after the consuming component is gone.

## Root cause

`useChatRegistry()` owns the AI SDK `Chat` instances but did not dispose its registry when the committed runtime was deleted. A passive-effect cleanup cannot distinguish final deletion from React lifecycle replay and hidden Activity transitions.

## Change

Use a deletion-only insertion-effect cleanup to stop every chat owned by the committed registry after final unmount or registry replacement. The registry becomes read-only before stopping chats, so pending thread creation and sends abort without repopulating it.

The disposed registry retains its existing chat metadata long enough for AI SDK `onFinish` to persist content already streamed. Teardown preserves the public `onFinish` callback but does not emit `run_stopped`, report incomplete Cloud telemetry, or start title generation.

## Verification

- Confirmed the original regression fails on main with `stop()` called zero times after unmount.
- Added final-unmount, Strict Mode replay, Activity hide/reveal, registry disposal, pending thread creation, and teardown persistence regressions.
- `pnpm -C packages/cloud-ai-sdk exec vitest run src/chat/ChatRegistry.test.ts src/chat/useChatRegistry.test.ts src/core/CloudChatCore.test.ts` (26/26)
- `pnpm --filter @assistant-ui/cloud-ai-sdk test` (140/140 on AI SDK v7, 140/140 on v6, plus the v6 type check)
- `pnpm --filter @assistant-ui/cloud-ai-sdk build`
- `pnpm changesets:check`
- Focused Oxlint and Oxfmt checks

## Public surface

`@assistant-ui/cloud-ai-sdk` receives a patch changeset. No exports, API signatures, documentation, or templates change.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.zc7iuRYSce5_DO0FJrM-6eOOPtOMpBKIs4QzZ8XCZhX7-iN_hc8Po6E7Nko?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->