### PR TITLE
fix(core): contain thread ID callback errors

### DIFF
--- a/.changeset/calm-thread-callbacks.md
+++ b/.changeset/calm-thread-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: isolate thread ID change callback errors from completed switches

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -1951,18 +1951,22 @@ describe("RemoteThreadList", () => {
       onThreadIdChange,
     );
     const threads = handle.getClient().threads;
-    await threads.getLoadThreadsPromise();
+    try {
+      await threads.getLoadThreadsPromise();
 
-    flushTapSync(() => threads.switchToThread("t1"));
+      flushTapSync(() => threads.switchToThread("t1"));
 
-    await vi.waitFor(() => {
-      expect(handle.getClient().threads.getState().mainThreadId).toBe("t1");
-      expect(onThreadIdChange).toHaveBeenCalledExactlyOnceWith("t1");
-      expect(errorSpy).toHaveBeenCalledWith(
-        "[assistant-ui] onThreadIdChange callback threw an error",
-        callbackError,
-      );
-    });
-    handle.destroy();
+      await vi.waitFor(() => {
+        expect(handle.getClient().threads.getState().mainThreadId).toBe("t1");
+        expect(onThreadIdChange).toHaveBeenCalledExactlyOnceWith("t1");
+        expect(errorSpy).toHaveBeenCalledWith(
+          "[assistant-ui] onThreadIdChange callback threw an error",
+          callbackError,
+        );
+      });
+    } finally {
+      handle.destroy();
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -118,8 +118,9 @@ const mountList = (
   refetch?: () => Promise<void>,
   onSwitchToThread?: (id: string) => void,
   onDelete?: (id: string) => void,
+  providedOnThreadIdChange?: (id: string | undefined) => void,
 ) => {
-  const onThreadIdChange = vi.fn();
+  const onThreadIdChange = providedOnThreadIdChange ?? vi.fn();
   const handle = createAssistantClient(
     AuiConfig({
       threads: RemoteThreadList({
@@ -1926,6 +1927,41 @@ describe("RemoteThreadList", () => {
     await aui.threads.item("main").initialize();
     await vi.waitFor(() => {
       expect(onThreadIdChange).toHaveBeenCalledWith(`remote-${localId}`);
+    });
+    handle.destroy();
+  });
+
+  it("keeps a completed switch when onThreadIdChange throws", async () => {
+    const callbackError = new Error("host callback failed");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const onThreadIdChange = vi.fn(() => {
+      throw callbackError;
+    });
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [{ status: "regular" as const, remoteId: "t1", title: "One" }],
+      })),
+    });
+    const { handle } = mountList(
+      adapter,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      onThreadIdChange,
+    );
+    const threads = handle.getClient().threads;
+    await threads.getLoadThreadsPromise();
+
+    flushTapSync(() => threads.switchToThread("t1"));
+
+    await vi.waitFor(() => {
+      expect(handle.getClient().threads.getState().mainThreadId).toBe("t1");
+      expect(onThreadIdChange).toHaveBeenCalledExactlyOnceWith("t1");
+      expect(errorSpy).toHaveBeenCalledWith(
+        "[assistant-ui] onThreadIdChange callback threw an error",
+        callbackError,
+      );
     });
     handle.destroy();
   });

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -57,6 +57,7 @@ import {
   startThreadTitleRename,
   type ThreadTitleState,
 } from "../../runtimes/remote-thread-list/title-generation";
+import { invokeUserCallback } from "../../utils/invoke-user-callback";
 
 const RESOLVED_PROMISE = Promise.resolve();
 
@@ -550,7 +551,14 @@ const useRemoteThreadList = (
     (remoteId: string | undefined, emit: boolean) => {
       if (session.lastNotifiedRemoteId === remoteId) return;
       session.lastNotifiedRemoteId = remoteId;
-      if (emit) session.onThreadIdChange?.(remoteId);
+      if (emit) {
+        invokeUserCallback(
+          "assistant-ui",
+          "onThreadIdChange",
+          session.onThreadIdChange,
+          remoteId,
+        );
+      }
     },
     [session],
   );
@@ -1255,7 +1263,12 @@ const useRemoteThreadList = (
   useEffect(() => {
     if (session.lastNotifiedRemoteId === mainRemoteId) return;
     session.lastNotifiedRemoteId = mainRemoteId;
-    onThreadIdChange?.(mainRemoteId);
+    invokeUserCallback(
+      "assistant-ui",
+      "onThreadIdChange",
+      onThreadIdChange,
+      mainRemoteId,
+    );
   }, [mainRemoteId, onThreadIdChange, session]);
 
   useEffect(() => {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -58,6 +58,7 @@ import { useAui } from "@assistant-ui/store";
 import type { ModelContextProvider } from "../../model-context/types";
 import { RuntimeAdapterProvider } from "./RuntimeAdapterProvider";
 import { useStableRuntimeAdapters } from "./useRuntimeAdapters";
+import { invokeUserCallback } from "../../utils/invoke-user-callback";
 
 const threadNotFoundError = (threadIdOrRemoteId: string, action: string) =>
   new Error(`Thread "${threadIdOrRemoteId}" not found while ${action}.`);
@@ -573,7 +574,12 @@ export class RemoteThreadListThreadListRuntimeCore
     if (this._lastNotifiedThreadId === threadId) return;
     this._lastNotifiedThreadId = threadId;
     if (emit) {
-      this._options.onThreadIdChange?.(threadId);
+      invokeUserCallback(
+        "assistant-ui",
+        "onThreadIdChange",
+        this._options.onThreadIdChange,
+        threadId,
+      );
     }
   }
 

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
@@ -109,7 +109,7 @@ export const useRemoteThreadListRuntime = (
   );
 
   const onThreadIdChange = useEffectEvent((threadId: string | undefined) => {
-    options.onThreadIdChange?.(threadId);
+    return options.onThreadIdChange?.(threadId);
   });
 
   const stableOptions = useMemo<RemoteThreadListOptions>(

--- a/packages/core/src/tests/remote-thread-list-reactive-threadId.test.ts
+++ b/packages/core/src/tests/remote-thread-list-reactive-threadId.test.ts
@@ -92,43 +92,51 @@ describe("onThreadIdChange", () => {
   it("does not reject a completed switch when the callback throws", async () => {
     const callbackError = new Error("host callback failed");
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const cb = vi.fn(() => {
-      throw callbackError;
-    });
-    const { core } = createCoreWithCallback(cb);
-    await flush();
+    try {
+      const cb = vi.fn(() => {
+        throw callbackError;
+      });
+      const { core } = createCoreWithCallback(cb);
+      await flush();
 
-    await expect(core.switchToThread("existing-1")).resolves.toBeUndefined();
+      await expect(core.switchToThread("existing-1")).resolves.toBeUndefined();
 
-    expect(core.mainThreadId).toBe("existing-1");
-    expect(cb).toHaveBeenCalledExactlyOnceWith("existing-1");
-    expect(errorSpy).toHaveBeenCalledWith(
-      "[assistant-ui] onThreadIdChange callback threw an error",
-      callbackError,
-    );
+      expect(core.mainThreadId).toBe("existing-1");
+      expect(cb).toHaveBeenCalledExactlyOnceWith("existing-1");
+      expect(errorSpy).toHaveBeenCalledWith(
+        "[assistant-ui] onThreadIdChange callback threw an error",
+        callbackError,
+      );
 
-    await expect(core.switchToThread("existing-2")).resolves.toBeUndefined();
-    expect(core.mainThreadId).toBe("existing-2");
-    expect(cb).toHaveBeenLastCalledWith("existing-2");
+      await expect(core.switchToThread("existing-2")).resolves.toBeUndefined();
+      expect(core.mainThreadId).toBe("existing-2");
+      expect(cb).toHaveBeenLastCalledWith("existing-2");
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("contains a rejected callback promise", async () => {
     const callbackError = new Error("async host callback failed");
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const cb = vi.fn(async () => {
-      throw callbackError;
-    });
-    const { core } = createCoreWithCallback(cb);
-    await flush();
+    try {
+      const cb = vi.fn(async () => {
+        throw callbackError;
+      });
+      const { core } = createCoreWithCallback(cb);
+      await flush();
 
-    await expect(core.switchToThread("existing-1")).resolves.toBeUndefined();
-    await vi.waitFor(() => {
-      expect(errorSpy).toHaveBeenCalledWith(
-        "[assistant-ui] onThreadIdChange callback threw an error",
-        callbackError,
-      );
-    });
+      await expect(core.switchToThread("existing-1")).resolves.toBeUndefined();
+      await vi.waitFor(() => {
+        expect(errorSpy).toHaveBeenCalledWith(
+          "[assistant-ui] onThreadIdChange callback threw an error",
+          callbackError,
+        );
+      });
 
-    expect(core.mainThreadId).toBe("existing-1");
+      expect(core.mainThreadId).toBe("existing-1");
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/packages/core/src/tests/remote-thread-list-reactive-threadId.test.ts
+++ b/packages/core/src/tests/remote-thread-list-reactive-threadId.test.ts
@@ -88,4 +88,47 @@ describe("onThreadIdChange", () => {
       expect(emitted).not.toBe(localId);
     }
   });
+
+  it("does not reject a completed switch when the callback throws", async () => {
+    const callbackError = new Error("host callback failed");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cb = vi.fn(() => {
+      throw callbackError;
+    });
+    const { core } = createCoreWithCallback(cb);
+    await flush();
+
+    await expect(core.switchToThread("existing-1")).resolves.toBeUndefined();
+
+    expect(core.mainThreadId).toBe("existing-1");
+    expect(cb).toHaveBeenCalledExactlyOnceWith("existing-1");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[assistant-ui] onThreadIdChange callback threw an error",
+      callbackError,
+    );
+
+    await expect(core.switchToThread("existing-2")).resolves.toBeUndefined();
+    expect(core.mainThreadId).toBe("existing-2");
+    expect(cb).toHaveBeenLastCalledWith("existing-2");
+  });
+
+  it("contains a rejected callback promise", async () => {
+    const callbackError = new Error("async host callback failed");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cb = vi.fn(async () => {
+      throw callbackError;
+    });
+    const { core } = createCoreWithCallback(cb);
+    await flush();
+
+    await expect(core.switchToThread("existing-1")).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        "[assistant-ui] onThreadIdChange callback threw an error",
+        callbackError,
+      );
+    });
+
+    expect(core.mainThreadId).toBe("existing-1");
+  });
 });

--- a/packages/core/src/tests/useRemoteThreadListRuntime-controlled.test.tsx
+++ b/packages/core/src/tests/useRemoteThreadListRuntime-controlled.test.tsx
@@ -269,6 +269,49 @@ describe("useRemoteThreadListRuntime controlled threadId", () => {
     expect(onThreadIdChange).toHaveBeenLastCalledWith(undefined);
   });
 
+  it("contains rejected callback promises on runtime-initiated switches", async () => {
+    const callbackError = new Error("async host callback failed");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const adapter = makeAdapter();
+    const onThreadIdChange = vi.fn(async () => {
+      throw callbackError;
+    });
+    const runtimeRef: RuntimeRef = { current: null };
+
+    const { unmount } = render(
+      <ControlledRuntime
+        adapter={adapter}
+        threadId="thread-a"
+        onThreadIdChange={onThreadIdChange}
+        runtimeRef={runtimeRef}
+      />,
+    );
+
+    try {
+      await waitForRemoteThread(runtimeRef, "thread-a");
+
+      await act(async () => {
+        await expect(
+          runtimeRef.current!.threads.switchToThread("thread-b"),
+        ).resolves.toBeUndefined();
+      });
+
+      await waitFor(() => {
+        expect(errorSpy).toHaveBeenCalledWith(
+          "[assistant-ui] onThreadIdChange callback threw an error",
+          callbackError,
+        );
+      });
+      expect(onThreadIdChange).toHaveBeenCalledExactlyOnceWith("thread-b");
+      expect(runtimeRef.current!.threads.mainItem.getState().remoteId).toBe(
+        "thread-b",
+      );
+    } finally {
+      unmount();
+      errorSpy.mockRestore();
+    }
+  });
+
   it("does not retain suppression after an initial switch fails", async () => {
     let threadAFetchCount = 0;
     const adapter = makeAdapter({


### PR DESCRIPTION
## Problem

A host `onThreadIdChange` callback can throw after a remote thread switch has already committed. The runtime then reports the switch as failed even though the selected thread and subscriber state already changed.

A direct reproduction on current main returned:

```json
{"outcome":"rejected: host callback failed","mainThreadId":"existing-1","remoteId":"existing-1"}
```

The legacy thread-list path invokes the same callback directly and can similarly interrupt the remaining switch notifications.

## Root cause

The current and legacy thread-list implementations update their last-notified marker and then call the host callback without the repository callback-isolation helper. The public `useRemoteThreadListRuntime` wrapper also discarded the callback return value, preventing asynchronous rejections from reaching that helper.

## Change

Route every current and legacy `onThreadIdChange` emission through `invokeUserCallback`, and preserve the callback return value through the public runtime wrapper.

The last-notified marker still updates before invocation, so a failing callback is reported once and does not enter a retry loop. Synchronous throws and rejected thenables are reported safely without changing the result of the completed switch.

Closes #7215.

## Verification

- `remote-thread-list-reactive-threadId.test.ts` and `RemoteThreadList.test.ts`: 59 tests passed
- Added current-runtime coverage for synchronous throws, rejected promises, and a later successful switch
- Added public `useRemoteThreadListRuntime` coverage for an asynchronously rejecting callback
- Added legacy coverage proving the selected thread remains committed when the callback throws
- Focused oxlint passed
- Focused oxfmt passed
- The direct reproduction rejects without this change and resolves with the selected thread intact after it

## Public surface

- Package: `@assistant-ui/core`
- Exports: no changes
- Documentation and API reference: no changes
- Changeset: patch

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.cx1QbOriKP0owJK9qxvL8dnFUqeu342_3TZmxM5NzOCZoNd-_jOmOxqghts?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
