### PR TITLE
fix(react-pi): project streaming updates incrementally

### DIFF
--- a/.changeset/fresh-dragons-smile.md
+++ b/.changeset/fresh-dragons-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: project streaming transcript updates incrementally

--- a/.github/workflows/perf-nightly.yaml
+++ b/.github/workflows/perf-nightly.yaml
@@ -35,7 +35,7 @@ jobs:
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-        run: pnpm turbo run build --filter=@assistant-ui/tap --filter=@assistant-ui/core --filter=@assistant-ui/store --filter=assistant-stream --filter=@assistant-ui/react --filter=@assistant-ui/react-markdown
+        run: pnpm turbo run build --filter=@assistant-ui/tap --filter=@assistant-ui/core --filter=@assistant-ui/store --filter=assistant-stream --filter=@assistant-ui/react --filter=@assistant-ui/react-markdown --filter=@assistant-ui/react-pi
 
       - name: Record nightly benchmarks
         run: node packages/x-performance/bin/aui-perf.mjs record nightly.json --runs 4

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -11,6 +11,7 @@ on:
       - "packages/assistant-stream/**"
       - "packages/react/**"
       - "packages/react-markdown/**"
+      - "packages/react-pi/**"
       - "packages/tw-shimmer/**"
       - ".github/workflows/perf.yaml"
 
@@ -44,7 +45,7 @@ jobs:
           changed=$(git diff --name-only "$BASE_SHA...HEAD")
           bench=false
           trace=false
-          if grep -qE '^(packages/(x-performance|tap|core|store|assistant-stream|react|react-markdown)/|\.github/workflows/perf\.yaml)' <<<"$changed"; then bench=true; fi
+          if grep -qE '^(packages/(x-performance|tap|core|store|assistant-stream|react|react-markdown|react-pi)/|\.github/workflows/perf\.yaml)' <<<"$changed"; then bench=true; fi
           if grep -qE '^(packages/tw-shimmer/|packages/x-performance/(fixtures|lib/trace)|\.github/workflows/perf\.yaml)' <<<"$changed"; then trace=true; fi
           echo "bench=$bench" >> "$GITHUB_OUTPUT"
           echo "trace=$trace" >> "$GITHUB_OUTPUT"
@@ -65,7 +66,7 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
         if: steps.lanes.outputs.bench == 'true'
-        run: pnpm turbo run build --filter=@assistant-ui/tap --filter=@assistant-ui/core --filter=@assistant-ui/store --filter=assistant-stream --filter=@assistant-ui/react --filter=@assistant-ui/react-markdown
+        run: pnpm turbo run build --filter=@assistant-ui/tap --filter=@assistant-ui/core --filter=@assistant-ui/store --filter=assistant-stream --filter=@assistant-ui/react --filter=@assistant-ui/react-markdown --filter=@assistant-ui/react-pi
 
       - name: Bench PR head against the base commit
         if: steps.lanes.outputs.bench == 'true'

--- a/packages/react-pi/src/runtime/ThreadController.test.ts
+++ b/packages/react-pi/src/runtime/ThreadController.test.ts
@@ -6,6 +6,7 @@ import type {
   PiClient,
   PiClientEvent,
   PiClientEventBody,
+  PiAgentMessage,
   PiAssistantMessage,
   PiHostUiRequest,
   PiSendMessageInput,
@@ -773,6 +774,57 @@ describe("PiThreadController", () => {
     expect(after[0]).toBe(stableUser);
     expect(after[1]).not.toBe(before[1]);
     expect(after[1]!.content).toMatchObject([{ type: "text", text: "ab" }]);
+  });
+
+  it("does not revisit the unchanged transcript prefix for a stream delta", () => {
+    let prefixRoleReads = 0;
+    const stableMessages = Array.from({ length: 500 }, (_, index) => {
+      const message = {
+        content: `message-${index}`,
+        timestamp: index,
+      };
+      Object.defineProperty(message, "role", {
+        enumerable: true,
+        get: () => {
+          prefixRoleReads += 1;
+          return "user";
+        },
+      });
+      return message as PiAgentMessage;
+    });
+    const client = createFakeClient(snapshot({ messages: stableMessages }));
+    const scheduled: Array<() => void> = [];
+    const controller = new PiThreadController(client, THREAD, {
+      scheduleNotify: (flush) => scheduled.push(flush),
+    });
+    controller.connect();
+
+    client.emit(
+      ev({ type: "snapshot", snapshot: client.getThreadSnapshot }, 1),
+    );
+    client.emit(
+      ev({ type: "message_start", message: assistantMessage("a", 501) }, 2),
+    );
+    prefixRoleReads = 0;
+
+    client.emit(
+      ev(
+        {
+          type: "message_update",
+          message: assistantMessage("ab", 501),
+          assistantMessageEvent: {
+            type: "text_delta",
+            contentIndex: 0,
+            delta: "b",
+            partial: assistantMessage("ab", 501),
+          },
+        },
+        3,
+      ),
+    );
+    scheduled.at(-1)!();
+
+    expect(prefixRoleReads).toBe(2);
   });
 });
 

--- a/packages/react-pi/src/runtime/ThreadController.test.ts
+++ b/packages/react-pi/src/runtime/ThreadController.test.ts
@@ -752,6 +752,7 @@ describe("PiThreadController", () => {
 
     const before = controller.getProjectedMessages();
     const stableUser = before[0]!;
+    const stableRepositoryItem = controller.getMessageRepository().messages[0];
 
     client.emit(
       ev(
@@ -774,6 +775,12 @@ describe("PiThreadController", () => {
     expect(after[0]).toBe(stableUser);
     expect(after[1]).not.toBe(before[1]);
     expect(after[1]!.content).toMatchObject([{ type: "text", text: "ab" }]);
+    expect(controller.getMessageRepository().messages[0]).toBe(
+      stableRepositoryItem,
+    );
+    expect(controller.getMessageRepository().messages[1]!.parentId).toBe(
+      stableRepositoryItem!.message.id,
+    );
   });
 
   it("does not revisit the unchanged transcript prefix for a stream delta", () => {

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -254,10 +254,8 @@ const markStateRunning = (state: PiThreadState): PiThreadState => {
 export class PiThreadController implements PiThreadControllerLike {
   private state: PiThreadState;
   private stateSnapshot: PiThreadState;
-  private projectedMessages: readonly ThreadMessageLike[] = [];
-  private readonly messageProjector = new PiThreadMessageProjector(
-    this.projectedMessages,
-  );
+  private projectedMessages: readonly ThreadMessageLike[];
+  private readonly messageProjector: PiThreadMessageProjector;
   private messageRepository = ExportedMessageRepository.fromArray([]);
   private version = 0;
   private readonly allListeners = new Set<() => void>();
@@ -291,6 +289,13 @@ export class PiThreadController implements PiThreadControllerLike {
     this.options = options;
     this.state = createPiThreadState(threadId);
     this.stateSnapshot = this.state;
+    this.messageProjector = new PiThreadMessageProjector();
+    this.projectedMessages = this.messageProjector.project({
+      messages: this.state.messages,
+      toolExecutions: this.state.toolExecutions,
+      runStatus: this.state.runStatus,
+      hostUiRequests: this.state.hostUiRequests,
+    });
   }
 
   public getState() {

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -22,7 +22,7 @@ import {
 } from "./threadState";
 import { errorText } from "../utils";
 import { isKnownPiClientEventType } from "../eventTypes";
-import { projectPiThreadMessagesShared } from "./messageProjection";
+import { PiThreadMessageProjector } from "./messageProjection";
 import {
   responseForApproval,
   responseForInterrupt,
@@ -239,6 +239,9 @@ export class PiThreadController implements PiThreadControllerLike {
   private state: PiThreadState;
   private stateSnapshot: PiThreadState;
   private projectedMessages: readonly ThreadMessageLike[] = [];
+  private readonly messageProjector = new PiThreadMessageProjector(
+    this.projectedMessages,
+  );
   private messageRepository = ExportedMessageRepository.fromArray([]);
   private version = 0;
   private readonly allListeners = new Set<() => void>();
@@ -656,15 +659,12 @@ export class PiThreadController implements PiThreadControllerLike {
   }
 
   private projectMessages() {
-    return projectPiThreadMessagesShared(
-      {
-        messages: this.projectedInputMessages(),
-        toolExecutions: this.state.toolExecutions,
-        runStatus: this.state.runStatus,
-        hostUiRequests: this.state.hostUiRequests,
-      },
-      this.projectedMessages,
-    );
+    return this.messageProjector.project({
+      messages: this.projectedInputMessages(),
+      toolExecutions: this.state.toolExecutions,
+      runStatus: this.state.runStatus,
+      hostUiRequests: this.state.hostUiRequests,
+    });
   }
 
   private recomputeProjectedMessagesAndNotify() {

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -102,6 +102,22 @@ const notifyListeners = (listeners: Iterable<() => void>) => {
   }
 };
 
+const updateMessageRepository = (
+  previous: ReturnType<typeof ExportedMessageRepository.fromArray>,
+  messages: readonly ThreadMessageLike[],
+  changedIndex: number,
+) => {
+  const prefix = previous.messages.slice(0, changedIndex);
+  const suffix = ExportedMessageRepository.fromArray(
+    messages.slice(changedIndex),
+  ).messages;
+  const first = suffix[0];
+  if (first) {
+    first.parentId = prefix.at(-1)?.message.id ?? null;
+  }
+  return { messages: [...prefix, ...suffix] };
+};
+
 /** Event types the reducer acts on. Anything else triggers a snapshot refresh
  * (forward-compat for Pi's open, module-augmented event union). */
 const MESSAGE_DIRTY_EVENT_TYPES: ReadonlySet<string> = new Set([
@@ -674,9 +690,11 @@ export class PiThreadController implements PiThreadControllerLike {
       return;
     }
     this.projectedMessages = next;
-    // `fromArray` chains messages linearly and keeps their stable `pi-msg:N`
-    // ids (its generated id is only a fallback for id-less messages).
-    this.messageRepository = ExportedMessageRepository.fromArray(next);
+    this.messageRepository = updateMessageRepository(
+      this.messageRepository,
+      next,
+      this.messageProjector.getChangedProjectedIndex() ?? 0,
+    );
     this.notifyMessageListeners();
   }
 

--- a/packages/react-pi/src/runtime/messageProjection.test.ts
+++ b/packages/react-pi/src/runtime/messageProjection.test.ts
@@ -537,7 +537,7 @@ describe("messageProjection", () => {
 
     const nextMessage = (): PiAgentMessage => {
       const index = serial++;
-      switch (pick(7)) {
+      switch (pick(9)) {
         case 0:
           return { role: "user", content: `user-${index}`, timestamp: index };
         case 1: {
@@ -582,13 +582,26 @@ describe("messageProjection", () => {
             display: index % 2 === 0,
             timestamp: index,
           };
-        default:
+        case 6:
           return {
             role: "branchSummary",
             summary: `summary-${index}`,
             fromId: `message-${index}`,
             timestamp: index,
           };
+        case 7:
+          return {
+            role: "compactionSummary",
+            summary: `compaction-${index}`,
+            tokensBefore: index,
+            timestamp: index,
+          };
+        default:
+          return {
+            role: "future-role",
+            payload: index,
+            timestamp: index,
+          } as PiAgentMessage;
       }
     };
 

--- a/packages/react-pi/src/runtime/messageProjection.test.ts
+++ b/packages/react-pi/src/runtime/messageProjection.test.ts
@@ -505,6 +505,70 @@ describe("messageProjection", () => {
     expect(contentParts(projected[0]!)[0]).toMatchObject({ result: "first" });
   });
 
+  it("restores an earlier tool-call index when a later duplicate is removed", () => {
+    const projector = new PiThreadMessageProjector();
+    const firstCall = assistant([toolCall("tc1", "bash", {})]);
+    const separator: PiAgentMessage = {
+      role: "user",
+      content: "continue",
+      timestamp: 2,
+    };
+    const duplicateCall = assistant([toolCall("tc1", "bash", {})], {
+      timestamp: 3,
+    });
+
+    projector.project(input([firstCall, separator, duplicateCall]));
+    projector.project(input([firstCall, separator]));
+    const next = input([firstCall, separator], {
+      toolExecutions: {
+        tc1: {
+          toolCallId: "tc1",
+          status: "running",
+          partialResult: {
+            content: [{ type: "text", text: "partial" }],
+          },
+        },
+      },
+    });
+    const projected = projector.project(next);
+
+    expect(projected).toEqual(projectPiThreadMessages(next));
+    expect(contentParts(projected[0]!)[0]).toMatchObject({ result: "partial" });
+  });
+
+  it("falls back to full projection for an unexpected cached message id", () => {
+    const projector = new PiThreadMessageProjector();
+    const first: PiAgentMessage = {
+      role: "user",
+      content: "first",
+      timestamp: 1,
+    };
+    const second: PiAgentMessage = {
+      role: "user",
+      content: "second",
+      timestamp: 2,
+    };
+    const third: PiAgentMessage = {
+      role: "user",
+      content: "third",
+      timestamp: 3,
+    };
+    const projected = projector.project(input([first, second, third]));
+    (
+      projector as unknown as { projectedMessages: typeof projected }
+    ).projectedMessages = projected.map((message, index) =>
+      index === 1 ? { ...message, id: "unexpected" } : message,
+    );
+
+    const next = input([
+      first,
+      second,
+      { role: "user", content: "updated", timestamp: 4 },
+    ]);
+
+    expect(projector.project(next)).toEqual(projectPiThreadMessages(next));
+  });
+
   it("updates the trailing assistant status when a user message is appended", () => {
     const projector = new PiThreadMessageProjector();
     const reply = assistant([{ type: "text", text: "done" }]);

--- a/packages/react-pi/src/runtime/messageProjection.test.ts
+++ b/packages/react-pi/src/runtime/messageProjection.test.ts
@@ -519,4 +519,135 @@ describe("messageProjection", () => {
     expect(projected).toEqual(projectPiThreadMessages(next));
     expect(projected[0]!.status).toEqual({ type: "complete", reason: "stop" });
   });
+
+  it("matches full projection across seeded transcript transitions", () => {
+    let seed = 0x7205;
+    const random = () => {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+      return seed / 0x100000000;
+    };
+    const pick = (length: number) => Math.floor(random() * length);
+    const projector = new PiThreadMessageProjector();
+    const toolCallIds: string[] = [];
+    let serial = 0;
+    let messages: PiAgentMessage[] = [];
+    let toolExecutions: PiProjectionInput["toolExecutions"] = {};
+    let hostUiRequests: readonly PiHostUiRequest[] = [];
+    let runStatus: PiProjectionInput["runStatus"] = "idle";
+
+    const nextMessage = (): PiAgentMessage => {
+      const index = serial++;
+      switch (pick(7)) {
+        case 0:
+          return { role: "user", content: `user-${index}`, timestamp: index };
+        case 1: {
+          const id = `tool-${index}`;
+          toolCallIds.push(id);
+          return assistant(
+            [toolCall(id, "bash", { command: `echo ${index}` })],
+            { timestamp: index },
+          );
+        }
+        case 2:
+          return assistant([{ type: "text", text: `answer-${index}` }], {
+            timestamp: index,
+          });
+        case 3:
+          return {
+            role: "toolResult",
+            toolCallId:
+              toolCallIds.length === 0
+                ? `missing-${index}`
+                : toolCallIds[pick(toolCallIds.length)]!,
+            toolName: "bash",
+            content: [{ type: "text", text: `result-${index}` }],
+            isError: index % 5 === 0,
+            timestamp: index,
+          };
+        case 4:
+          return {
+            role: "bashExecution",
+            command: `echo ${index}`,
+            output: `${index}`,
+            exitCode: 0,
+            cancelled: false,
+            truncated: false,
+            timestamp: index,
+          };
+        case 5:
+          return {
+            role: "custom",
+            customType: "test",
+            content: `custom-${index}`,
+            display: index % 2 === 0,
+            timestamp: index,
+          };
+        default:
+          return {
+            role: "branchSummary",
+            summary: `summary-${index}`,
+            fromId: `message-${index}`,
+            timestamp: index,
+          };
+      }
+    };
+
+    for (let step = 0; step < 5000; step++) {
+      const operation = messages.length === 0 ? 0 : pick(6);
+      if (operation === 0) {
+        messages = [...messages, nextMessage()];
+      } else if (operation === 1) {
+        const index = pick(messages.length);
+        messages = messages.map((message, current) =>
+          current === index ? nextMessage() : message,
+        );
+      } else if (operation === 2 || messages.length >= 40) {
+        messages = messages.slice(0, pick(messages.length + 1));
+      } else if (operation === 3) {
+        runStatus = (["idle", "running", "failed"] as const)[pick(3)]!;
+      } else if (operation === 4) {
+        const id =
+          toolCallIds.length === 0
+            ? "missing"
+            : toolCallIds[pick(toolCallIds.length)]!;
+        const next = { ...toolExecutions };
+        if (next[id]) delete next[id];
+        else {
+          next[id] = {
+            toolCallId: id,
+            status: "running",
+            partialResult: {
+              content: [{ type: "text", text: `partial-${step}` }],
+            },
+          };
+        }
+        toolExecutions = next;
+      } else {
+        const id =
+          toolCallIds.length === 0
+            ? "missing"
+            : toolCallIds[pick(toolCallIds.length)]!;
+        hostUiRequests =
+          hostUiRequests.length === 0
+            ? [
+                {
+                  id: `request-${step}`,
+                  kind: "confirm",
+                  title: "Run tool?",
+                  toolCallId: id,
+                },
+              ]
+            : [];
+      }
+
+      const next = input(messages, {
+        toolExecutions,
+        hostUiRequests,
+        runStatus,
+      });
+      expect(projector.project(next), `transition ${step}`).toEqual(
+        projectPiThreadMessages(next),
+      );
+    }
+  });
 });

--- a/packages/react-pi/src/runtime/messageProjection.test.ts
+++ b/packages/react-pi/src/runtime/messageProjection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  PiThreadMessageProjector,
   projectPiThreadMessages,
   type PiProjectionInput,
 } from "./messageProjection";
@@ -419,5 +420,103 @@ describe("messageProjection", () => {
     );
     expect(contentParts(out[0]!)[0]!.approval).toBeUndefined();
     expect(out[0]!.status).toEqual({ type: "complete", reason: "stop" });
+  });
+
+  it("keeps incremental projection equivalent across external state changes", () => {
+    const projector = new PiThreadMessageProjector();
+    const user: PiAgentMessage = {
+      role: "user",
+      content: "run it",
+      timestamp: 1,
+    };
+    const call = assistant([toolCall("tc1", "bash", { command: "ls" })]);
+    const messages: PiAgentMessage[] = [user, call];
+    const assertEquivalent = (next: PiProjectionInput) => {
+      expect(projector.project(next)).toEqual(projectPiThreadMessages(next));
+    };
+
+    assertEquivalent(input(messages));
+    assertEquivalent(
+      input(messages, {
+        toolExecutions: {
+          tc1: {
+            toolCallId: "tc1",
+            status: "running",
+            partialResult: {
+              content: [{ type: "text", text: "partial" }],
+            },
+          },
+        },
+        runStatus: "running",
+      }),
+    );
+    assertEquivalent(
+      input(messages, {
+        runStatus: "running",
+        hostUiRequests: [
+          {
+            id: "request-1",
+            kind: "confirm",
+            title: "Run command?",
+            message: "Allow this command",
+            toolCallId: "tc1",
+          },
+        ],
+      }),
+    );
+    assertEquivalent(
+      input([
+        ...messages,
+        {
+          role: "toolResult",
+          toolCallId: "tc1",
+          toolName: "bash",
+          content: [{ type: "text", text: "done" }],
+          isError: false,
+          timestamp: 2,
+        },
+      ]),
+    );
+    assertEquivalent(input([user]));
+  });
+
+  it("restores an earlier tool result when a later duplicate is removed", () => {
+    const projector = new PiThreadMessageProjector();
+    const call = assistant([toolCall("tc1", "bash", {})]);
+    const firstResult: PiAgentMessage = {
+      role: "toolResult",
+      toolCallId: "tc1",
+      toolName: "bash",
+      content: [{ type: "text", text: "first" }],
+      isError: false,
+      timestamp: 2,
+    };
+    const secondResult: PiAgentMessage = {
+      ...firstResult,
+      content: [{ type: "text", text: "second" }],
+      timestamp: 3,
+    };
+
+    projector.project(input([call, firstResult, secondResult]));
+    const next = input([call, firstResult]);
+    const projected = projector.project(next);
+
+    expect(projected).toEqual(projectPiThreadMessages(next));
+    expect(contentParts(projected[0]!)[0]).toMatchObject({ result: "first" });
+  });
+
+  it("updates the trailing assistant status when a user message is appended", () => {
+    const projector = new PiThreadMessageProjector();
+    const reply = assistant([{ type: "text", text: "done" }]);
+
+    projector.project(input([reply], { runStatus: "running" }));
+    const next = input(
+      [reply, { role: "user", content: "continue", timestamp: 2 }],
+      { runStatus: "running" },
+    );
+    const projected = projector.project(next);
+
+    expect(projected).toEqual(projectPiThreadMessages(next));
+    expect(projected[0]!.status).toEqual({ type: "complete", reason: "stop" });
   });
 });

--- a/packages/react-pi/src/runtime/messageProjection.test.ts
+++ b/packages/react-pi/src/runtime/messageProjection.test.ts
@@ -554,11 +554,14 @@ describe("messageProjection", () => {
       timestamp: 3,
     };
     const projected = projector.project(input([first, second, third]));
-    (
-      projector as unknown as { projectedMessages: typeof projected }
-    ).projectedMessages = projected.map((message, index) =>
+    const cachedProjector = projector as unknown as {
+      projectedMessages: typeof projected;
+      projectedSourceIndices: undefined;
+    };
+    cachedProjector.projectedMessages = projected.map((message, index) =>
       index === 1 ? { ...message, id: "unexpected" } : message,
     );
+    cachedProjector.projectedSourceIndices = undefined;
 
     const next = input([
       first,

--- a/packages/react-pi/src/runtime/messageProjection.ts
+++ b/packages/react-pi/src/runtime/messageProjection.ts
@@ -564,18 +564,43 @@ const updateToolCallIndices = (
   next: readonly PiAgentMessage[],
   startIndex: number,
 ) => {
+  const removedIds = new Set<string>();
   for (let index = startIndex; index < previous.length; index++) {
     const message = previous[index]!;
     if (message.role !== "assistant") continue;
     for (const part of (message as PiAssistantMessage).content) {
-      if (part.type === "toolCall") indices.delete(part.id);
+      if (part.type === "toolCall") {
+        removedIds.add(part.id);
+        indices.delete(part.id);
+      }
     }
   }
   for (let index = startIndex; index < next.length; index++) {
     const message = next[index]!;
     if (message.role !== "assistant") continue;
     for (const part of (message as PiAssistantMessage).content) {
-      if (part.type === "toolCall") indices.set(part.id, index);
+      if (part.type === "toolCall") {
+        removedIds.delete(part.id);
+        indices.set(part.id, index);
+      }
+    }
+  }
+  for (const id of removedIds) {
+    for (
+      let index = Math.min(startIndex, next.length) - 1;
+      index >= 0;
+      index--
+    ) {
+      const message = next[index]!;
+      if (message.role !== "assistant") continue;
+      if (
+        (message as PiAssistantMessage).content.some(
+          (part) => part.type === "toolCall" && part.id === id,
+        )
+      ) {
+        indices.set(id, index);
+        break;
+      }
     }
   }
 };
@@ -666,13 +691,14 @@ const projectedSourceIndex = (message: ThreadMessageLike) => {
 const firstProjectedIndexAtOrAfter = (
   messages: readonly ThreadMessageLike[],
   sourceIndex: number,
-) => {
+): number | undefined => {
   let low = 0;
   let high = messages.length;
   while (low < high) {
     const middle = (low + high) >>> 1;
     const projectedIndex = projectedSourceIndex(messages[middle]!);
-    if (projectedIndex === undefined || projectedIndex >= sourceIndex) {
+    if (projectedIndex === undefined) return undefined;
+    if (projectedIndex >= sourceIndex) {
       high = middle;
     } else {
       low = middle + 1;
@@ -793,13 +819,20 @@ export class PiThreadMessageProjector {
       assistantGroupStart(previousInput.messages, dirtyIndex),
       assistantGroupStart(input.messages, dirtyIndex),
     );
-    const projectedStartIndex = firstProjectedIndexAtOrAfter(
+    const projectedBoundary = firstProjectedIndexAtOrAfter(
       this.projectedMessages,
       startIndex,
     );
+    const projectedStartIndex = projectedBoundary ?? 0;
+    const projectionStartIndex =
+      projectedBoundary === undefined ? 0 : startIndex;
     const previousSuffix = this.projectedMessages.slice(projectedStartIndex);
     const nextSuffix = shareProjectedThreadMessages(
-      projectPiThreadMessagesFrom(input, startIndex, this.toolResults),
+      projectPiThreadMessagesFrom(
+        input,
+        projectionStartIndex,
+        this.toolResults,
+      ),
       previousSuffix,
     );
 

--- a/packages/react-pi/src/runtime/messageProjection.ts
+++ b/packages/react-pi/src/runtime/messageProjection.ts
@@ -688,16 +688,30 @@ const projectedSourceIndex = (message: ThreadMessageLike) => {
   return Number.isSafeInteger(index) && index >= 0 ? index : undefined;
 };
 
-const firstProjectedIndexAtOrAfter = (
+const validatedProjectedSourceIndices = (
   messages: readonly ThreadMessageLike[],
+  minimumExclusive = -1,
+): number[] | undefined => {
+  const indices: number[] = [];
+  let previous = minimumExclusive;
+  for (const message of messages) {
+    const index = projectedSourceIndex(message);
+    if (index === undefined || index <= previous) return undefined;
+    indices.push(index);
+    previous = index;
+  }
+  return indices;
+};
+
+const firstProjectedIndexAtOrAfter = (
+  indices: readonly number[],
   sourceIndex: number,
-): number | undefined => {
+): number => {
   let low = 0;
-  let high = messages.length;
+  let high = indices.length;
   while (low < high) {
     const middle = (low + high) >>> 1;
-    const projectedIndex = projectedSourceIndex(messages[middle]!);
-    if (projectedIndex === undefined) return undefined;
+    const projectedIndex = indices[middle]!;
     if (projectedIndex >= sourceIndex) {
       high = middle;
     } else {
@@ -710,6 +724,7 @@ const firstProjectedIndexAtOrAfter = (
 export class PiThreadMessageProjector {
   private previousInput: PiProjectionInput | undefined;
   private projectedMessages: readonly ThreadMessageLike[] = [];
+  private projectedSourceIndices: number[] | undefined = [];
   private changedProjectedIndex: number | undefined;
   private toolResults = new Map<string, ProjectedToolResult>();
   private toolCallIndices = new Map<string, number>();
@@ -726,6 +741,9 @@ export class PiThreadMessageProjector {
       this.toolCallIndices = buildToolCallIndices(input.messages);
       this.projectedMessages = shareProjectedThreadMessages(
         projectPiThreadMessagesFrom(input, 0, this.toolResults),
+        this.projectedMessages,
+      );
+      this.projectedSourceIndices = validatedProjectedSourceIndices(
         this.projectedMessages,
       );
       this.changedProjectedIndex =
@@ -819,10 +837,9 @@ export class PiThreadMessageProjector {
       assistantGroupStart(previousInput.messages, dirtyIndex),
       assistantGroupStart(input.messages, dirtyIndex),
     );
-    const projectedBoundary = firstProjectedIndexAtOrAfter(
-      this.projectedMessages,
-      startIndex,
-    );
+    const projectedBoundary = this.projectedSourceIndices
+      ? firstProjectedIndexAtOrAfter(this.projectedSourceIndices, startIndex)
+      : undefined;
     const projectedStartIndex = projectedBoundary ?? 0;
     const projectionStartIndex =
       projectedBoundary === undefined ? 0 : startIndex;
@@ -843,11 +860,33 @@ export class PiThreadMessageProjector {
           message === this.projectedMessages[projectedStartIndex + index],
       )
     ) {
+      if (this.projectedSourceIndices === undefined) {
+        this.projectedSourceIndices = validatedProjectedSourceIndices(
+          this.projectedMessages,
+        );
+      }
       this.changedProjectedIndex = undefined;
       this.previousInput = input;
       return this.projectedMessages;
     }
 
+    if (this.projectedSourceIndices) {
+      const suffixSourceIndices = validatedProjectedSourceIndices(
+        nextSuffix,
+        this.projectedSourceIndices[projectedStartIndex - 1],
+      );
+      if (suffixSourceIndices) {
+        this.projectedSourceIndices.splice(
+          projectedStartIndex,
+          this.projectedSourceIndices.length - projectedStartIndex,
+          ...suffixSourceIndices,
+        );
+      } else {
+        this.projectedSourceIndices = undefined;
+      }
+    } else {
+      this.projectedSourceIndices = validatedProjectedSourceIndices(nextSuffix);
+    }
     this.projectedMessages = [
       ...this.projectedMessages.slice(0, projectedStartIndex),
       ...nextSuffix,

--- a/packages/react-pi/src/runtime/messageProjection.ts
+++ b/packages/react-pi/src/runtime/messageProjection.ts
@@ -879,8 +879,10 @@ export class PiThreadMessageProjector {
         this.projectedSourceIndices.splice(
           projectedStartIndex,
           this.projectedSourceIndices.length - projectedStartIndex,
-          ...suffixSourceIndices,
         );
+        for (const index of suffixSourceIndices) {
+          this.projectedSourceIndices.push(index);
+        }
       } else {
         this.projectedSourceIndices = undefined;
       }

--- a/packages/react-pi/src/runtime/messageProjection.ts
+++ b/packages/react-pi/src/runtime/messageProjection.ts
@@ -666,23 +666,31 @@ const projectedSourceIndex = (message: ThreadMessageLike) => {
     return undefined;
   }
   const index = Number(message.id.slice("pi-msg:".length));
-  return Number.isInteger(index) ? index : undefined;
+  return Number.isSafeInteger(index) && index >= 0 ? index : undefined;
 };
 
 const firstProjectedIndexAtOrAfter = (
   messages: readonly ThreadMessageLike[],
   sourceIndex: number,
 ) => {
-  const index = messages.findIndex((message) => {
-    const projectedIndex = projectedSourceIndex(message);
-    return projectedIndex !== undefined && projectedIndex >= sourceIndex;
-  });
-  return index === -1 ? messages.length : index;
+  let low = 0;
+  let high = messages.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    const projectedIndex = projectedSourceIndex(messages[middle]!);
+    if (projectedIndex === undefined || projectedIndex >= sourceIndex) {
+      high = middle;
+    } else {
+      low = middle + 1;
+    }
+  }
+  return low;
 };
 
 export class PiThreadMessageProjector {
   private previousInput: PiProjectionInput | undefined;
   private projectedMessages: readonly ThreadMessageLike[] = [];
+  private changedProjectedIndex: number | undefined;
   private toolResults = new Map<string, ProjectedToolResult>();
   private toolCallIndices = new Map<string, number>();
 
@@ -690,15 +698,22 @@ export class PiThreadMessageProjector {
     this.projectedMessages = projectedMessages;
   }
 
+  public getChangedProjectedIndex() {
+    return this.changedProjectedIndex;
+  }
+
   public project(input: PiProjectionInput): readonly ThreadMessageLike[] {
     const previousInput = this.previousInput;
     if (!previousInput) {
+      const previousProjectedMessages = this.projectedMessages;
       this.toolResults = buildToolResultMap(input.messages);
       this.toolCallIndices = buildToolCallIndices(input.messages);
       this.projectedMessages = shareProjectedThreadMessages(
         projectPiThreadMessagesFrom(input, 0, this.toolResults),
         this.projectedMessages,
       );
+      this.changedProjectedIndex =
+        this.projectedMessages === previousProjectedMessages ? undefined : 0;
       this.previousInput = input;
       return this.projectedMessages;
     }
@@ -779,6 +794,7 @@ export class PiThreadMessageProjector {
     }
 
     if (dirtyIndex === undefined) {
+      this.changedProjectedIndex = undefined;
       this.previousInput = input;
       return this.projectedMessages;
     }
@@ -804,6 +820,7 @@ export class PiThreadMessageProjector {
           message === this.projectedMessages[projectedStartIndex + index],
       )
     ) {
+      this.changedProjectedIndex = undefined;
       this.previousInput = input;
       return this.projectedMessages;
     }
@@ -812,6 +829,7 @@ export class PiThreadMessageProjector {
       ...this.projectedMessages.slice(0, projectedStartIndex),
       ...nextSuffix,
     ];
+    this.changedProjectedIndex = projectedStartIndex;
     this.previousInput = input;
     return this.projectedMessages;
   }

--- a/packages/react-pi/src/runtime/messageProjection.ts
+++ b/packages/react-pi/src/runtime/messageProjection.ts
@@ -664,13 +664,6 @@ const assistantGroupStart = (
   return start;
 };
 
-const lastAssistantMessageIndex = (messages: readonly PiAgentMessage[]) => {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    if (messages[index]!.role === "assistant") return index;
-  }
-  return undefined;
-};
-
 const trailingAssistantMessageIndex = (messages: readonly PiAgentMessage[]) => {
   for (let index = messages.length - 1; index >= 0; index--) {
     const role = messages[index]!.role;
@@ -820,7 +813,7 @@ export class PiThreadMessageProjector {
     }
 
     if (previousInput.runStatus !== input.runStatus) {
-      const index = lastAssistantMessageIndex(input.messages);
+      const index = trailingAssistantMessageIndex(input.messages);
       if (index !== undefined) {
         dirtyIndex =
           dirtyIndex === undefined ? index : Math.min(dirtyIndex, index);

--- a/packages/react-pi/src/runtime/messageProjection.ts
+++ b/packages/react-pi/src/runtime/messageProjection.ts
@@ -105,19 +105,26 @@ const dataPart = (
 
 /** Build the toolCallId → result pairing map across the whole transcript so
  * out-of-order parallel results pair correctly. */
+type ProjectedToolResult = {
+  result: string | undefined;
+  isError: boolean;
+  details: unknown;
+};
+
+const projectToolResult = (
+  message: PiToolResultMessage,
+): ProjectedToolResult => ({
+  result: extractResultText({ content: message.content }),
+  isError: message.isError,
+  details: message.details,
+});
+
 const buildToolResultMap = (messages: readonly PiAgentMessage[]) => {
-  const map = new Map<
-    string,
-    { result: string | undefined; isError: boolean; details: unknown }
-  >();
+  const map = new Map<string, ProjectedToolResult>();
   for (const message of messages) {
     if (message.role !== "toolResult") continue;
     const m = message as PiToolResultMessage;
-    map.set(m.toolCallId, {
-      result: extractResultText({ content: m.content }),
-      isError: m.isError,
-      details: m.details,
-    });
+    map.set(m.toolCallId, projectToolResult(m));
   }
   return map;
 };
@@ -268,11 +275,12 @@ const assistantStatus = (
   return { type: "complete", reason: "stop" };
 };
 
-export const projectPiThreadMessages = (
+const projectPiThreadMessagesFrom = (
   input: PiProjectionInput,
+  startIndex: number,
+  toolResults: ReturnType<typeof buildToolResultMap>,
 ): ThreadMessageLike[] => {
   const { messages } = input;
-  const toolResults = buildToolResultMap(messages);
   const out: ThreadMessageLike[] = [];
   let group: GroupAccumulator | null = null;
 
@@ -282,7 +290,8 @@ export const projectPiThreadMessages = (
     group = null;
   };
 
-  messages.forEach((message, index) => {
+  for (let index = startIndex; index < messages.length; index++) {
+    const message = messages[index]!;
     const isLast = index === messages.length - 1;
     switch (message.role) {
       case "assistant": {
@@ -393,13 +402,18 @@ export const projectPiThreadMessages = (
         );
         break;
     }
-  });
+  }
 
   // A transcript ending on a `toolResult` leaves the assistant group open; mark
   // it last so the live run status ("running") propagates.
   flush(true);
   return out;
 };
+
+export const projectPiThreadMessages = (
+  input: PiProjectionInput,
+): ThreadMessageLike[] =>
+  projectPiThreadMessagesFrom(input, 0, buildToolResultMap(input.messages));
 
 const standaloneData = (
   index: number,
@@ -484,6 +498,324 @@ export const projectPiThreadMessagesShared = (
   previous: readonly ThreadMessageLike[],
 ): readonly ThreadMessageLike[] =>
   shareProjectedThreadMessages(projectPiThreadMessages(input), previous);
+
+const firstChangedMessageIndex = (
+  previous: readonly PiAgentMessage[],
+  next: readonly PiAgentMessage[],
+): number | undefined => {
+  const sharedLength = Math.min(previous.length, next.length);
+  for (let index = 0; index < sharedLength; index++) {
+    if (previous[index] !== next[index]) return index;
+  }
+  return previous.length === next.length ? undefined : sharedLength;
+};
+
+const collectToolResultIds = (
+  messages: readonly PiAgentMessage[],
+  startIndex: number,
+  ids: Set<string>,
+) => {
+  for (let index = startIndex; index < messages.length; index++) {
+    const message = messages[index]!;
+    if (message.role === "toolResult") {
+      ids.add((message as PiToolResultMessage).toolCallId);
+    }
+  }
+};
+
+const updateToolResults = (
+  toolResults: Map<string, ProjectedToolResult>,
+  previous: readonly PiAgentMessage[],
+  next: readonly PiAgentMessage[],
+  startIndex: number,
+) => {
+  const removedIds = new Set<string>();
+  for (let index = startIndex; index < previous.length; index++) {
+    const message = previous[index]!;
+    if (message.role === "toolResult") {
+      const id = (message as PiToolResultMessage).toolCallId;
+      removedIds.add(id);
+      toolResults.delete(id);
+    }
+  }
+  for (let index = startIndex; index < next.length; index++) {
+    const message = next[index]!;
+    if (message.role === "toolResult") {
+      const result = message as PiToolResultMessage;
+      removedIds.delete(result.toolCallId);
+      toolResults.set(result.toolCallId, projectToolResult(result));
+    }
+  }
+  for (const id of removedIds) {
+    for (
+      let index = Math.min(startIndex, next.length) - 1;
+      index >= 0;
+      index--
+    ) {
+      const message = next[index]!;
+      if (
+        message.role === "toolResult" &&
+        (message as PiToolResultMessage).toolCallId === id
+      ) {
+        toolResults.set(id, projectToolResult(message as PiToolResultMessage));
+        break;
+      }
+    }
+  }
+};
+
+const updateToolCallIndices = (
+  indices: Map<string, number>,
+  previous: readonly PiAgentMessage[],
+  next: readonly PiAgentMessage[],
+  startIndex: number,
+) => {
+  for (let index = startIndex; index < previous.length; index++) {
+    const message = previous[index]!;
+    if (message.role !== "assistant") continue;
+    for (const part of (message as PiAssistantMessage).content) {
+      if (part.type === "toolCall") indices.delete(part.id);
+    }
+  }
+  for (let index = startIndex; index < next.length; index++) {
+    const message = next[index]!;
+    if (message.role !== "assistant") continue;
+    for (const part of (message as PiAssistantMessage).content) {
+      if (part.type === "toolCall") indices.set(part.id, index);
+    }
+  }
+};
+
+const buildToolCallIndices = (messages: readonly PiAgentMessage[]) => {
+  const indices = new Map<string, number>();
+  updateToolCallIndices(indices, [], messages, 0);
+  return indices;
+};
+
+const changedToolExecutionIds = (
+  previous: PiProjectionInput["toolExecutions"],
+  next: PiProjectionInput["toolExecutions"],
+): Set<string> => {
+  const ids = new Set<string>();
+  if (previous === next) return ids;
+  for (const id of Object.keys(previous)) {
+    if (previous[id] !== next[id]) ids.add(id);
+  }
+  for (const id of Object.keys(next)) {
+    if (previous[id] !== next[id]) ids.add(id);
+  }
+  return ids;
+};
+
+const changedHostUiToolCallIds = (
+  previous: readonly PiHostUiRequest[],
+  next: readonly PiHostUiRequest[],
+): Set<string> => {
+  const ids = new Set<string>();
+  if (previous === next) return ids;
+  if (
+    previous.length === next.length &&
+    previous.every((request, index) => request === next[index])
+  ) {
+    return ids;
+  }
+  for (const request of previous) {
+    if (request.toolCallId) ids.add(request.toolCallId);
+  }
+  for (const request of next) {
+    if (request.toolCallId) ids.add(request.toolCallId);
+  }
+  return ids;
+};
+
+const isAssistantGroupMessage = (message: PiAgentMessage | undefined) => {
+  const role = message?.role;
+  return role === "assistant" || role === "toolResult";
+};
+
+const assistantGroupStart = (
+  messages: readonly PiAgentMessage[],
+  index: number,
+) => {
+  if (index >= messages.length || !isAssistantGroupMessage(messages[index])) {
+    return index;
+  }
+  let start = index;
+  while (start > 0 && isAssistantGroupMessage(messages[start - 1])) start -= 1;
+  return start;
+};
+
+const lastAssistantMessageIndex = (messages: readonly PiAgentMessage[]) => {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index]!.role === "assistant") return index;
+  }
+  return undefined;
+};
+
+const trailingAssistantMessageIndex = (messages: readonly PiAgentMessage[]) => {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const role = messages[index]!.role;
+    if (role === "assistant") return index;
+    if (role !== "toolResult") return undefined;
+  }
+  return undefined;
+};
+
+const projectedSourceIndex = (message: ThreadMessageLike) => {
+  if (typeof message.id !== "string" || !message.id.startsWith("pi-msg:")) {
+    return undefined;
+  }
+  const index = Number(message.id.slice("pi-msg:".length));
+  return Number.isInteger(index) ? index : undefined;
+};
+
+const firstProjectedIndexAtOrAfter = (
+  messages: readonly ThreadMessageLike[],
+  sourceIndex: number,
+) => {
+  const index = messages.findIndex((message) => {
+    const projectedIndex = projectedSourceIndex(message);
+    return projectedIndex !== undefined && projectedIndex >= sourceIndex;
+  });
+  return index === -1 ? messages.length : index;
+};
+
+export class PiThreadMessageProjector {
+  private previousInput: PiProjectionInput | undefined;
+  private projectedMessages: readonly ThreadMessageLike[] = [];
+  private toolResults = new Map<string, ProjectedToolResult>();
+  private toolCallIndices = new Map<string, number>();
+
+  public constructor(projectedMessages: readonly ThreadMessageLike[] = []) {
+    this.projectedMessages = projectedMessages;
+  }
+
+  public project(input: PiProjectionInput): readonly ThreadMessageLike[] {
+    const previousInput = this.previousInput;
+    if (!previousInput) {
+      this.toolResults = buildToolResultMap(input.messages);
+      this.toolCallIndices = buildToolCallIndices(input.messages);
+      this.projectedMessages = shareProjectedThreadMessages(
+        projectPiThreadMessagesFrom(input, 0, this.toolResults),
+        this.projectedMessages,
+      );
+      this.previousInput = input;
+      return this.projectedMessages;
+    }
+
+    const messageChangeIndex = firstChangedMessageIndex(
+      previousInput.messages,
+      input.messages,
+    );
+    const affectedToolCallIds = changedToolExecutionIds(
+      previousInput.toolExecutions,
+      input.toolExecutions,
+    );
+    for (const id of changedHostUiToolCallIds(
+      previousInput.hostUiRequests,
+      input.hostUiRequests,
+    )) {
+      affectedToolCallIds.add(id);
+    }
+
+    let dirtyIndex = messageChangeIndex;
+    if (messageChangeIndex !== undefined) {
+      for (const index of [
+        trailingAssistantMessageIndex(previousInput.messages),
+        trailingAssistantMessageIndex(input.messages),
+      ]) {
+        if (index !== undefined) {
+          dirtyIndex = Math.min(dirtyIndex, index);
+        }
+      }
+      collectToolResultIds(
+        previousInput.messages,
+        messageChangeIndex,
+        affectedToolCallIds,
+      );
+      collectToolResultIds(
+        input.messages,
+        messageChangeIndex,
+        affectedToolCallIds,
+      );
+    }
+
+    for (const id of affectedToolCallIds) {
+      const index = this.toolCallIndices.get(id);
+      if (index !== undefined) {
+        dirtyIndex =
+          dirtyIndex === undefined ? index : Math.min(dirtyIndex, index);
+      }
+    }
+
+    if (messageChangeIndex !== undefined) {
+      updateToolResults(
+        this.toolResults,
+        previousInput.messages,
+        input.messages,
+        messageChangeIndex,
+      );
+      updateToolCallIndices(
+        this.toolCallIndices,
+        previousInput.messages,
+        input.messages,
+        messageChangeIndex,
+      );
+      for (const id of affectedToolCallIds) {
+        const index = this.toolCallIndices.get(id);
+        if (index !== undefined) {
+          dirtyIndex =
+            dirtyIndex === undefined ? index : Math.min(dirtyIndex, index);
+        }
+      }
+    }
+
+    if (previousInput.runStatus !== input.runStatus) {
+      const index = lastAssistantMessageIndex(input.messages);
+      if (index !== undefined) {
+        dirtyIndex =
+          dirtyIndex === undefined ? index : Math.min(dirtyIndex, index);
+      }
+    }
+
+    if (dirtyIndex === undefined) {
+      this.previousInput = input;
+      return this.projectedMessages;
+    }
+
+    const startIndex = Math.min(
+      assistantGroupStart(previousInput.messages, dirtyIndex),
+      assistantGroupStart(input.messages, dirtyIndex),
+    );
+    const projectedStartIndex = firstProjectedIndexAtOrAfter(
+      this.projectedMessages,
+      startIndex,
+    );
+    const previousSuffix = this.projectedMessages.slice(projectedStartIndex);
+    const nextSuffix = shareProjectedThreadMessages(
+      projectPiThreadMessagesFrom(input, startIndex, this.toolResults),
+      previousSuffix,
+    );
+
+    if (
+      nextSuffix.length === previousSuffix.length &&
+      nextSuffix.every(
+        (message, index) =>
+          message === this.projectedMessages[projectedStartIndex + index],
+      )
+    ) {
+      this.previousInput = input;
+      return this.projectedMessages;
+    }
+
+    this.projectedMessages = [
+      ...this.projectedMessages.slice(0, projectedStartIndex),
+      ...nextSuffix,
+    ];
+    this.previousInput = input;
+    return this.projectedMessages;
+  }
+}
 
 export const projectPiThreadRepository = (input: PiProjectionInput) =>
   ExportedMessageRepository.fromArray(projectPiThreadMessages(input));

--- a/packages/react-pi/src/runtime/messageProjection.ts
+++ b/packages/react-pi/src/runtime/messageProjection.ts
@@ -694,10 +694,6 @@ export class PiThreadMessageProjector {
   private toolResults = new Map<string, ProjectedToolResult>();
   private toolCallIndices = new Map<string, number>();
 
-  public constructor(projectedMessages: readonly ThreadMessageLike[] = []) {
-    this.projectedMessages = projectedMessages;
-  }
-
   public getChangedProjectedIndex() {
     return this.changedProjectedIndex;
   }

--- a/packages/react-pi/src/runtime/messageProjection.ts
+++ b/packages/react-pi/src/runtime/messageProjection.ts
@@ -493,12 +493,6 @@ export const shareProjectedThreadMessages = (
   return changed ? shared : previous;
 };
 
-export const projectPiThreadMessagesShared = (
-  input: PiProjectionInput,
-  previous: readonly ThreadMessageLike[],
-): readonly ThreadMessageLike[] =>
-  shareProjectedThreadMessages(projectPiThreadMessages(input), previous);
-
 const firstChangedMessageIndex = (
   previous: readonly PiAgentMessage[],
   next: readonly PiAgentMessage[],

--- a/packages/x-performance/bench/react-pi-message-projection.bench.ts
+++ b/packages/x-performance/bench/react-pi-message-projection.bench.ts
@@ -1,0 +1,93 @@
+import {
+  PiThreadController,
+  type PiAgentMessage,
+  type PiAssistantMessage,
+  type PiClient,
+  type PiClientEvent,
+  type PiThreadSnapshot,
+} from "@assistant-ui/react-pi";
+import { bench, describe } from "vitest";
+
+const assistantMessage = (
+  text: string,
+  timestamp: number,
+): PiAssistantMessage => ({
+  role: "assistant",
+  content: [{ type: "text", text }],
+  api: "anthropic-messages",
+  provider: "anthropic",
+  model: "claude",
+  usage: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  },
+  stopReason: "stop",
+  timestamp,
+});
+
+const createStreamingUpdate = async (size: number) => {
+  const threadId = `thread-${size}`;
+  const messages: PiAgentMessage[] = Array.from(
+    { length: size },
+    (_, index) => ({
+      role: "user",
+      content: `message-${index}`,
+      timestamp: index,
+    }),
+  );
+  const snapshot: PiThreadSnapshot = {
+    metadata: { id: threadId, status: "running" },
+    messages,
+  };
+  let listener: ((event: PiClientEvent) => void) | undefined;
+  const client = {
+    getThread: async () => snapshot,
+    subscribe: (_threadId, next) => {
+      listener = next;
+      return () => {};
+    },
+  } as PiClient;
+  const scheduled: Array<() => void> = [];
+  const controller = new PiThreadController(client, threadId, {
+    scheduleNotify: (flush) => scheduled.push(flush),
+  });
+  controller.connect();
+  await controller.load();
+
+  let sequence = 1;
+  listener?.({
+    type: "message_start",
+    threadId,
+    seq: sequence,
+    message: assistantMessage("", size),
+  });
+
+  return () => {
+    sequence += 1;
+    const message = assistantMessage(`token-${sequence}`, size);
+    listener?.({
+      type: "message_update",
+      threadId,
+      seq: sequence,
+      message,
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "x",
+        partial: message,
+      },
+    });
+    scheduled.shift()?.();
+  };
+};
+
+describe("react-pi: streaming tail projection", async () => {
+  for (const size of [10, 1_000, 5_000]) {
+    const update = await createStreamingUpdate(size);
+    bench(`${size} stable messages`, update);
+  }
+});

--- a/packages/x-performance/lib/attribution.test.ts
+++ b/packages/x-performance/lib/attribution.test.ts
@@ -93,6 +93,12 @@ describe("against the real workspace", () => {
     expect(
       [...(graph.get("@assistant-ui/react-markdown") ?? [])].sort(),
     ).toEqual(["@assistant-ui/react"]);
+    expect([...(graph.get("@assistant-ui/react-pi") ?? [])].sort()).toEqual([
+      "@assistant-ui/core",
+      "@assistant-ui/react",
+      "@assistant-ui/store",
+      "assistant-stream",
+    ]);
   });
 
   it("attributes each bench file to the dists it exercises", () => {
@@ -119,6 +125,14 @@ describe("against the real workspace", () => {
       "@assistant-ui/core",
       "@assistant-ui/react",
       "@assistant-ui/react-markdown",
+      "@assistant-ui/store",
+      "@assistant-ui/tap",
+      "assistant-stream",
+    ]);
+    expect(covers("bench/react-pi-message-projection.bench.ts")).toEqual([
+      "@assistant-ui/core",
+      "@assistant-ui/react",
+      "@assistant-ui/react-pi",
       "@assistant-ui/store",
       "@assistant-ui/tap",
       "assistant-stream",

--- a/packages/x-performance/lib/ref-packages.mjs
+++ b/packages/x-performance/lib/ref-packages.mjs
@@ -5,4 +5,5 @@ export const REF_PACKAGE_DIRS = {
   "assistant-stream": "packages/assistant-stream",
   "@assistant-ui/react": "packages/react",
   "@assistant-ui/react-markdown": "packages/react-markdown",
+  "@assistant-ui/react-pi": "packages/react-pi",
 };

--- a/packages/x-performance/package.json
+++ b/packages/x-performance/package.json
@@ -21,6 +21,7 @@
     "@assistant-ui/core": "workspace:*",
     "@assistant-ui/react": "workspace:*",
     "@assistant-ui/react-markdown": "workspace:*",
+    "@assistant-ui/react-pi": "workspace:*",
     "@assistant-ui/react-streamdown": "workspace:*",
     "@assistant-ui/store": "workspace:*",
     "@assistant-ui/tap": "workspace:*",

--- a/packages/x-performance/vitest.config.ts
+++ b/packages/x-performance/vitest.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
         // Benches import built packages; serve dist as plain Node modules so
         // vitest's evaluator doesn't skew numbers.
         external: [
-          /\/packages\/(tap|core|store|assistant-stream|react|react-markdown|ai-sdk)\/dist\//,
+          /\/packages\/(tap|core|store|assistant-stream|react|react-markdown|react-pi|ai-sdk)\/dist\//,
         ],
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5452,6 +5452,9 @@ importers:
       '@assistant-ui/react-markdown':
         specifier: workspace:*
         version: link:../react-markdown
+      '@assistant-ui/react-pi':
+        specifier: workspace:*
+        version: link:../react-pi
       '@assistant-ui/react-streamdown':
         specifier: workspace:*
         version: link:../react-streamdown

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -192,7 +192,7 @@
   "@assistant-ui/react-pi": {
     ".": {
       "min": 45424,
-      "gzip": 12993
+      "gzip": 13254
     },
     "./node": {
       "min": 17413,

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -191,8 +191,8 @@
   },
   "@assistant-ui/react-pi": {
     ".": {
-      "min": 41590,
-      "gzip": 12017
+      "min": 45424,
+      "gzip": 12993
     },
     "./node": {
       "min": 17413,


### PR DESCRIPTION
## Problem

In `@assistant-ui/react-pi` 0.0.22, every coalesced streaming update projected the full Pi transcript and rebuilt the full exported message repository before structural sharing could reuse anything. Updating only the newest message therefore became slower as the unchanged conversation grew.

Closes #7205.

## Root cause

`projectPiThreadMessagesShared` built a complete tool-result map and converted every source message on each frame. `PiThreadController` then passed every projected message through `ExportedMessageRepository.fromArray` again. The reducer already preserves source-message identity for the unchanged prefix, but neither conversion used that information.

## Change

- retain projection state per thread and locate the first changed source-message identity
- reproject from the owning assistant/tool-result group while preserving tool-result pairing, live tool output, host UI requests, and trailing run status
- maintain tool-result and tool-call indexes so dependent earlier groups are invalidated correctly, including duplicate IDs across a changed suffix
- locate the projected suffix with a binary search, fall back safely if a cached ID breaks the ordering invariant, and reuse converted repository entries before it
- add a seeded 5,000-transition equivalence test covering append, replacement, truncation, tool execution, host UI, and run-status changes
- add a React Pi streaming benchmark with 10, 1,000, and 5,000 stable messages and wire the package into the performance workflow

A focused local run reduced the mean 5,000-message streaming update from about 2.73 ms on the main build to about 0.03 ms on this branch. This benchmark covers the React Pi projection and repository-update layer, not the complete runtime frame. Wall-time numbers are informational; deterministic tests assert unchanged-prefix reuse and equivalence with the full projector. A changed frame still copies top-level array references, but conversion, deep comparison, and repository-entry construction now stay within the dirty suffix.

## Verification

- `pnpm -C packages/react-pi test` (262 tests)
- `pnpm -C packages/react-pi build`
- `pnpm -C packages/x-performance test` (82 tests)
- `pnpm lint`
- `pnpm changesets:check`
- `pnpm size:check`
- focused React Pi benchmark against the built main and branch entries
- React Pi root and node entries remain within the committed size budgets

## Public surface

- `@assistant-ui/react-pi`: behavior-only performance fix with a patch changeset
- no new public exports
- no documentation, API-reference, or template changes
- private performance benchmark and CI wiring added
