### PR TITLE
fix(react-pi): reconnect returning stream subscribers

### DIFF
--- a/.changeset/reconnect-returning-pi-subscribers.md
+++ b/.changeset/reconnect-returning-pi-subscribers.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: reconnect promptly when subscribers return during stream backoff

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { createSseDecoder, openPiEventStream } from "./eventSource";
+import {
+  createPiEventStreamConnection,
+  createSseDecoder,
+  openPiEventStream,
+} from "./eventSource";
 import type {
   PiAnyClientEvent,
   PiAssistantMessage,
@@ -573,6 +577,73 @@ describe("openPiEventStream", () => {
     });
 
     expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("settles when closed during a pending reconnect delay", async () => {
+    const reconnectDelay = vi.fn(() => new Promise<void>(() => {}));
+    const fetchImpl = vi.fn(async () =>
+      sseResponse([]),
+    ) as unknown as typeof fetch;
+    const connection = createPiEventStreamConnection({
+      url: "/events",
+      fetchImpl,
+      reconnectDelay,
+      onEvent: vi.fn(),
+    });
+
+    await vi.waitFor(() => expect(reconnectDelay).toHaveBeenCalledOnce());
+    connection.close();
+
+    await connection.finished;
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("retains reconnect requests made while a failed reader is cancelling", async () => {
+    let finishCancel!: () => void;
+    const firstBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            rawSseFrame({
+              type: "message_start",
+              threadId: "t1",
+              seq: 1,
+            }),
+          ),
+        );
+      },
+      cancel: () =>
+        new Promise<void>((resolve) => {
+          finishCancel = resolve;
+        }),
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(firstBody, {
+          headers: { "content-type": "text/event-stream" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(new ReadableStream<Uint8Array>(), {
+          headers: { "content-type": "text/event-stream" },
+        }),
+      ) as unknown as typeof fetch;
+    const connection = createPiEventStreamConnection({
+      url: "/events",
+      expectedThreadId: "t1",
+      fetchImpl,
+      reconnectDelay: () => new Promise<void>(() => {}),
+      onEvent: vi.fn(),
+    });
+
+    await vi.waitFor(() => expect(finishCancel).toBeTypeOf("function"));
+    expect(connection.reconnect()).toBe(true);
+    finishCancel();
+
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+    connection.close();
+    await connection.finished;
   });
 
   it.each(["throws", "rejects"] as const)(

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -236,9 +236,13 @@ const parseEventStreamPayload = (
  */
 export const openPiEventStream = (
   options: PiEventStreamOptions,
-): (() => void) => createPiEventStreamConnection(options);
+): (() => void) => createPiEventStreamConnection(options).close;
 
-type PiEventStreamConnection = (() => void) & { reconnect: () => void };
+export type PiEventStreamConnection = {
+  close: () => void;
+  reconnect: () => boolean;
+  finished: Promise<void>;
+};
 
 export const createPiEventStreamConnection = (
   options: PiEventStreamOptions,
@@ -259,6 +263,8 @@ export const createPiEventStreamConnection = (
   let needsSnapshotRecovery = false;
   let cancelActiveReader: (() => void) | undefined;
   let interruptReconnectWait: (() => void) | undefined;
+  let reconnectPending = false;
+  let reconnectRequested = false;
   const abort = new AbortController();
   const reportCallbackError = (callbackError: unknown) => {
     console.error("[react-pi] onError callback threw an error", callbackError);
@@ -296,33 +302,32 @@ export const createPiEventStreamConnection = (
     }
   };
 
-  const waitForReconnect = async () => {
-    let interrupt!: () => void;
-    const interrupted = new Promise<void>((resolve) => {
-      interrupt = resolve;
-    });
-    interruptReconnectWait = interrupt;
-
-    try {
-      const result = await Promise.race([
-        Promise.resolve()
-          .then(() => reconnectDelay())
-          .then(
-            () => ({ status: "ready" as const }),
-            (error: unknown) => ({ status: "error" as const, error }),
-          ),
-        interrupted.then(() => ({ status: "interrupted" as const })),
-      ]);
-
-      if (result.status === "error" && !closed) {
-        reportError(result.error);
-        await Promise.race([defaultReconnectDelay(), interrupted]);
-      }
-    } finally {
-      if (interruptReconnectWait === interrupt) {
-        interruptReconnectWait = undefined;
-      }
+  const waitForReconnect = () => {
+    if (reconnectRequested) {
+      reconnectRequested = false;
+      return Promise.resolve();
     }
+
+    return new Promise<void>((resolve) => {
+      let pending = true;
+      const finish = () => {
+        if (!pending) return;
+        pending = false;
+        if (interruptReconnectWait === finish) {
+          interruptReconnectWait = undefined;
+        }
+        resolve();
+      };
+      interruptReconnectWait = finish;
+
+      void Promise.resolve()
+        .then(reconnectDelay)
+        .then(finish, (error: unknown) => {
+          if (!pending || closed) return;
+          reportError(error);
+          void defaultReconnectDelay().then(finish);
+        });
+    });
   };
 
   const run = async () => {
@@ -396,6 +401,7 @@ export const createPiEventStreamConnection = (
         } finally {
           if (cancelActiveReader === requestCancel)
             cancelActiveReader = undefined;
+          if (!closed) reconnectPending = true;
           try {
             if (shouldCancel || cancelPromise) await cancelReader();
           } finally {
@@ -408,21 +414,30 @@ export const createPiEventStreamConnection = (
       }
       if (closed) break;
       needsSnapshotRecovery = true;
+      reconnectPending = true;
       // Snapshot-first: the next connect replaces local state, so we lose
       // nothing by not replaying. Back off, then retry.
       await waitForReconnect();
+      reconnectPending = false;
+      reconnectRequested = false;
     }
   };
 
-  void run();
+  const finished = run();
 
-  return Object.assign(
-    () => {
+  return {
+    close: () => {
       closed = true;
       abort.abort();
       cancelActiveReader?.();
       interruptReconnectWait?.();
     },
-    { reconnect: () => interruptReconnectWait?.() },
-  );
+    reconnect: () => {
+      if (closed || !reconnectPending) return false;
+      reconnectRequested = true;
+      interruptReconnectWait?.();
+      return true;
+    },
+    finished,
+  };
 };

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -236,7 +236,13 @@ const parseEventStreamPayload = (
  */
 export const openPiEventStream = (
   options: PiEventStreamOptions,
-): (() => void) => {
+): (() => void) => createPiEventStreamConnection(options);
+
+type PiEventStreamConnection = (() => void) & { reconnect: () => void };
+
+export const createPiEventStreamConnection = (
+  options: PiEventStreamOptions,
+): PiEventStreamConnection => {
   const {
     url,
     onEvent,
@@ -252,6 +258,7 @@ export const openPiEventStream = (
   let closed = false;
   let needsSnapshotRecovery = false;
   let cancelActiveReader: (() => void) | undefined;
+  let interruptReconnectWait: (() => void) | undefined;
   const abort = new AbortController();
   const reportCallbackError = (callbackError: unknown) => {
     console.error("[react-pi] onError callback threw an error", callbackError);
@@ -286,6 +293,35 @@ export const openPiEventStream = (
       void Promise.resolve(onConnect()).catch(reportConnectCallbackError);
     } catch (callbackError) {
       reportConnectCallbackError(callbackError);
+    }
+  };
+
+  const waitForReconnect = async () => {
+    let interrupt!: () => void;
+    const interrupted = new Promise<void>((resolve) => {
+      interrupt = resolve;
+    });
+    interruptReconnectWait = interrupt;
+
+    try {
+      const result = await Promise.race([
+        Promise.resolve()
+          .then(() => reconnectDelay())
+          .then(
+            () => ({ status: "ready" as const }),
+            (error: unknown) => ({ status: "error" as const, error }),
+          ),
+        interrupted.then(() => ({ status: "interrupted" as const })),
+      ]);
+
+      if (result.status === "error" && !closed) {
+        reportError(result.error);
+        await Promise.race([defaultReconnectDelay(), interrupted]);
+      }
+    } finally {
+      if (interruptReconnectWait === interrupt) {
+        interruptReconnectWait = undefined;
+      }
     }
   };
 
@@ -374,22 +410,19 @@ export const openPiEventStream = (
       needsSnapshotRecovery = true;
       // Snapshot-first: the next connect replaces local state, so we lose
       // nothing by not replaying. Back off, then retry.
-      try {
-        await reconnectDelay();
-      } catch (error) {
-        if (closed) break;
-        reportError(error);
-        await defaultReconnectDelay();
-        if (closed) break;
-      }
+      await waitForReconnect();
     }
   };
 
   void run();
 
-  return () => {
-    closed = true;
-    abort.abort();
-    cancelActiveReader?.();
-  };
+  return Object.assign(
+    () => {
+      closed = true;
+      abort.abort();
+      cancelActiveReader?.();
+      interruptReconnectWait?.();
+    },
+    { reconnect: () => interruptReconnectWait?.() },
+  );
 };

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -410,6 +410,7 @@ export const createPiEventStreamConnection = (
         }
       } catch (error) {
         if (closed || abort.signal.aborted) break;
+        reconnectPending = true;
         reportError(error);
       }
       if (closed) break;

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -550,7 +550,7 @@ describe("createPiHttpClient", () => {
     finishBackoff();
   });
 
-  it("allows only one prompt reconnect during a retained stream lifetime", async () => {
+  it("allows only one prompt reconnect until a connection succeeds", async () => {
     const finishBackoffs: Array<() => void> = [];
     const reconnectDelay = vi.fn(
       () =>
@@ -558,12 +558,16 @@ describe("createPiHttpClient", () => {
           finishBackoffs.push(resolve);
         }),
     );
-    const fetchImpl = vi.fn(async () =>
-      sseResponse(
-        { type: "agent_start", threadId: "t1", seq: 1 },
-        { keepOpen: fetchImpl.mock.calls.length > 2 },
-      ),
-    ) as unknown as typeof fetch;
+    const fetchImpl = vi.fn(async () => {
+      if (fetchImpl.mock.calls.length === 1) {
+        return sseResponse({
+          type: "agent_start",
+          threadId: "t1",
+          seq: 1,
+        });
+      }
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
     const client = createPiHttpClient({
       fetchImpl,
       reconnectDelay,
@@ -587,6 +591,34 @@ describe("createPiHttpClient", () => {
     await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(3));
     unsubscribeThird();
     finishBackoffs[0]!();
+  });
+
+  it("re-enables prompt reconnects after a successful connection", async () => {
+    const reconnectDelay = vi.fn(() => new Promise<void>(() => {}));
+    const fetchImpl = vi.fn(async () =>
+      sseResponse(
+        { type: "agent_start", threadId: "t1", seq: 1 },
+        { keepOpen: fetchImpl.mock.calls.length > 2 },
+      ),
+    ) as unknown as typeof fetch;
+    const client = createPiHttpClient({
+      fetchImpl,
+      reconnectDelay,
+      streamCloseDelayMs: 100,
+    });
+
+    const unsubscribeFirst = client.subscribe("t1", () => {});
+    await vi.waitFor(() => expect(reconnectDelay).toHaveBeenCalledOnce());
+    unsubscribeFirst();
+
+    const unsubscribeSecond = client.subscribe("t1", () => {});
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(reconnectDelay).toHaveBeenCalledTimes(2));
+    unsubscribeSecond();
+
+    const unsubscribeThird = client.subscribe("t1", () => {});
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(3));
+    unsubscribeThird();
   });
 
   it("isolates listener errors while delivering shared stream events", async () => {

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -550,6 +550,45 @@ describe("createPiHttpClient", () => {
     finishBackoff();
   });
 
+  it("allows only one prompt reconnect during a retained stream lifetime", async () => {
+    const finishBackoffs: Array<() => void> = [];
+    const reconnectDelay = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishBackoffs.push(resolve);
+        }),
+    );
+    const fetchImpl = vi.fn(async () =>
+      sseResponse(
+        { type: "agent_start", threadId: "t1", seq: 1 },
+        { keepOpen: fetchImpl.mock.calls.length > 2 },
+      ),
+    ) as unknown as typeof fetch;
+    const client = createPiHttpClient({
+      fetchImpl,
+      reconnectDelay,
+      streamCloseDelayMs: 100,
+    });
+
+    const unsubscribeFirst = client.subscribe("t1", () => {});
+    await vi.waitFor(() => expect(reconnectDelay).toHaveBeenCalledOnce());
+    unsubscribeFirst();
+
+    const unsubscribeSecond = client.subscribe("t1", () => {});
+    await vi.waitFor(() => expect(reconnectDelay).toHaveBeenCalledTimes(2));
+    unsubscribeSecond();
+
+    const unsubscribeThird = client.subscribe("t1", () => {});
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    finishBackoffs[1]!();
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(3));
+    unsubscribeThird();
+    finishBackoffs[0]!();
+  });
+
   it("isolates listener errors while delivering shared stream events", async () => {
     const event: PiAnyClientEvent = {
       type: "agent_start",

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -550,6 +550,41 @@ describe("createPiHttpClient", () => {
     finishBackoff();
   });
 
+  it("retains a reconnect requested synchronously from a stream error", async () => {
+    let failRequest!: (error: unknown) => void;
+    const firstRequest = new Promise<Response>((_, reject) => {
+      failRequest = reject;
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockReturnValueOnce(firstRequest)
+      .mockImplementation(async () =>
+        sseResponse(
+          { type: "agent_start", threadId: "t1", seq: 1 },
+          { keepOpen: true },
+        ),
+      ) as unknown as typeof fetch;
+    const reconnectDelay = vi.fn(() => new Promise<void>(() => {}));
+    let unsubscribeSecond: (() => void) | undefined;
+    let client!: ReturnType<typeof createPiHttpClient>;
+    client = createPiHttpClient({
+      fetchImpl,
+      reconnectDelay,
+      streamCloseDelayMs: 100,
+      onStreamError: () => {
+        unsubscribeSecond = client.subscribe("t1", () => {});
+      },
+    });
+
+    const unsubscribeFirst = client.subscribe("t1", () => {});
+    unsubscribeFirst();
+    failRequest(new Error("offline"));
+
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+    expect(reconnectDelay).not.toHaveBeenCalled();
+    unsubscribeSecond?.();
+  });
+
   it("allows only one prompt reconnect until a connection succeeds", async () => {
     const finishBackoffs: Array<() => void> = [];
     const reconnectDelay = vi.fn(

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -519,6 +519,37 @@ describe("createPiHttpClient", () => {
     expect(events).toEqual([event]);
   });
 
+  it("reconnects promptly when a listener joins during backoff", async () => {
+    let finishBackoff!: () => void;
+    const reconnectDelay = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishBackoff = resolve;
+        }),
+    );
+    const fetchImpl = vi.fn(async () =>
+      sseResponse(
+        { type: "agent_start", threadId: "t1", seq: 1 },
+        { keepOpen: fetchImpl.mock.calls.length > 1 },
+      ),
+    ) as unknown as typeof fetch;
+    const client = createPiHttpClient({
+      fetchImpl,
+      reconnectDelay,
+      streamCloseDelayMs: 1,
+    });
+
+    const unsubscribeFirst = client.subscribe("t1", () => {});
+    await vi.waitFor(() => expect(reconnectDelay).toHaveBeenCalledOnce());
+    unsubscribeFirst();
+
+    const unsubscribeSecond = client.subscribe("t1", () => {});
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+
+    unsubscribeSecond();
+    finishBackoff();
+  });
+
   it("isolates listener errors while delivering shared stream events", async () => {
     const event: PiAnyClientEvent = {
       type: "agent_start",

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -31,6 +31,7 @@ import {
   createPiEventStreamConnection,
   openPiEventStream,
 } from "./eventSource";
+import type { PiEventStreamConnection } from "./eventSource";
 import { isThreadMetadata, isThreadSnapshot } from "./validation";
 import type {
   PiClient,
@@ -67,7 +68,8 @@ type SharedStream = {
   liveSnapshotSeq: number;
   awaitingLiveSnapshot: boolean;
   snapshotLoad: SharedSnapshotLoad | undefined;
-  close: ReturnType<typeof createPiEventStreamConnection>;
+  connection: PiEventStreamConnection;
+  reconnectOnReturnAvailable: boolean;
   closeTimer: ReturnType<typeof setTimeout> | undefined;
 };
 
@@ -419,7 +421,8 @@ export const createPiHttpClient = (
           awaitingLiveSnapshot: false,
           snapshotLoad: undefined,
           closeTimer: undefined,
-          close: createPiEventStreamConnection({
+          reconnectOnReturnAvailable: true,
+          connection: createPiEventStreamConnection({
             url: eventsUrl,
             expectedThreadId: threadId,
             ...(!includeSnapshot && {
@@ -505,7 +508,12 @@ export const createPiHttpClient = (
       } else if (stream.closeTimer) {
         clearTimeout(stream.closeTimer);
         stream.closeTimer = undefined;
-        stream.close.reconnect();
+        if (
+          stream.reconnectOnReturnAvailable &&
+          stream.connection.reconnect()
+        ) {
+          stream.reconnectOnReturnAvailable = false;
+        }
       }
 
       const isNewListener = !stream.listeners.has(listener);
@@ -656,14 +664,14 @@ export const createPiHttpClient = (
         }
         if (current.listeners.size > 0 || current.closeTimer) return;
         if (streamCloseDelayMs <= 0) {
-          current.close();
+          current.connection.close();
           streams.delete(streamKey);
           return;
         }
         current.closeTimer = setTimeout(() => {
           const latest = streams.get(streamKey);
           if (!latest || latest.listeners.size > 0) return;
-          latest.close();
+          latest.connection.close();
           streams.delete(streamKey);
         }, streamCloseDelayMs);
       };

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -27,7 +27,10 @@
  *   GET    /threads/:id/events      → SSE of PiClientEvent (?snapshot=false skips initial snapshot)
  */
 import { isRecord } from "@assistant-ui/core/internal";
-import { openPiEventStream } from "./eventSource";
+import {
+  createPiEventStreamConnection,
+  openPiEventStream,
+} from "./eventSource";
 import { isThreadMetadata, isThreadSnapshot } from "./validation";
 import type {
   PiClient,
@@ -64,7 +67,7 @@ type SharedStream = {
   liveSnapshotSeq: number;
   awaitingLiveSnapshot: boolean;
   snapshotLoad: SharedSnapshotLoad | undefined;
-  close: () => void;
+  close: ReturnType<typeof createPiEventStreamConnection>;
   closeTimer: ReturnType<typeof setTimeout> | undefined;
 };
 
@@ -416,7 +419,7 @@ export const createPiHttpClient = (
           awaitingLiveSnapshot: false,
           snapshotLoad: undefined,
           closeTimer: undefined,
-          close: openPiEventStream({
+          close: createPiEventStreamConnection({
             url: eventsUrl,
             expectedThreadId: threadId,
             ...(!includeSnapshot && {
@@ -502,6 +505,7 @@ export const createPiHttpClient = (
       } else if (stream.closeTimer) {
         clearTimeout(stream.closeTimer);
         stream.closeTimer = undefined;
+        stream.close.reconnect();
       }
 
       const isNewListener = !stream.listeners.has(listener);

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -433,6 +433,7 @@ export const createPiHttpClient = (
             ...(reconnectDelay ? { reconnectDelay } : {}),
             ...(onStreamError ? { onError: onStreamError } : {}),
             onConnect: () => {
+              createdStream.reconnectOnReturnAvailable = true;
               createdStream.awaitingLiveSnapshot = true;
               const snapshotLoad = createdStream.snapshotLoad;
               if (snapshotLoad) {

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -191,8 +191,8 @@
   },
   "@assistant-ui/react-pi": {
     ".": {
-      "min": 41590,
-      "gzip": 12017
+      "min": 42783,
+      "gzip": 12372
     },
     "./node": {
       "min": 17413,


### PR DESCRIPTION
## Problem

In `@assistant-ui/react-pi` 0.0.22, a shared SSE stream can enter reconnect backoff while its last subscriber leaves. The client retains that stream for the configured idle grace period, but a subscriber returning during the grace period cannot wake the stale backoff. With a delayed reconnect policy, the active subscriber receives no events until that old delay settles.

A focused reproduction subscribed, let the first stream close into a blocked reconnect delay, unsubscribed, and subscribed again before idle cleanup. On `main`, the second subscription made no new request until the blocked delay was manually released.

## Root cause

`createPiHttpClient()` cancels the pending idle-close timer when a listener returns, but `openPiEventStream()` exposes no way to interrupt its current reconnect wait. The retained stream therefore remains owned by the previous backoff.

## Change

Add an internal controlled event-stream connection whose close function can also wake the current reconnect wait. The shared HTTP client wakes that wait only when a listener returns during the idle grace period. Healthy streams, cached snapshots, ordinary reconnect timing, and the public `openPiEventStream()` callable API remain unchanged. Closing a stream also wakes its wait so the loop can settle promptly.

## Verification

- Added a regression covering unsubscribe and resubscribe during a blocked reconnect delay.
- Confirmed the regression fails on `main` with one request and passes with two after the fix.
- `pnpm --filter @assistant-ui/react-pi test` (256 tests)
- `pnpm --filter @assistant-ui/react-pi build`
- Targeted oxfmt and oxlint checks
- `pnpm changesets:check`

## Public surface

`@assistant-ui/react-pi` behavior changes and receives a patch changeset. No public exports or types change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.GPHL-gMU8F1xlggp8oKGPBsBIDRKDbap0VGL4LlhjxPEEPSNjKVmI_8KOf4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->