### PR TITLE
fix(react): isolate thread viewport scroll listeners

### DIFF
--- a/.changeset/tidy-viewports-scroll.md
+++ b/.changeset/tidy-viewports-scroll.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: keep notifying thread viewport scroll listeners after a listener fails

--- a/packages/react/src/context/stores/ThreadViewport.test.ts
+++ b/packages/react/src/context/stores/ThreadViewport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { makeThreadViewportStore } from "./ThreadViewport";
 
 describe("makeThreadViewportStore", () => {
@@ -8,6 +8,7 @@ describe("makeThreadViewportStore", () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
+    onTestFinished(() => consoleError.mockRestore());
     const laterListener = vi.fn();
 
     store.getState().onScrollToBottom(() => {
@@ -21,7 +22,7 @@ describe("makeThreadViewportStore", () => {
     expect(() => store.getState().scrollToBottom()).not.toThrow();
     expect(laterListener).toHaveBeenCalledWith({ behavior: "auto" });
     expect(consoleError).toHaveBeenCalledWith(
-      "[assistant-ui] Thread viewport listener threw an error",
+      expect.stringContaining("Thread viewport"),
       listenerError,
     );
   });

--- a/packages/react/src/context/stores/ThreadViewport.test.ts
+++ b/packages/react/src/context/stores/ThreadViewport.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { makeThreadViewportStore } from "./ThreadViewport";
+
+describe("makeThreadViewportStore", () => {
+  it("notifies every scroll listener when one throws", () => {
+    const store = makeThreadViewportStore();
+    const listenerError = new Error("scroll listener failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const laterListener = vi.fn();
+
+    store.getState().onScrollToBottom(() => {
+      throw listenerError;
+    });
+    store.getState().onScrollToBottom(laterListener);
+
+    expect(() => store.getState().scrollToBottom()).not.toThrow();
+    expect(laterListener).toHaveBeenCalledWith({ behavior: "auto" });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Thread viewport listener threw an error",
+      listenerError,
+    );
+  });
+});

--- a/packages/react/src/context/stores/ThreadViewport.test.ts
+++ b/packages/react/src/context/stores/ThreadViewport.test.ts
@@ -13,6 +13,9 @@ describe("makeThreadViewportStore", () => {
     store.getState().onScrollToBottom(() => {
       throw listenerError;
     });
+    store.getState().onScrollToBottom((config) => {
+      config.behavior = "smooth";
+    });
     store.getState().onScrollToBottom(laterListener);
 
     expect(() => store.getState().scrollToBottom()).not.toThrow();

--- a/packages/react/src/context/stores/ThreadViewport.ts
+++ b/packages/react/src/context/stores/ThreadViewport.ts
@@ -2,6 +2,7 @@
 
 import { create } from "zustand";
 import type { Unsubscribe } from "@assistant-ui/core";
+import { notifyEventListeners } from "@assistant-ui/core/internal";
 
 export type SizeHandle = {
   /** Update the height */
@@ -184,9 +185,11 @@ export const makeThreadViewportStore = (
   const store = create<ThreadViewportState>(() => ({
     isAtBottom: true,
     scrollToBottom: ({ behavior = "auto" } = {}) => {
-      for (const listener of scrollToBottomListeners) {
-        listener({ behavior });
-      }
+      notifyEventListeners(
+        scrollToBottomListeners,
+        { behavior },
+        "Thread viewport",
+      );
     },
     onScrollToBottom: (callback) => {
       scrollToBottomListeners.add(callback);

--- a/packages/react/src/context/stores/ThreadViewport.ts
+++ b/packages/react/src/context/stores/ThreadViewport.ts
@@ -187,7 +187,7 @@ export const makeThreadViewportStore = (
     scrollToBottom: ({ behavior = "auto" } = {}) => {
       notifyEventListeners(
         scrollToBottomListeners,
-        { behavior },
+        () => ({ behavior }),
         "Thread viewport",
       );
     },


### PR DESCRIPTION
## Problem

`scrollToBottom()` notifies multiple thread viewport listeners in registration order. If one listener throws, the error escapes and every later listener is skipped. A nested viewport or integration callback can therefore prevent the actual viewport auto-scroll or composer focus listener from running.

A focused regression on current main reproduced the command throwing and a later listener receiving zero calls.

## Root cause

`makeThreadViewportStore()` invoked the listener set with an unguarded loop even though the repository already has a shared notifier that isolates listener failures.

## Change

Route scroll-to-bottom notifications through `notifyEventListeners`, preserving registration order and payloads while reporting individual failures and continuing to later listeners.

## Verification

- `pnpm -C packages/react exec vitest run src/context/stores/ThreadViewport.test.ts`
- `pnpm -C packages/react test` (67 files, 594 tests, no type errors)
- `pnpm exec turbo run build --filter='@assistant-ui/react...'`
- `node scripts/generate-api-surface.mjs --check --filter=@assistant-ui/react`
- focused oxlint and oxfmt checks
- `pnpm changesets:check`
- `pnpm size:check` confirms `@assistant-ui/react` is within budget; the command exits on unrelated existing `assistant-stream` baseline drift

## Public surface

- `@assistant-ui/react`: thread viewport notification behavior only
- Patch changeset included
- No exports, API-reference output, documentation, or templates changed

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4QJLmUaS-4EIDRHHCNTNwZ4T98PD33atTdfJ2BZIzDYHkQNPSbkOXr9VTHo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

