### PR TITLE
fix(safe-content-frame): clean up pending and failed renders

### DIFF
--- a/.changeset/calm-frames-cancel.md
+++ b/.changeset/calm-frames-cancel.md
@@ -1,0 +1,6 @@
+---
+"safe-content-frame": patch
+"@assistant-ui/react": patch
+---
+
+fix: cancel pending sandbox frame renders during teardown

--- a/api-surface/safe-content-frame.ts
+++ b/api-surface/safe-content-frame.ts
@@ -9,11 +9,13 @@ interface RenderedFrame {
 declare class SafeContentFrame {
   #private;
   constructor(product: string, options?: SafeContentFrameOptions);
-  renderHtml(html: string, container: HTMLElement, opts?: {
-    unsafeDocumentWrite?: boolean;
-  }): Promise<RenderedFrame>;
-  renderRaw(content: Uint8Array | string, mimeType: string, container: HTMLElement): Promise<RenderedFrame>;
-  renderPdf(content: Uint8Array, container: HTMLElement): Promise<RenderedFrame>;
+  renderHtml(html: string, container: HTMLElement, opts?: SafeContentFrameHtmlRenderOptions): Promise<RenderedFrame>;
+  renderRaw(content: Uint8Array | string, mimeType: string, container: HTMLElement, opts?: SafeContentFrameRenderOptions): Promise<RenderedFrame>;
+  renderPdf(content: Uint8Array, container: HTMLElement, opts?: SafeContentFrameRenderOptions): Promise<RenderedFrame>;
+}
+
+interface SafeContentFrameHtmlRenderOptions extends SafeContentFrameRenderOptions {
+  unsafeDocumentWrite?: boolean;
 }
 
 interface SafeContentFrameOptions {
@@ -21,6 +23,10 @@ interface SafeContentFrameOptions {
   enableBrowserCaching?: boolean;
   sandbox?: SandboxOption[];
   salt?: string;
+}
+
+interface SafeContentFrameRenderOptions {
+  signal?: AbortSignal;
 }
 
 type SandboxOption = "allow-downloads" | "allow-forms" | "allow-modals" | "allow-popups" | "allow-popups-to-escape-sandbox" | "allow-same-origin" | "allow-scripts";
@@ -34,7 +40,7 @@ type ShimLoadErrorCode = "render-timeout" | "shim-error" | "shim-unavailable";
 declare const enableShadowDom: () => boolean;
 
 declare namespace entry_root_exports {
-  export { RenderedFrame, SafeContentFrame, SafeContentFrameOptions, SandboxOption, ShimLoadError, ShimLoadErrorCode, isShimLoadError };
+  export { RenderedFrame, SafeContentFrame, SafeContentFrameHtmlRenderOptions, SafeContentFrameOptions, SafeContentFrameRenderOptions, SandboxOption, ShimLoadError, ShimLoadErrorCode, isShimLoadError };
 }
 
 declare function isShimLoadError(error: unknown): error is ShimLoadError;

--- a/packages/react/src/sandbox-host/SandboxHost.test.tsx
+++ b/packages/react/src/sandbox-host/SandboxHost.test.tsx
@@ -416,6 +416,40 @@ describe("SandboxHost", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("cancels pending renders on replacement and unmount", async () => {
+    renderHtmlMock.mockImplementation(() => new Promise(() => {}));
+
+    await act(async () => {
+      root.render(
+        <SandboxHost
+          content={{ html: "first" }}
+          contentKey="first"
+          createBridge={() => ({ onMessage: vi.fn(), dispose: vi.fn() })}
+        />,
+      );
+    });
+    const firstSignal = renderHtmlMock.mock.calls[0]![2].signal as AbortSignal;
+
+    await act(async () => {
+      root.render(
+        <SandboxHost
+          content={{ html: "second" }}
+          contentKey="second"
+          createBridge={() => ({ onMessage: vi.fn(), dispose: vi.fn() })}
+        />,
+      );
+    });
+    const secondSignal = renderHtmlMock.mock.calls[1]![2].signal as AbortSignal;
+
+    expect(firstSignal.aborted).toBe(true);
+    expect(secondSignal.aborted).toBe(false);
+
+    await act(async () => {
+      root.unmount();
+    });
+    expect(secondSignal.aborted).toBe(true);
+  });
+
   it("contains failures thrown by onError", async () => {
     const renderError = new Error("render failed");
     const callbackError = new Error("error callback failed");

--- a/packages/react/src/sandbox-host/SandboxHost.tsx
+++ b/packages/react/src/sandbox-host/SandboxHost.tsx
@@ -107,6 +107,7 @@ export function SandboxHost({
     let frame: RenderedFrame | null = null;
     let bridge: SandboxBridge | null = null;
     let onMessage: ((event: MessageEvent) => void) | null = null;
+    const renderController = new AbortController();
 
     const { content: liveContent, sandbox: sb } = liveRef.current;
 
@@ -129,10 +130,12 @@ export function SandboxHost({
       ...(sb?.salt !== undefined && { salt: sb.salt }),
     });
 
-    const renderOpts =
-      sb?.unsafeDocumentWrite !== undefined
-        ? { unsafeDocumentWrite: sb.unsafeDocumentWrite }
-        : undefined;
+    const renderOpts = {
+      signal: renderController.signal,
+      ...(sb?.unsafeDocumentWrite !== undefined && {
+        unsafeDocumentWrite: sb.unsafeDocumentWrite,
+      }),
+    };
 
     scf
       .renderHtml(liveContent.html, container, renderOpts)
@@ -216,6 +219,7 @@ export function SandboxHost({
       const bridgeToDispose = bridge;
       bridge = null;
       if (bridgeToDispose) runCleanup(() => bridgeToDispose.dispose());
+      runCleanup(() => renderController.abort());
       const frameToDispose = frame;
       frame = null;
       if (frameToDispose) runCleanup(() => frameToDispose.dispose());

--- a/packages/safe-content-frame/src/index.test.ts
+++ b/packages/safe-content-frame/src/index.test.ts
@@ -120,6 +120,48 @@ describe("SafeContentFrame", () => {
     expect(MockMessageChannel.instances[0]!.port2.close).toHaveBeenCalledOnce();
   });
 
+  it("cancels a pending render before the iframe loads", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = new SafeContentFrame("test", { salt: "fixed" });
+    const controller = new AbortController();
+    const removeMessageListener = vi.spyOn(window, "removeEventListener");
+
+    const framePromise = renderer.renderHtml("<p>Hello</p>", container, {
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => {
+      expect(container.querySelector("iframe")).toBeTruthy();
+    });
+
+    controller.abort();
+
+    await expect(framePromise).rejects.toMatchObject({ name: "AbortError" });
+    expect(container.childElementCount).toBe(0);
+    expect(MockMessageChannel.instances[0]!.port1.close).toHaveBeenCalledOnce();
+    expect(MockMessageChannel.instances[0]!.port2.close).toHaveBeenCalledOnce();
+    expect(removeMessageListener).toHaveBeenCalledWith(
+      "message",
+      expect.any(Function),
+    );
+  });
+
+  it("does not mount a frame when the render is already aborted", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = new SafeContentFrame("test", { salt: "fixed" });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      renderer.renderHtml("<p>Hello</p>", container, {
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(container.childElementCount).toBe(0);
+    expect(MockMessageChannel.instances).toHaveLength(0);
+  });
+
   it("surfaces shim errors reported after the iframe loads", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);

--- a/packages/safe-content-frame/src/index.test.ts
+++ b/packages/safe-content-frame/src/index.test.ts
@@ -162,6 +162,38 @@ describe("SafeContentFrame", () => {
     expect(MockMessageChannel.instances).toHaveLength(0);
   });
 
+  it("keeps a resolved frame alive when the render signal aborts", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = new SafeContentFrame("test", { salt: "fixed" });
+    const controller = new AbortController();
+
+    const framePromise = renderer.renderHtml("<p>Hello</p>", container, {
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => {
+      expect(container.querySelector("iframe")).toBeTruthy();
+    });
+
+    const iframe = container.querySelector("iframe")!;
+    setContentWindow(iframe);
+    iframe.dispatchEvent(new Event("load"));
+    const frame = await framePromise;
+
+    controller.abort();
+
+    expect(container.contains(iframe)).toBe(true);
+    expect(MockMessageChannel.instances[0]!.port1.close).not.toHaveBeenCalled();
+    frame.sendMessage({ type: "ping" });
+    expect(iframe.contentWindow?.postMessage).toHaveBeenCalledWith(
+      { type: "ping" },
+      frame.origin,
+      undefined,
+    );
+
+    frame.dispose();
+  });
+
   it("surfaces shim errors reported after the iframe loads", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);

--- a/packages/safe-content-frame/src/index.ts
+++ b/packages/safe-content-frame/src/index.ts
@@ -14,6 +14,14 @@ export interface SafeContentFrameOptions {
   salt?: string;
 }
 
+export interface SafeContentFrameRenderOptions {
+  signal?: AbortSignal;
+}
+
+export interface SafeContentFrameHtmlRenderOptions extends SafeContentFrameRenderOptions {
+  unsafeDocumentWrite?: boolean;
+}
+
 /**
  * Why a frame never signalled a completed render. `shim-unavailable` means the
  * shim never acknowledged that it started, so the document at the shim URL is
@@ -107,6 +115,21 @@ function randomSalt(): ArrayBuffer {
   return arr.buffer as ArrayBuffer;
 }
 
+function getAbortError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) return signal.reason;
+  const error = new Error(
+    signal.reason === undefined
+      ? "The operation was aborted"
+      : String(signal.reason),
+  );
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw getAbortError(signal);
+}
+
 async function contentSalt(
   content: Uint8Array,
   pathname: string,
@@ -134,7 +157,7 @@ export class SafeContentFrame {
   async renderHtml(
     html: string,
     container: HTMLElement,
-    opts?: { unsafeDocumentWrite?: boolean },
+    opts?: SafeContentFrameHtmlRenderOptions,
   ): Promise<RenderedFrame> {
     return this.render(
       new TextEncoder().encode(html),
@@ -148,25 +171,29 @@ export class SafeContentFrame {
     content: Uint8Array | string,
     mimeType: string,
     container: HTMLElement,
+    opts?: SafeContentFrameRenderOptions,
   ): Promise<RenderedFrame> {
     const data =
       typeof content === "string" ? new TextEncoder().encode(content) : content;
-    return this.render(data, mimeType, container);
+    return this.render(data, mimeType, container, opts);
   }
 
   async renderPdf(
     content: Uint8Array,
     container: HTMLElement,
+    opts?: SafeContentFrameRenderOptions,
   ): Promise<RenderedFrame> {
-    return this.render(content, "application/pdf", container);
+    return this.render(content, "application/pdf", container, opts);
   }
 
   private async render(
     content: Uint8Array,
     mimeType: string,
     container: HTMLElement,
-    opts?: { unsafeDocumentWrite?: boolean },
+    opts?: SafeContentFrameHtmlRenderOptions,
   ): Promise<RenderedFrame> {
+    const signal = opts?.signal;
+    throwIfAborted(signal);
     const origin = window.location.origin;
     const salt = this.options.salt
       ? (new TextEncoder().encode(this.options.salt).buffer as ArrayBuffer)
@@ -174,7 +201,9 @@ export class SafeContentFrame {
         ? await contentSalt(content, location.pathname)
         : randomSalt();
 
+    throwIfAborted(signal);
     const hash = await computeOriginHash(this.product, salt, origin);
+    throwIfAborted(signal);
     const shimUrl = `https://${hash}-${PRODUCT_HASH}.${SCF_HOST}/${this.product}/shim.html?origin=${encodeURIComponent(origin)}${this.options.enableBrowserCaching ? "&cache=1" : ""}`;
     const iframeOrigin = new URL(shimUrl).origin;
 
@@ -217,9 +246,10 @@ export class SafeContentFrame {
       };
       window.addEventListener("message", onWindowMessage);
 
-      const cleanup = () => {
+      function cleanup() {
         if (cleanedUp) return;
         cleanedUp = true;
+        signal?.removeEventListener("abort", onAbort);
         iframe.onload = null;
         iframe.onerror = null;
         window.removeEventListener("message", onWindowMessage);
@@ -227,7 +257,20 @@ export class SafeContentFrame {
         channel.port1.close();
         if (!channelTransferred) channel.port2.close();
         mountElement.remove();
-      };
+      }
+
+      function onAbort() {
+        if (!signal) return;
+        const error = getAbortError(signal);
+        onLoadError(error);
+        cleanup();
+        reject(error);
+      }
+      signal?.addEventListener("abort", onAbort, { once: true });
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
 
       channel.port1.onmessage = (e) => {
         if (e.data?.type === "msg") onLoaded();

--- a/packages/safe-content-frame/src/index.ts
+++ b/packages/safe-content-frame/src/index.ts
@@ -247,7 +247,6 @@ export class SafeContentFrame {
 
       function onAbort() {
         if (!signal) return;
-        onLoadError(signal.reason);
         cleanup();
         reject(signal.reason);
       }

--- a/packages/safe-content-frame/src/index.ts
+++ b/packages/safe-content-frame/src/index.ts
@@ -15,6 +15,7 @@ export interface SafeContentFrameOptions {
 }
 
 export interface SafeContentFrameRenderOptions {
+  /** Cancels the render while its iframe is still loading. */
   signal?: AbortSignal;
 }
 
@@ -115,21 +116,6 @@ function randomSalt(): ArrayBuffer {
   return arr.buffer as ArrayBuffer;
 }
 
-function getAbortError(signal: AbortSignal): Error {
-  if (signal.reason instanceof Error) return signal.reason;
-  const error = new Error(
-    signal.reason === undefined
-      ? "The operation was aborted"
-      : String(signal.reason),
-  );
-  error.name = "AbortError";
-  return error;
-}
-
-function throwIfAborted(signal?: AbortSignal): void {
-  if (signal?.aborted) throw getAbortError(signal);
-}
-
 async function contentSalt(
   content: Uint8Array,
   pathname: string,
@@ -193,7 +179,7 @@ export class SafeContentFrame {
     opts?: SafeContentFrameHtmlRenderOptions,
   ): Promise<RenderedFrame> {
     const signal = opts?.signal;
-    throwIfAborted(signal);
+    signal?.throwIfAborted();
     const origin = window.location.origin;
     const salt = this.options.salt
       ? (new TextEncoder().encode(this.options.salt).buffer as ArrayBuffer)
@@ -201,9 +187,9 @@ export class SafeContentFrame {
         ? await contentSalt(content, location.pathname)
         : randomSalt();
 
-    throwIfAborted(signal);
+    signal?.throwIfAborted();
     const hash = await computeOriginHash(this.product, salt, origin);
-    throwIfAborted(signal);
+    signal?.throwIfAborted();
     const shimUrl = `https://${hash}-${PRODUCT_HASH}.${SCF_HOST}/${this.product}/shim.html?origin=${encodeURIComponent(origin)}${this.options.enableBrowserCaching ? "&cache=1" : ""}`;
     const iframeOrigin = new URL(shimUrl).origin;
 
@@ -261,16 +247,11 @@ export class SafeContentFrame {
 
       function onAbort() {
         if (!signal) return;
-        const error = getAbortError(signal);
-        onLoadError(error);
+        onLoadError(signal.reason);
         cleanup();
-        reject(error);
+        reject(signal.reason);
       }
       signal?.addEventListener("abort", onAbort, { once: true });
-      if (signal?.aborted) {
-        onAbort();
-        return;
-      }
 
       channel.port1.onmessage = (e) => {
         if (e.data?.type === "msg") onLoaded();
@@ -301,6 +282,7 @@ export class SafeContentFrame {
             [channel.port2],
           );
           channelTransferred = true;
+          signal?.removeEventListener("abort", onAbort);
         } catch (error) {
           cleanup();
           reject(error);


### PR DESCRIPTION
## Problem

SafeContentFrame can allocate an iframe, window listener, and MessageChannel before it can return a disposal handle.

Two failures follow from that lifecycle:

- If SandboxHost is replaced or unmounted before the iframe loads, the pending render cannot be disposed.
- If the authenticated shim reports an initialization error before the iframe load event, the render promise stays pending and the mounted frame resources remain active.

The initialization-error reproduction on current main hangs until the 5 second test timeout.

Fixes #7206
Fixes #7691

## Root cause

Cleanup was available only after renderHtml resolved. The window-message error path also rejected the internal loaded promise without cleaning resources or rejecting the outer render promise while setup was still pending.

## Change

Add an optional AbortSignal to the HTML, raw-content, and PDF render options. SandboxHost now owns one controller per committed effect and aborts pending work during replacement or unmount.

While iframe setup is pending, authenticated shim initialization failures report the original error, remove the iframe and listeners, close both message ports, and reject the render. After the frame has been handed to the caller, later shim errors preserve the existing ownership contract: the frame remains mounted and only its readiness promise rejects.

## Verification

- pnpm --filter safe-content-frame exec vitest run src/index.test.ts --maxWorkers=2 (17 tests)
- The pre-load shim-error regression test times out without the fix and passes with it
- A post-load regression test confirms later shim errors do not remove the caller-owned frame
- pnpm --filter @assistant-ui/react exec vitest run src/sandbox-host/SandboxHost.test.tsx --maxWorkers=2 (17 tests, no type errors)
- pnpm exec turbo run build --filter=@assistant-ui/react...
- node scripts/generate-api-surface.mjs --check --filter=safe-content-frame
- pnpm changesets:check
- Focused oxlint and oxfmt checks

## Public surface

- safe-content-frame adds render option types with an optional signal
- @assistant-ui/react changes SandboxHost teardown behavior
- Generated API surface updated
- Patch changeset included
- No documentation or template changes