### PR TITLE
fix(core): cancel removed cloud attachment uploads

### DIFF
--- a/.changeset/fuzzy-cloud-uploads.md
+++ b/.changeset/fuzzy-cloud-uploads.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: cancel cloud attachment uploads when the attachment is removed

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
@@ -193,7 +193,7 @@ describe("CloudFileAttachmentAdapter", () => {
       "https://storage.example/upload",
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
-    expect(vi.mocked(fetchMock).mock.calls[0]?.[1]?.signal.aborted).toBe(true);
+    expect(vi.mocked(fetchMock).mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
 
     await expect(completion).resolves.toEqual({ done: true, value: undefined });
     expect(errorSpy).not.toHaveBeenCalled();

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
@@ -167,8 +167,16 @@ describe("CloudFileAttachmentAdapter", () => {
   });
 
   it("does not finish an upload removed during the file request", async () => {
-    const response = deferred<{ ok: boolean }>();
-    const fetchMock = vi.fn().mockReturnValue(response.promise);
+    const fetchMock = vi.fn((_url: string, init: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init.signal!.addEventListener(
+          "abort",
+          () =>
+            reject(new DOMException("The operation was aborted", "AbortError")),
+          { once: true },
+        );
+      });
+    });
     vi.stubGlobal("fetch", fetchMock);
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const adapter = new CloudFileAttachmentAdapter(makeCloud());
@@ -186,7 +194,6 @@ describe("CloudFileAttachmentAdapter", () => {
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(vi.mocked(fetchMock).mock.calls[0]?.[1]?.signal.aborted).toBe(true);
-    response.resolve({ ok: true });
 
     await expect(completion).resolves.toEqual({ done: true, value: undefined });
     expect(errorSpy).not.toHaveBeenCalled();

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
@@ -3,6 +3,14 @@ import type { AssistantCloud } from "assistant-cloud";
 import type { PendingAttachment } from "../../../types/attachment";
 import { CloudFileAttachmentAdapter } from "./CloudFileAttachmentAdapter";
 
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
 const makeCloud = () =>
   ({
     files: {
@@ -121,6 +129,68 @@ describe("CloudFileAttachmentAdapter", () => {
       uploadError,
     );
     await expect(adapter.send(yields.at(-1)!)).rejects.toThrow(
+      "Attachment not uploaded",
+    );
+  });
+
+  it("does not finish an upload removed while requesting its URL", async () => {
+    const presigned = deferred<{
+      signedUrl: string;
+      publicUrl: string;
+    }>();
+    const cloud = makeCloud();
+    vi.mocked(cloud.files.generatePresignedUploadUrl).mockReturnValue(
+      presigned.promise,
+    );
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    const adapter = new CloudFileAttachmentAdapter(cloud);
+    const generator = adapter.add({ file: makeFile() });
+
+    const running = await generator.next();
+    const completion = generator.next();
+    await vi.waitFor(() => {
+      expect(cloud.files.generatePresignedUploadUrl).toHaveBeenCalledOnce();
+    });
+
+    await adapter.remove(running.value!);
+    presigned.resolve({
+      signedUrl: "https://storage.example/upload",
+      publicUrl: "https://cdn.example/file.png",
+    });
+
+    await expect(completion).resolves.toEqual({ done: true, value: undefined });
+    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(adapter.send(running.value!)).rejects.toThrow(
+      "Attachment not uploaded",
+    );
+  });
+
+  it("does not finish an upload removed during the file request", async () => {
+    const response = deferred<{ ok: boolean }>();
+    const fetchMock = vi.fn().mockReturnValue(response.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const adapter = new CloudFileAttachmentAdapter(makeCloud());
+    const generator = adapter.add({ file: makeFile() });
+
+    const running = await generator.next();
+    const completion = generator.next();
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    await adapter.remove(running.value!);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://storage.example/upload",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(vi.mocked(fetchMock).mock.calls[0]?.[1]?.signal.aborted).toBe(true);
+    response.resolve({ ok: true });
+
+    await expect(completion).resolves.toEqual({ done: true, value: undefined });
+    expect(errorSpy).not.toHaveBeenCalled();
+    await expect(adapter.send(running.value!)).rejects.toThrow(
       "Attachment not uploaded",
     );
   });

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
@@ -30,7 +30,7 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
   private uploadedUrls = new Map<string, string>();
   private activeUploads = new Map<
     string,
-    { cancelled: boolean; controller: AbortController | undefined }
+    { cancelled: boolean; controller: AbortController }
   >();
 
   public async *add({
@@ -48,10 +48,7 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
       file,
       status: { type: "running", reason: "uploading", progress: 0 },
     };
-    const controller =
-      typeof AbortController === "undefined"
-        ? undefined
-        : new AbortController();
+    const controller = new AbortController();
     const upload = { cancelled: false, controller };
     this.activeUploads.set(id, upload);
 
@@ -72,7 +69,7 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
           "Content-Type": file.type,
         },
         mode: "cors",
-        ...(controller ? { signal: controller.signal } : undefined),
+        signal: controller.signal,
       });
       if (upload.cancelled) return;
 
@@ -111,7 +108,7 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
     const upload = this.activeUploads.get(attachment.id);
     if (upload) {
       upload.cancelled = true;
-      upload.controller?.abort();
+      upload.controller.abort();
       this.activeUploads.delete(attachment.id);
     }
     this.uploadedUrls.delete(attachment.id);

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
@@ -28,6 +28,10 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
   }
 
   private uploadedUrls = new Map<string, string>();
+  private activeUploads = new Map<
+    string,
+    { cancelled: boolean; controller: AbortController | undefined }
+  >();
 
   public async *add({
     file,
@@ -44,13 +48,23 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
       file,
       status: { type: "running", reason: "uploading", progress: 0 },
     };
-    yield attachment;
+    const controller =
+      typeof AbortController === "undefined"
+        ? undefined
+        : new AbortController();
+    const upload = { cancelled: false, controller };
+    this.activeUploads.set(id, upload);
 
     try {
+      yield attachment;
+      if (upload.cancelled) return;
+
       const { signedUrl, publicUrl } =
         await this.getCloud().files.generatePresignedUploadUrl({
           filename: file.name,
         });
+      if (upload.cancelled) return;
+
       const res = await fetch(signedUrl, {
         method: "PUT",
         body: file,
@@ -58,7 +72,10 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
           "Content-Type": file.type,
         },
         mode: "cors",
+        ...(controller ? { signal: controller.signal } : undefined),
       });
+      if (upload.cancelled) return;
+
       if (!res.ok) {
         throw new Error(
           `Failed to upload file: ${res.status} ${res.statusText}`,
@@ -71,6 +88,8 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
       };
       yield attachment;
     } catch (error) {
+      if (upload.cancelled) return;
+
       console.error("[assistant-ui] Failed to upload attachment:", error);
       attachment = {
         ...attachment,
@@ -81,10 +100,20 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
         },
       };
       yield attachment;
+    } finally {
+      if (this.activeUploads.get(id) === upload) {
+        this.activeUploads.delete(id);
+      }
     }
   }
 
   public async remove(attachment: Attachment): Promise<void> {
+    const upload = this.activeUploads.get(attachment.id);
+    if (upload) {
+      upload.cancelled = true;
+      upload.controller?.abort();
+      this.activeUploads.delete(attachment.id);
+    }
     this.uploadedUrls.delete(attachment.id);
   }
 


### PR DESCRIPTION
## Problem

Removing a cloud attachment while its upload is still running hides it from the composer, but the pending upload can later repopulate the adapter URL cache. A retained attachment object can then still be sent.

On current main, the reproduction in #7214 completes with a ready attachment and returns the uploaded URL after `remove()`.

## Root cause

`remove()` only deletes an URL that is already cached. The asynchronous `add()` path stores the public URL after the presign and upload requests finish, without checking whether that attachment was removed during either await.

## Change

Track each active upload before yielding its running attachment. Removal now marks that operation cancelled, aborts the upload request when `AbortController` is available, deletes cached state, and prevents later async completions from storing or yielding the attachment.

Intentional removal exits quietly instead of reporting an upload failure. Other uploads remain independent because operation state is keyed by attachment ID.

Closes #7214.

## Verification

- `CloudFileAttachmentAdapter.test.ts`: 6 tests passed
- Added a presigned-URL race regression that proves the upload request never starts after removal
- Added an in-flight upload regression that proves removal aborts the request, yields no completed attachment, logs no upload error, and leaves `send()` unavailable
- Focused oxlint passed
- Focused oxfmt check passed
- The reproduction fails without the cancellation guard and passes with it

## Public surface

- Package: `@assistant-ui/core`
- Exports: no changes
- Documentation and API reference: no changes
- Changeset: patch

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.t_DfzJvW0Not7LYWmWPsQ-NMFHsv6wuQg7tCwKzkEgT3tCvjgu09xiIIUTs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->