### PR TITLE
feat(docs): count WebMCP docs-tool calls so we can tell whether anyone uses them

### DIFF
--- a/apps/docs/lib/analytics.test.ts
+++ b/apps/docs/lib/analytics.test.ts
@@ -107,16 +107,18 @@ it("tracks assistant feedback lifecycle events to PostHog", () => {
   );
 });
 
-it("tracks WebMCP calls and host detection to PostHog", () => {
+it("tracks WebMCP host detection, registration, and calls to PostHog", () => {
   const capture = vi.fn();
   globalObject.window = { posthog: { capture } };
   const props = { tool: "searchDocs", status: "ok", latency_ms: 12 } as const;
 
   analytics.webmcp.hostDetected();
+  analytics.webmcp.toolRegistered({ tool: "searchDocs", status: "ok" });
   analytics.webmcp.toolCalled(props);
 
   expect(capture.mock.calls).toEqual([
     ["webmcp_host_detected", undefined],
+    ["webmcp_tool_registered", { tool: "searchDocs", status: "ok" }],
     ["webmcp_tool_called", props],
   ]);
 });

--- a/apps/docs/lib/analytics.test.ts
+++ b/apps/docs/lib/analytics.test.ts
@@ -106,3 +106,30 @@ it("tracks assistant feedback lifecycle events to PostHog", () => {
     }),
   );
 });
+
+it("tracks WebMCP calls and host detection to PostHog", () => {
+  const capture = vi.fn();
+  globalObject.window = { posthog: { capture } };
+  const props = { tool: "searchDocs", status: "ok", latency_ms: 12 } as const;
+
+  analytics.webmcp.hostDetected();
+  analytics.webmcp.toolCalled(props);
+
+  expect(capture.mock.calls).toEqual([
+    ["webmcp_host_detected", undefined],
+    ["webmcp_tool_called", props],
+  ]);
+});
+
+it("WebMCP tracking does not throw when posthog is undefined", () => {
+  globalObject.window = {};
+
+  expect(() => {
+    analytics.webmcp.hostDetected();
+    analytics.webmcp.toolCalled({
+      tool: "getDoc",
+      status: "error",
+      latency_ms: 0,
+    });
+  }).not.toThrow();
+});

--- a/apps/docs/lib/analytics.ts
+++ b/apps/docs/lib/analytics.ts
@@ -355,6 +355,16 @@ export const analytics = {
   webmcp: {
     hostDetected: () => trackEvent("webmcp_host_detected"),
 
+    toolRegistered: (
+      props:
+        | { tool: "searchDocs" | "getDoc" | "getExample"; status: "ok" }
+        | {
+            tool: "searchDocs" | "getDoc" | "getExample";
+            status: "failed";
+            error_name: string;
+          },
+    ) => trackEvent("webmcp_tool_registered", props),
+
     toolCalled: (props: {
       tool: "searchDocs" | "getDoc" | "getExample";
       status: "ok" | "error" | "aborted";

--- a/apps/docs/lib/analytics.ts
+++ b/apps/docs/lib/analytics.ts
@@ -351,4 +351,14 @@ export const analytics = {
       template_id?: string;
     }) => trackEvent("xulux_converted", props),
   },
+
+  webmcp: {
+    hostDetected: () => trackEvent("webmcp_host_detected"),
+
+    toolCalled: (props: {
+      tool: "searchDocs" | "getDoc" | "getExample";
+      status: "ok" | "error" | "aborted";
+      latency_ms: number;
+    }) => trackEvent("webmcp_tool_called", props),
+  },
 };

--- a/apps/docs/lib/webmcp-tools.test.ts
+++ b/apps/docs/lib/webmcp-tools.test.ts
@@ -26,7 +26,11 @@ function fetchReturning(payload: unknown, ok = true, status = 200) {
 type Tracker = Parameters<typeof registerWebMcpTools>[2];
 
 function spyTracker() {
-  return { hostDetected: vi.fn(), toolCalled: vi.fn() };
+  return {
+    hostDetected: vi.fn(),
+    toolRegistered: vi.fn(),
+    toolCalled: vi.fn(),
+  };
 }
 
 function registeredTools(
@@ -396,6 +400,40 @@ describe("WebMCP call counter", () => {
     expect(tracker.toolCalled).not.toHaveBeenCalled();
   });
 
+  it("reports each tool's registration outcome without the error message", async () => {
+    const tracker = spyTracker();
+    const modelContext: WebMcpModelContext = {
+      registerTool: vi.fn((tool) =>
+        tool.name === "getDoc"
+          ? Promise.reject(
+              new DOMException("blocked by /docs policy", "NotAllowedError"),
+            )
+          : Promise.resolve(),
+      ),
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      registerWebMcpTools(
+        modelContext,
+        fetchReturning({ result: okResult }),
+        tracker,
+      );
+      await vi.waitFor(() =>
+        expect(tracker.toolRegistered).toHaveBeenCalledTimes(3),
+      );
+      expect(tracker.toolRegistered.mock.calls.map(([props]) => props)).toEqual(
+        [
+          { tool: "searchDocs", status: "ok" },
+          { tool: "getDoc", status: "failed", error_name: "NotAllowedError" },
+          { tool: "getExample", status: "ok" },
+        ],
+      );
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("reports successful searches with rounded latency", async () => {
     const tracker = spyTracker();
     const now = vi
@@ -487,11 +525,12 @@ describe("WebMCP call counter", () => {
         await expect(
           toolByName(fetchReturning({ result: okResult }), "searchDocs", {
             hostDetected: track,
+            toolRegistered: track,
             toolCalled: track,
           }).execute({ query: "tools" }),
         ).resolves.toEqual(okResult);
         await vi.waitFor(() =>
-          expect(warn).toHaveBeenCalledTimes(failure === "pending" ? 0 : 2),
+          expect(warn).toHaveBeenCalledTimes(failure === "pending" ? 0 : 5),
         );
       } finally {
         warn.mockRestore();

--- a/apps/docs/lib/webmcp-tools.test.ts
+++ b/apps/docs/lib/webmcp-tools.test.ts
@@ -23,7 +23,16 @@ function fetchReturning(payload: unknown, ok = true, status = 200) {
   }));
 }
 
-function registeredTools(fetchImpl: FetchLike) {
+type Tracker = Parameters<typeof registerWebMcpTools>[2];
+
+function spyTracker() {
+  return { hostDetected: vi.fn(), toolCalled: vi.fn() };
+}
+
+function registeredTools(
+  fetchImpl: FetchLike,
+  tracker: Tracker = spyTracker(),
+) {
   const tools: Parameters<WebMcpModelContext["registerTool"]>[0][] = [];
   registerWebMcpTools(
     {
@@ -33,12 +42,13 @@ function registeredTools(fetchImpl: FetchLike) {
       },
     },
     fetchImpl,
+    tracker,
   );
   return tools;
 }
 
-function toolByName(fetchImpl: FetchLike, name: string) {
-  const tool = registeredTools(fetchImpl).find((t) => t.name === name);
+function toolByName(fetchImpl: FetchLike, name: string, tracker?: Tracker) {
+  const tool = registeredTools(fetchImpl, tracker).find((t) => t.name === name);
   if (!tool) throw new Error(`missing tool ${name}`);
   return tool;
 }
@@ -366,6 +376,143 @@ describe("registerWebMcpTools lifecycle", () => {
       });
     } finally {
       warn.mockRestore();
+    }
+  });
+});
+
+describe("WebMCP call counter", () => {
+  it("reports host detection exactly once per registration", () => {
+    const tracker = spyTracker();
+    const fetchImpl = fetchReturning({ result: okResult });
+    registeredTools(fetchImpl, tracker);
+    expect(tracker.hostDetected.mock.calls).toEqual([[]]);
+    registeredTools(fetchImpl, tracker);
+    expect(tracker.hostDetected.mock.calls).toEqual([[], []]);
+    expect(tracker.toolCalled).not.toHaveBeenCalled();
+  });
+
+  it("reports successful searches with rounded latency", async () => {
+    const tracker = spyTracker();
+    const now = vi
+      .spyOn(performance, "now")
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(12.6);
+    try {
+      await expect(
+        toolByName(
+          fetchReturning({ result: okResult }),
+          "searchDocs",
+          tracker,
+        ).execute({ query: "tools" }),
+      ).resolves.toEqual(okResult);
+      expect(tracker.toolCalled).toHaveBeenCalledExactlyOnceWith({
+        tool: "searchDocs",
+        status: "ok",
+        latency_ms: 3,
+      });
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it("reports route isError results and passes them through", async () => {
+    const tracker = spyTracker();
+    const routeResult = errorResult("Page not found: nope");
+    await expect(
+      toolByName(
+        fetchReturning({ result: routeResult }),
+        "getDoc",
+        tracker,
+      ).execute({ path: "/docs/nope" }),
+    ).resolves.toEqual(routeResult);
+    expect(tracker.toolCalled).toHaveBeenCalledExactlyOnceWith({
+      tool: "getDoc",
+      status: "error",
+      latency_ms: expect.any(Number),
+    });
+  });
+
+  it("reports thrown non-abort errors after conversion to error results", async () => {
+    const tracker = spyTracker();
+    await expect(
+      toolByName(fetchReturning({}, false, 500), "searchDocs", tracker).execute(
+        { query: "tools" },
+      ),
+    ).resolves.toEqual(errorResult("Docs request failed with status 500"));
+    expect(tracker.toolCalled).toHaveBeenCalledExactlyOnceWith({
+      tool: "searchDocs",
+      status: "error",
+      latency_ms: expect.any(Number),
+    });
+  });
+
+  it("reports aborts and preserves the rejection reference", async () => {
+    const tracker = spyTracker();
+    const controller = new AbortController();
+    controller.abort();
+    const fetchImpl: FetchLike = async (_url, init) => {
+      init.signal?.throwIfAborted();
+      throw new Error("expected an aborted signal");
+    };
+    await expect(
+      toolByName(fetchImpl, "searchDocs", tracker).execute(
+        { query: "tools" },
+        { signal: controller.signal },
+      ),
+    ).rejects.toBe(controller.signal.reason);
+    expect(controller.signal.reason.name).toBe("AbortError");
+    expect(tracker.toolCalled).toHaveBeenCalledExactlyOnceWith({
+      tool: "searchDocs",
+      status: "aborted",
+      latency_ms: expect.any(Number),
+    });
+  });
+
+  it.each(["throwing", "pending"])(
+    "isolates a %s tracker from the tool result",
+    async (failure) => {
+      const track = vi.fn(() => {
+        if (failure === "throwing") throw new Error("tracking failed");
+        return new Promise<void>(() => {});
+      });
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        await expect(
+          toolByName(fetchReturning({ result: okResult }), "searchDocs", {
+            hostDetected: track,
+            toolCalled: track,
+          }).execute({ query: "tools" }),
+        ).resolves.toEqual(okResult);
+        expect(warn).toHaveBeenCalledTimes(failure === "throwing" ? 2 : 0);
+      } finally {
+        warn.mockRestore();
+      }
+    },
+  );
+
+  it("sends only tool, status, and latency for all three tools", async () => {
+    const tracker = spyTracker();
+    const tools = registeredTools(
+      fetchReturning({ result: okResult }),
+      tracker,
+    );
+    for (const tool of tools) {
+      await tool.execute({ query: "private query", path: "private/path" });
+    }
+    expect(tracker.toolCalled.mock.calls.map(([props]) => props.tool)).toEqual([
+      "searchDocs",
+      "getDoc",
+      "getExample",
+    ]);
+    for (const [props] of tracker.toolCalled.mock.calls) {
+      expect(Object.keys(props).sort()).toEqual([
+        "latency_ms",
+        "status",
+        "tool",
+      ]);
+      expect(props.status).toBe("ok");
+      expect(Number.isInteger(props.latency_ms)).toBe(true);
+      expect(props.latency_ms).toBeGreaterThanOrEqual(0);
     }
   });
 });

--- a/apps/docs/lib/webmcp-tools.test.ts
+++ b/apps/docs/lib/webmcp-tools.test.ts
@@ -354,6 +354,7 @@ describe("registerWebMcpTools lifecycle", () => {
     const cleanup = registerWebMcpTools(
       modelContext,
       fetchReturning({ result: okResult }),
+      spyTracker(),
     );
     expect(modelContext.registerTool).toHaveBeenCalledTimes(3);
     expect(signals).toHaveLength(3);
@@ -369,7 +370,11 @@ describe("registerWebMcpTools lifecycle", () => {
       const modelContext: WebMcpModelContext = {
         registerTool: vi.fn(() => Promise.reject(new Error("duplicate"))),
       };
-      registerWebMcpTools(modelContext, fetchReturning({ result: okResult }));
+      registerWebMcpTools(
+        modelContext,
+        fetchReturning({ result: okResult }),
+        spyTracker(),
+      );
       await vi.waitFor(() => {
         expect(modelContext.registerTool).toHaveBeenCalledTimes(3);
         expect(warn).toHaveBeenCalledTimes(3);
@@ -468,11 +473,13 @@ describe("WebMCP call counter", () => {
     });
   });
 
-  it.each(["throwing", "pending"])(
+  it.each(["throwing", "rejecting", "pending"])(
     "isolates a %s tracker from the tool result",
     async (failure) => {
       const track = vi.fn(() => {
-        if (failure === "throwing") throw new Error("tracking failed");
+        const error = new Error("tracking failed");
+        if (failure === "throwing") throw error;
+        if (failure === "rejecting") return Promise.reject(error);
         return new Promise<void>(() => {});
       });
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -483,7 +490,9 @@ describe("WebMCP call counter", () => {
             toolCalled: track,
           }).execute({ query: "tools" }),
         ).resolves.toEqual(okResult);
-        expect(warn).toHaveBeenCalledTimes(failure === "throwing" ? 2 : 0);
+        await vi.waitFor(() =>
+          expect(warn).toHaveBeenCalledTimes(failure === "pending" ? 0 : 2),
+        );
       } finally {
         warn.mockRestore();
       }

--- a/apps/docs/lib/webmcp-tools.ts
+++ b/apps/docs/lib/webmcp-tools.ts
@@ -318,13 +318,26 @@ export function registerWebMcpTools(
         },
         { signal: controller.signal },
       ),
-    ).catch((error) => {
-      // Registration failures (permissions policy, duplicate names, spec
-      // drift) must not break the page, but should be visible in development.
-      if (process.env.NODE_ENV !== "production") {
-        console.warn(`WebMCP: failed to register ${tool.name}`, error);
-      }
-    });
+    ).then(
+      () =>
+        trackSafely(`${tool.name} registration`, () =>
+          tracker.toolRegistered({ tool: tool.name, status: "ok" }),
+        ),
+      (error) => {
+        trackSafely(`${tool.name} registration`, () =>
+          tracker.toolRegistered({
+            tool: tool.name,
+            status: "failed",
+            error_name: error instanceof Error ? error.name : typeof error,
+          }),
+        );
+        // Registration failures (permissions policy, duplicate names, spec
+        // drift) must not break the page, but should be visible in development.
+        if (process.env.NODE_ENV !== "production") {
+          console.warn(`WebMCP: failed to register ${tool.name}`, error);
+        }
+      },
+    );
   }
   return () => {
     controller.abort();

--- a/apps/docs/lib/webmcp-tools.ts
+++ b/apps/docs/lib/webmcp-tools.ts
@@ -7,6 +7,7 @@ import {
   readPageTool,
   searchDocsTool,
 } from "@/lib/mcp-tool-definitions";
+import { analytics } from "./analytics";
 
 type WebMcpToolResult = {
   content: { type: string; text?: string }[];
@@ -14,7 +15,7 @@ type WebMcpToolResult = {
 };
 
 type WebMcpToolDescriptor = {
-  name: string;
+  name: "searchDocs" | "getDoc" | "getExample";
   description: string;
   inputSchema: Record<string, unknown>;
   annotations?: { readOnlyHint?: boolean };
@@ -148,6 +149,44 @@ const withErrorResults =
     }
   };
 
+type WebMcpTracker = typeof analytics.webmcp;
+
+function trackSafely(label: string, track: () => void) {
+  try {
+    track();
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(`WebMCP: failed to track ${label}`, error);
+    }
+  }
+}
+
+const withCallCounter =
+  (
+    tool: WebMcpToolDescriptor["name"],
+    execute: WebMcpToolDescriptor["execute"],
+    tracker: WebMcpTracker,
+  ): WebMcpToolDescriptor["execute"] =>
+  async (args, context) => {
+    const start = performance.now();
+    const report = (status: "ok" | "error" | "aborted") =>
+      trackSafely(tool, () =>
+        tracker.toolCalled({
+          tool,
+          status,
+          latency_ms: Math.round(performance.now() - start),
+        }),
+      );
+    try {
+      const result = await execute(args, context);
+      report(result.isError ? "error" : "ok");
+      return result;
+    } catch (error) {
+      report(isAbortError(error) ? "aborted" : "error");
+      throw error;
+    }
+  };
+
 function stringArg(args: Record<string, unknown>, key: string) {
   const value = args[key];
   return typeof value === "string" ? value.trim() : "";
@@ -259,12 +298,21 @@ function webMcpTools(fetchImpl: FetchLike): WebMcpToolDescriptor[] {
 export function registerWebMcpTools(
   modelContext: WebMcpModelContext,
   fetchImpl: FetchLike,
+  tracker: WebMcpTracker = analytics.webmcp,
 ): () => void {
+  trackSafely("host detection", () => tracker.hostDetected());
   const controller = new AbortController();
   for (const tool of webMcpTools(fetchImpl)) {
     Promise.resolve(
       modelContext.registerTool(
-        { ...tool, execute: withErrorResults(tool.execute) },
+        {
+          ...tool,
+          execute: withCallCounter(
+            tool.name,
+            withErrorResults(tool.execute),
+            tracker,
+          ),
+        },
         { signal: controller.signal },
       ),
     ).catch((error) => {

--- a/apps/docs/lib/webmcp-tools.ts
+++ b/apps/docs/lib/webmcp-tools.ts
@@ -152,12 +152,15 @@ const withErrorResults =
 type WebMcpTracker = typeof analytics.webmcp;
 
 function trackSafely(label: string, track: () => void) {
-  try {
-    track();
-  } catch (error) {
+  const warn = (error: unknown) => {
     if (process.env.NODE_ENV !== "production") {
       console.warn(`WebMCP: failed to track ${label}`, error);
     }
+  };
+  try {
+    Promise.resolve(track()).catch(warn);
+  } catch (error) {
+    warn(error);
   }
 }
 


### PR DESCRIPTION
The docs site has registered three WebMCP tools (`searchDocs`, `getDoc`, `getExample`) on every page since 2026-08-31, and we have no signal on whether any host ever calls them. #6720 (Origin-Trial token) means most Chrome stable users cannot even see them yet, so we want a baseline before the token ships and a way to read the change after it does.

This adds three PII-free events through the existing `trackEvent` path in `apps/docs/lib/analytics.ts`, so they land in the same PostHog project as the `search_*` and `assistant_*` events and the existing consent and Global Privacy Control gating applies unchanged. `webmcp_host_detected` fires once per `registerWebMcpTools` call (a WebMCP host was present on a docs page, the denominator). `webmcp_tool_registered` fires once per tool from the existing per-tool registration promise, so a supported browser with zero calls can be told apart from one where registration failed (asked for in review). `webmcp_tool_called` fires once per invocation, wrapped outside `withErrorResults` so it sees the final outcome. The wrapper lives in the docs app only; `packages/react/src/unstable/webmcp` is untouched. Tracking is fire-and-forget and wrapped in try/catch, so it never delays or alters the result returned to the host and a failing sink cannot throw into the tool. The tracker is an optional third argument defaulting to `analytics.webmcp`, so tests inject a spy and never touch `window.posthog`.

## What is sent

`webmcp_host_detected`: no properties.

`webmcp_tool_registered`:
- `tool`: `searchDocs` / `getDoc` / `getExample`
- `status`: `ok` / `failed`
- `error_name` (failed only): the rejection's `name` (for example `NotAllowedError`), or its `typeof` when it is not an Error. Never the message text.

`webmcp_tool_called`:
- `tool`: `searchDocs` / `getDoc` / `getExample`
- `status`: `ok` / `error` (route `isError` result or a converted transport error) / `aborted` (an `AbortError` rejection)
- `latency_ms`: integer

Never the arguments, the query, the path, the result text, or the page URL. A test asserts the exact key set of the call event for all three tools, and the registration test asserts the exact payloads for a mixed success/failure batch.

## Disclosures

- Consent gating undercounts: EEA/UK/CH visitors who have not accepted, and any GPC browser, produce no events. That is acceptable for a "does anyone use this at all" signal; exact counts would need a server-side path on `/api/mcp`, which is a separate decision and not in scope.
- The metric reads zero until #6720 lands. The host-detected event alone will show whether extension or flagged-Chrome traffic exists today.
- PostHog attaches its usual `$current_url` to every event; that is existing behaviour for every docs event and is covered by the privacy policy.
- Still owed after deploy: the manual check from `notes/research/webmcp-launch-checklist.md` (run the three tools in flagged Chrome, confirm the events show only `tool`, `status`, `latency_ms`, and confirm nothing fires when consent is declined), then PostHog insights for `webmcp_tool_registered` and `webmcp_tool_called` by `tool` and `status` next to `webmcp_host_detected`. The insight labels will say events, not unique users; none of these events identify a visitor.
- The internal `WebMcpToolDescriptor.name` type is narrowed from `string` to the three tool names so the `tool` property is typed. The type is not exported.

## Verification

- `apps/docs` vitest: 862 passed, 7 skipped; 11 new tests (`webmcp-tools.test.ts` 9, `analytics.test.ts` 2), the two touched files at 33/33.
- `tsc --noEmit` for `apps/docs`: identical to the `main` baseline (the same 19 pre-existing errors from the missing generated `next-env.d.ts`, zero new).
- oxlint and oxfmt clean.
- Review: a fresh-context leanness pass (ten trims applied, including collapsing the duplicated warn-and-swallow blocks and dropping a Promise wrapper the void-typed tracker made dead) followed by a gpt-6-astra review of the reworked diff that signed off with no findings. The registration event went through the same two passes (Claude fresh-context, then astra); both signed off.

No changeset: `apps/docs` is not a published package.

No issue precedes this; it is instrumentation for the docs app, not library surface. If you would rather not instrument, say so and I will close it.

Refs #6720

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.gmQhlyLxTLLvKnoGnSvs5Yo5UY4jmRLOBQeCgh-D9cO__yCrSiKicJlcN7M?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
