### PR TITLE
fix(external-store): keep a cancelled run visible when the composer refuses the rollback

### DIFF
--- a/.changeset/cancelled-assistant-turn.md
+++ b/.changeset/cancelled-assistant-turn.md
@@ -1,5 +1,6 @@
 ---
 "@assistant-ui/core": patch
+"@assistant-ui/ai-sdk": patch
 ---
 
 fix(core): Keep a cancelled assistant turn when the composer refuses the cancel rollback.

--- a/.changeset/cancelled-assistant-turn.md
+++ b/.changeset/cancelled-assistant-turn.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): Keep a cancelled assistant turn when the composer refuses the cancel rollback.

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -211,6 +211,10 @@ Each handler enables a specific UI feature.
 | `onAddToolResult` | Client-side tool result handoff |
 | `queue` | Queueing messages sent while a run is in progress |
 
+### Stopping before the first output
+
+A cancel that lands while a run is in progress but before it produced anything rolls the turn back: the runtime moves the trailing user message into the composer and, on the deferred resync, removes it from your store through `setMessages`, so the prompt is ready to edit and resend. When the composer cannot take it (it already holds a draft, the adapter has no `setMessages`, or the message carries non-text content parts), the message stays in the thread and a cancelled assistant turn is shown under it until a new run starts, the tail changes, either message is deleted, or the thread is reset or imported. That turn lives only in the runtime: it is never passed to `setMessages`, exported, or persisted, and its regenerate button calls `onReload` with the user message as the parent.
+
 ## Streaming responses
 
 Stream by mutating the assistant message in place:

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -84,6 +84,63 @@ describe("useAISDKRuntime", () => {
     });
   });
 
+  it.each([true, false])(
+    "keeps pre-stream cancellation out of chat.messages with a busy composer: %s",
+    async (busy) => {
+      const user = {
+        id: "u1",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+      };
+      const chat = createChatHelpers([user]);
+      chat.status = "submitted";
+      chat.stop = vi.fn().mockResolvedValue(undefined);
+      const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+      act(() => {
+        if (busy) result.current.thread.composer.setText("draft");
+        result.current.thread.cancelRun();
+      });
+      await act(async () => {
+        await chat.stop.mock.results[0].value;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      rerender();
+      expect(chat.status).toBe("submitted");
+      expect(chat.messages).toEqual(busy ? [user] : []);
+      chat.status = "ready";
+      rerender();
+
+      const messages = result.current.thread.getState().messages;
+      expect(result.current.thread.composer.getState().text).toBe(
+        busy ? "draft" : "hello",
+      );
+      expect(chat.messages).toEqual(busy ? [user] : []);
+      if (!busy) {
+        expect(messages).toEqual([]);
+        return;
+      }
+      expect(messages).toHaveLength(2);
+      expect(messages[0]?.id).toBe("u1");
+      const marker = messages.at(-1)!;
+      expect(marker).toMatchObject({
+        role: "assistant",
+        content: [],
+        status: { type: "incomplete", reason: "cancelled" },
+      });
+      expect(chat.setMessages).toHaveBeenLastCalledWith([user]);
+      act(() => {
+        result.current.thread.startRun({
+          parentId: "u1",
+          sourceId: marker.id,
+          runConfig: {},
+        });
+      });
+      await waitFor(() => expect(chat.regenerate).toHaveBeenCalledTimes(1));
+      expect(chat.messages).toEqual([user]);
+      expect(chat.setMessages).toHaveBeenLastCalledWith([user]);
+    },
+  );
+
   it("sends a new user message through the runtime", async () => {
     const chat = createChatHelpers();
 

--- a/packages/ai-sdk/src/runtime/useExternalHistory.test.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.test.ts
@@ -749,6 +749,23 @@ describe("useExternalHistory persistence", () => {
     );
   });
 
+  it("skips a runtime-only cancelled turn instead of reporting an empty batch", async () => {
+    const { append, reportTelemetry, runCycle, flush } =
+      createPersistenceHarness(false);
+    const cancelledTurn = createAssistantMessage(
+      { type: "incomplete", reason: "cancelled" },
+      [],
+      "cancelled-turn",
+    );
+    cancelledTurn.metadata = { ...cancelledTurn.metadata, isOptimistic: true };
+
+    await runCycle([cancelledTurn]);
+    await flush();
+
+    expect(append).not.toHaveBeenCalled();
+    expect(reportTelemetry).not.toHaveBeenCalled();
+  });
+
   it("defers run telemetry until the paused message completes", async () => {
     const { reportTelemetry, runCycle, flush } = createPersistenceHarness(true);
     const pendingInnerMessage = { id: "inner-a", parts: ["pending"] };

--- a/packages/ai-sdk/src/runtime/useExternalHistory.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.ts
@@ -312,6 +312,11 @@ export const useExternalHistory = <TMessage>(
 
           for (const message of messages) {
             const innerMessages = getExternalStoreMessages<TMessage>(message);
+            // A runtime-only message (an optimistic node with nothing bound,
+            // such as the cancelled turn left by a refused cancel rollback)
+            // has nothing to persist or report.
+            if (message.metadata.isOptimistic && innerMessages.length === 0)
+              continue;
 
             const isTerminal =
               message.status === undefined ||

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -656,12 +656,16 @@ export class ExternalStoreThreadRuntimeCore
   public async append(rawMessage: AppendMessage): Promise<void> {
     // sourceId marks an edit send; the parent may coincide with the head
     // after a resync (e.g. cancelRun dropped the edited message).
+    // A host that computes the parent from its own store names the user
+    // message under the cancelled turn; both address the same tail.
+    const cancelledRun = this._cancelledRun;
     const isEdit =
       rawMessage.sourceId != null ||
-      rawMessage.parentId !== (this.messages.at(-1)?.id ?? null);
+      (rawMessage.parentId !== (this.messages.at(-1)?.id ?? null) &&
+        rawMessage.parentId !== cancelledRun?.parentId);
 
-    if (!isEdit && rawMessage.parentId === this._cancelledRun?.id) {
-      rawMessage = { ...rawMessage, parentId: this._cancelledRun.parentId };
+    if (!isEdit && cancelledRun && rawMessage.parentId === cancelledRun.id) {
+      rawMessage = { ...rawMessage, parentId: cancelledRun.parentId };
     }
 
     // A transformed-queue send is stamped at flush; any other queue's
@@ -866,6 +870,7 @@ export class ExternalStoreThreadRuntimeCore
    * without run-cancel semantics (`onCancel`, composer draft restoration).
    */
   public unstable_notifySessionReset(): void {
+    this._dropCancelledRun();
     this._runTrackerUpdate(() => this._toolInvocations?.reset());
     this._store.queue?.__internal_notifyCancelled?.();
   }
@@ -934,7 +939,7 @@ export class ExternalStoreThreadRuntimeCore
       this._addCancelledRunMessage(this._cancelledRun);
     }
     this._messages = this.repository.getMessages();
-    if (!movedLeaf) this._notifySubscribers();
+    this._notifySubscribers();
 
     // The resync commits what the cancel left (a kept optimistic message, the
     // restored branch) back to the store a macrotask later. The store may move

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -894,9 +894,10 @@ export class ExternalStoreThreadRuntimeCore
 
     observeAdapterCallback("onCancel", this._store.onCancel());
 
-    // A second stop re-evaluates the rollback from scratch, so a composer
-    // freed since the first one takes the prompt back.
-    this._dropCancelledRun();
+    // A second stop while the run is still reported re-evaluates the rollback
+    // from scratch, so a composer freed since the first one takes the prompt
+    // back; a stop after the host settled leaves the cancelled turn alone.
+    if (wasRunning) this._dropCancelledRun();
     this.dropEmptyOptimisticHead();
 
     const messages = this.repository.getMessages();
@@ -938,7 +939,10 @@ export class ExternalStoreThreadRuntimeCore
       this._cancelledRun = { id: generateId(), parentId: previousMessage.id };
       this._addCancelledRunMessage(this._cancelledRun);
     }
-    this._messages = this.repository.getMessages();
+    // Publish the placeholder drop now; a moved leaf stays visible until the
+    // resync commits its removal, so a host render in between does not flash
+    // it out and back in.
+    this._messages = movedLeaf ? messages : this.repository.getMessages();
     this._notifySubscribers();
 
     // The resync commits what the cancel left (a kept optimistic message, the

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -152,6 +152,7 @@ export class ExternalStoreThreadRuntimeCore
   // passes while the same tail message awaits its response so the placeholder
   // keeps one identity per response.
   private _optimistic: { id: string; parentId: string | null } | null = null;
+  private _cancelledRun: { id: string; parentId: string } | null = null;
 
   private _store!: ExternalStoreAdapter<any>;
 
@@ -250,6 +251,7 @@ export class ExternalStoreThreadRuntimeCore
       repositoryInstance !== undefined &&
       repositoryInstance !== this.repository;
     if (repositoryChanged) {
+      this._cancelledRun = null;
       this.repository = repositoryInstance;
       this._pendingDeleteEvictions.clear();
     }
@@ -260,7 +262,11 @@ export class ExternalStoreThreadRuntimeCore
         // the prefix gated against is the one the message lands on whatever
         // the host routes by. Queuing only ever accepts a tail append, so a
         // later tail is the same intent.
-        const parentId = this.messages.at(-1)?.id ?? null;
+        const tailId = this.messages.at(-1)?.id ?? null;
+        const parentId =
+          tailId === this._cancelledRun?.id
+            ? this._cancelledRun.parentId
+            : tailId;
         return this.enrichAppendMetadata({ ...message, parentId }, parentId);
       });
       if (store.queue?.__internal_setDispatchTransform)
@@ -465,6 +471,17 @@ export class ExternalStoreThreadRuntimeCore
     }
 
     if (optimisticId === null) this._optimistic = null;
+    if (
+      this._cancelledRun &&
+      ((!previousIsRunning && isRunning) ||
+        messages.at(-1)?.id !== this._cancelledRun.parentId)
+    ) {
+      this._cancelledRun = null;
+    }
+    if (optimisticId === null && this._cancelledRun) {
+      this._addCancelledRunMessage(this._cancelledRun);
+      optimisticId = this._cancelledRun.id;
+    }
     this.repository.resetHead(optimisticId ?? messages.at(-1)?.id ?? null);
 
     const messagesSnapshot = this.repository.getMessages();
@@ -643,6 +660,10 @@ export class ExternalStoreThreadRuntimeCore
       rawMessage.sourceId != null ||
       rawMessage.parentId !== (this.messages.at(-1)?.id ?? null);
 
+    if (!isEdit && rawMessage.parentId === this._cancelledRun?.id) {
+      rawMessage = { ...rawMessage, parentId: this._cancelledRun.parentId };
+    }
+
     // A transformed-queue send is stamped at flush; any other queue's
     // transform would gate against its own thread's messages, so those stamp
     // at send.
@@ -706,6 +727,11 @@ export class ExternalStoreThreadRuntimeCore
   }
 
   public async deleteMessage(messageId: string): Promise<void> {
+    if (messageId === this._cancelledRun?.id) {
+      this._dropCancelledRun();
+      return;
+    }
+
     if (this._store.onDelete) {
       // The host owns deletion here, and it may decline (fail a server call,
       // cancel a confirm dialog, ignore an off-branch id). The eviction is
@@ -732,6 +758,10 @@ export class ExternalStoreThreadRuntimeCore
     if (this._getEffectiveIsRunning(this._store)) {
       await this._toolInvocations?.abort();
     }
+
+    // The host-owned path above evicts on the confirming snapshot, which also
+    // clears the cancelled turn; a local delete of its parent drops it now.
+    if (messageId === this._cancelledRun?.parentId) this._dropCancelledRun();
 
     const messages = this.repository.getMessages();
     const messageIndex = messages.findIndex((m) => m.id === messageId);
@@ -788,6 +818,9 @@ export class ExternalStoreThreadRuntimeCore
       throw new Error("Runtime does not support reloading messages.");
 
     this._pendingDeleteEvictions.clear();
+    // A retry started before the host settles the stopped run must not
+    // resurface the cancelled turn if it ends without output.
+    this._dropCancelledRun();
 
     // Auto-abort in-flight client-side tool executions when a run reloads;
     // any results that land afterward would target a turn that no longer
@@ -838,6 +871,7 @@ export class ExternalStoreThreadRuntimeCore
   }
 
   public cancelRun(): void {
+    const wasRunning = this._effectiveIsRunning;
     if (!this._store.onCancel)
       throw new Error("Runtime does not support cancelling runs.");
 
@@ -855,6 +889,9 @@ export class ExternalStoreThreadRuntimeCore
 
     observeAdapterCallback("onCancel", this._store.onCancel());
 
+    // A second stop re-evaluates the rollback from scratch, so a composer
+    // freed since the first one takes the prompt back.
+    this._dropCancelledRun();
     this.dropEmptyOptimisticHead();
 
     const messages = this.repository.getMessages();
@@ -892,6 +929,11 @@ export class ExternalStoreThreadRuntimeCore
         movedLeaf = { id: trailingUserLeaf.id, draft };
       }
     }
+    if (!movedLeaf && wasRunning && previousMessage?.role === "user") {
+      this._cancelledRun = { id: generateId(), parentId: previousMessage.id };
+      this._addCancelledRunMessage(this._cancelledRun);
+    }
+    this._messages = this.repository.getMessages();
     if (!movedLeaf) this._notifySubscribers();
 
     // The resync commits what the cancel left (a kept optimistic message, the
@@ -918,11 +960,42 @@ export class ExternalStoreThreadRuntimeCore
     }, 0);
   }
 
-  // Placeholder or pre-stream message; a partially-streamed one is kept and
+  private _addCancelledRunMessage({
+    id,
+    parentId,
+  }: {
+    id: string;
+    parentId: string;
+  }): void {
+    this.repository.addOrUpdateMessage(
+      parentId,
+      fromThreadMessageLike(
+        { role: "assistant", content: [], metadata: { isOptimistic: true } },
+        id,
+        { type: "incomplete", reason: "cancelled" },
+      ),
+    );
+  }
+
+  // Clearing the record must also evict the node: a cancel resync still
+  // pending would otherwise commit it to the host once the filter is gone.
+  private _dropCancelledRun(): void {
+    if (!this._cancelledRun) return;
+    const { id } = this._cancelledRun;
+    this._cancelledRun = null;
+    this._evictDeletedMessage(id);
+  }
+
+  // Running placeholder or pre-stream message; a partially-streamed one is kept and
   // committed to the store by the cancel resync.
   private dropEmptyOptimisticHead(): void {
     const head = this.repository.getMessages().at(-1);
-    if (head && head.metadata.isOptimistic && head.content.length === 0) {
+    if (
+      head?.role === "assistant" &&
+      head.status.type === "running" &&
+      head.metadata.isOptimistic &&
+      head.content.length === 0
+    ) {
       this.repository.deleteMessage(head.id);
     }
   }
@@ -969,12 +1042,14 @@ export class ExternalStoreThreadRuntimeCore
   }
 
   public override reset(initialMessages?: readonly ThreadMessageLike[]) {
+    this._dropCancelledRun();
     const repo = new MessageRepository();
     repo.import(ExportedMessageRepository.fromArray(initialMessages ?? []));
     this.updateMessages(repo.getMessages());
   }
 
   public override import(data: ExportedMessageRepository) {
+    this._dropCancelledRun();
     super.import(data);
 
     if (this._store.onImport) {
@@ -983,6 +1058,8 @@ export class ExternalStoreThreadRuntimeCore
   }
 
   private updateMessages = (messages: readonly ThreadMessage[]) => {
+    const cancelledId = this._cancelledRun?.id;
+    if (cancelledId) messages = messages.filter((m) => m.id !== cancelledId);
     const hasConverter = this._store.convertMessage !== undefined;
     if (hasConverter) {
       this._store.setMessages?.(messages.flatMap(getExternalStoreMessages));

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -930,8 +930,10 @@ export class ExternalStoreThreadRuntimeCore
         attachments: trailingUserLeaf.attachments,
         quote: trailingUserLeaf.metadata.custom.quote as QuoteInfo | undefined,
       };
+      // The repository keeps the leaf until the resync commits its removal:
+      // subscribers notified below resolve every published id, and a host
+      // render in between would otherwise flash the prompt out and back in.
       if (this.composer.restoreDraft(draft)) {
-        this.repository.deleteMessage(trailingUserLeaf.id);
         movedLeaf = { id: trailingUserLeaf.id, draft };
       }
     }
@@ -939,10 +941,7 @@ export class ExternalStoreThreadRuntimeCore
       this._cancelledRun = { id: generateId(), parentId: previousMessage.id };
       this._addCancelledRunMessage(this._cancelledRun);
     }
-    // Publish the placeholder drop now; a moved leaf stays visible until the
-    // resync commits its removal, so a host render in between does not flash
-    // it out and back in.
-    this._messages = movedLeaf ? messages : this.repository.getMessages();
+    this._messages = this.repository.getMessages();
     this._notifySubscribers();
 
     // The resync commits what the cancel left (a kept optimistic message, the

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -325,6 +325,42 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       expect(core.messages).toEqual([user]);
     });
 
+    it("keeps the cancelled turn across an explicit switch onto its branch", async () => {
+      const { core, adapter, user } = stopBeforeStream();
+      const markerId = expectCancelledTurn(core);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [user],
+      });
+      for (const target of ["u1", markerId]) {
+        core.switchToBranch(target);
+        expect(adapter.setMessages).toHaveBeenLastCalledWith([user]);
+        core.__internal_setAdapter({
+          ...adapter,
+          isRunning: false,
+          messages: [user],
+        });
+        expect(expectCancelledTurn(core)).toBe(markerId);
+      }
+    });
+
+    it("keeps the cancelled turn when stopped again after the host settled", async () => {
+      const { core, adapter, user } = stopBeforeStream();
+      const markerId = expectCancelledTurn(core);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [user],
+      });
+      core.cancelRun();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(expectCancelledTurn(core)).toBe(markerId);
+      expect(core.composer.text).toBe("draft");
+    });
+
     it("does not leave a cancelled turn when stopped while idle", async () => {
       const { core, user } = stopBeforeStream({ isRunning: false });
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -437,10 +473,16 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
       core.composer.setText("");
       core.cancelRun();
+      expect(core.messages).toEqual([user]);
       await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(core.messages).toEqual([]);
       expect(core.composer.text).toBe(getThreadMessageText(user));
       expect(adapter.setMessages).toHaveBeenLastCalledWith([]);
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [],
+      });
+      expect(core.messages).toEqual([]);
     });
 
     it.each(["cancelled turn", "user parent"] as const)(
@@ -923,7 +965,10 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
 
       core.cancelRun();
-      expect(core.messages).toEqual([]);
+      // the placeholder is gone at once; the prompt stays until the resync
+      expect(core.messages).toEqual([userMessage]);
+      core.__internal_setAdapter({ ...adapter, isRunning: false });
+      expect(core.messages).toEqual([userMessage]);
 
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(adapter.setMessages).toHaveBeenLastCalledWith([]);

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -7,6 +7,7 @@ import type { ExternalStoreAdapter } from "../runtimes/external-store/external-s
 import type { ModelContextProvider } from "../model-context/types";
 import type { AppendMessage, ThreadMessage } from "../types/message";
 import { createMessageQueue } from "../runtime/queue/message-queue";
+import { MessageRepository } from "../runtime/utils/message-repository";
 import { getThreadMessageText } from "../utils/text";
 import { invalidateThreadRuntime } from "../runtime/utils/thread-runtime-lifecycle";
 
@@ -216,6 +217,310 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
   });
 
   describe("cancelRun", () => {
+    const stopBeforeStream = (
+      overrides: Partial<ExternalStoreAdapter<ThreadMessage>> = {},
+    ) => {
+      const user = createUserMessage("u1", "hello");
+      const adapter = createBaseAdapter({
+        messages: [user],
+        isRunning: true,
+        onCancel: vi.fn(),
+        setMessages: vi.fn(),
+        onReload: vi.fn(),
+        onEdit: vi.fn(),
+        ...overrides,
+      });
+      const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
+      core.composer.setText("draft");
+      core.cancelRun();
+      return { core, adapter, user };
+    };
+
+    const expectCancelledTurn = (core: ExternalStoreThreadRuntimeCore) => {
+      expect(core.messages).toHaveLength(2);
+      expect(core.messages[0]?.id).toBe("u1");
+      const marker = core.messages[1]!;
+      expect(marker).toMatchObject({
+        role: "assistant",
+        content: [],
+        status: { type: "incomplete", reason: "cancelled" },
+        metadata: { isOptimistic: true },
+      });
+      expect(core.getMessageById(marker.id)?.parentId).toBe("u1");
+      return marker.id;
+    };
+
+    it.each([
+      "assistant",
+      "user",
+      "session reset",
+      "reset",
+      "import",
+      "repository",
+    ] as const)(
+      "keeps the cancelled turn across snapshots until the %s changes",
+      async (change) => {
+        const { core, adapter, user } = stopBeforeStream();
+        const markerId = expectCancelledTurn(core);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        const settled = { ...adapter, isRunning: false, messages: [user] };
+        core.__internal_setAdapter(settled);
+        expect(expectCancelledTurn(core)).toBe(markerId);
+        core.__internal_setAdapter({ ...settled });
+        expect(expectCancelledTurn(core)).toBe(markerId);
+        if (change === "repository") {
+          const replacement = new MessageRepository();
+          core.__internal_setAdapter({
+            ...settled,
+            unstable_messageRepositoryInstance: replacement,
+          });
+          expect(core.messages.map((m) => m.id)).toEqual(["u1"]);
+        } else {
+          const messages =
+            change === "assistant"
+              ? [user, createAssistantMessage("a1")]
+              : change === "user"
+                ? [user, createUserMessage("u2")]
+                : change === "import"
+                  ? [user]
+                  : [];
+          if (change === "session reset") core.unstable_notifySessionReset();
+          if (change === "reset") core.reset();
+          if (change === "import") core.import(core.export());
+          core.__internal_setAdapter({ ...settled, messages });
+          expect(core.messages).toEqual(messages);
+        }
+        core.__internal_setAdapter(settled);
+        expect(core.messages).toEqual([user]);
+      },
+    );
+
+    it("keeps the cancelled turn when the host settles late", async () => {
+      const { core, adapter, user } = stopBeforeStream();
+      const markerId = expectCancelledTurn(core);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: true,
+        messages: [user],
+      });
+      expect(core.messages.at(-1)).toMatchObject({
+        status: { type: "running" },
+      });
+      expect(core.messages.at(-1)?.id).not.toBe(markerId);
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [user],
+      });
+      expect(expectCancelledTurn(core)).toBe(markerId);
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: true,
+        messages: [user],
+      });
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [user],
+      });
+      expect(core.messages).toEqual([user]);
+    });
+
+    it("does not leave a cancelled turn when stopped while idle", async () => {
+      const { core, user } = stopBeforeStream({ isRunning: false });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(core.messages).toEqual([user]);
+    });
+
+    it("deletes the cancelled turn with its user parent without restoring it on a snapshot", async () => {
+      const { core, adapter } = stopBeforeStream();
+      expectCancelledTurn(core);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await core.deleteMessage("u1");
+      expect(core.messages).toEqual([]);
+      expect(adapter.setMessages).toHaveBeenLastCalledWith([]);
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [],
+      });
+      expect(core.messages).toEqual([]);
+    });
+
+    it("keeps the cancelled turn until the host confirms the parent deletion", async () => {
+      const { core, adapter, user } = stopBeforeStream({ onDelete: vi.fn() });
+      const markerId = expectCancelledTurn(core);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await core.deleteMessage("u1");
+      expect(expectCancelledTurn(core)).toBe(markerId);
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [user],
+      });
+      expect(expectCancelledTurn(core)).toBe(markerId);
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [],
+      });
+      expect(core.messages).toEqual([]);
+    });
+
+    it("does not commit the cancelled turn when a reset races the resync", async () => {
+      const { core, adapter } = stopBeforeStream();
+      const markerId = expectCancelledTurn(core);
+      core.reset();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const committed = vi
+        .mocked(adapter.setMessages!)
+        .mock.calls.flatMap(([messages]) => messages.map((m) => m.id));
+      expect(committed).not.toContain(markerId);
+    });
+
+    it("retries the cancelled turn from its user parent", async () => {
+      const { core, adapter, user } = stopBeforeStream();
+      const markerId = expectCancelledTurn(core);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await core.startRun({
+        parentId: "u1",
+        sourceId: markerId,
+        runConfig: {},
+      });
+      expect(adapter.onReload).toHaveBeenCalledWith("u1", {
+        parentId: "u1",
+        sourceId: markerId,
+        runConfig: {},
+      });
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: true,
+        messages: [user],
+      });
+      expect(core.messages.at(-1)).toMatchObject({
+        status: { type: "running" },
+      });
+      expect(core.messages.at(-1)?.id).not.toBe(markerId);
+      const reply = createAssistantMessage("a1");
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [user, reply],
+      });
+      expect(core.messages).toEqual([user, reply]);
+    });
+
+    it("does not resurface the cancelled turn for a retry started before the host settles", async () => {
+      const { core, adapter, user } = stopBeforeStream();
+      const markerId = expectCancelledTurn(core);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await core.startRun({
+        parentId: "u1",
+        sourceId: markerId,
+        runConfig: {},
+      });
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: true,
+        messages: [user],
+      });
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [user],
+      });
+      expect(core.messages).toEqual([user]);
+    });
+
+    it("restores the prompt on a second stop once the composer is free", async () => {
+      const { core, adapter, user } = stopBeforeStream();
+      expectCancelledTurn(core);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      core.composer.setText("");
+      core.cancelRun();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(core.messages).toEqual([]);
+      expect(core.composer.text).toBe(getThreadMessageText(user));
+      expect(adapter.setMessages).toHaveBeenLastCalledWith([]);
+    });
+
+    it("sends after the cancelled turn using its user parent without editing", async () => {
+      const { core, adapter, user } = stopBeforeStream();
+      const markerId = expectCancelledTurn(core);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [user],
+      });
+      await core.append({
+        role: "user",
+        createdAt: new Date(),
+        metadata: { custom: {} },
+        parentId: markerId,
+        content: [{ type: "text", text: "next" }],
+        attachments: [],
+        runConfig: {},
+        sourceId: null,
+      });
+      expect(adapter.onNew).toHaveBeenCalledWith(
+        expect.objectContaining({ parentId: "u1" }),
+      );
+      expect(adapter.onEdit).not.toHaveBeenCalled();
+    });
+
+    it("dispatches queued sends from the cancelled turn's user parent", async () => {
+      const run = vi.fn();
+      const queue = createMessageQueue({ run });
+      const { core, adapter, user } = stopBeforeStream({
+        queue: queue.adapter,
+      });
+      const markerId = expectCancelledTurn(core);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [user],
+      });
+      await core.append({
+        role: "user",
+        createdAt: new Date(),
+        metadata: { custom: {} },
+        parentId: markerId,
+        sourceId: null,
+        runConfig: {},
+        content: [{ type: "text", text: "next" }],
+        attachments: [],
+      });
+      expect(run).toHaveBeenCalledWith(
+        expect.objectContaining({ parentId: "u1" }),
+        { steer: false },
+      );
+      expect(adapter.onEdit).not.toHaveBeenCalled();
+    });
+
+    it("deletes the cancelled turn locally without restoring it on a snapshot", async () => {
+      const onDelete = vi.fn();
+      const { core, adapter, user } = stopBeforeStream({ onDelete });
+      const markerId = expectCancelledTurn(core);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      vi.mocked(adapter.setMessages!).mockClear();
+      const notified = vi.fn(() => core.messages.map((m) => m.id));
+      core.subscribe(notified);
+      await core.deleteMessage(markerId);
+      expect(core.messages).toEqual([user]);
+      expect(notified).toHaveLastReturnedWith(["u1"]);
+      expect(onDelete).not.toHaveBeenCalled();
+      expect(adapter.setMessages).not.toHaveBeenCalled();
+      core.__internal_setAdapter({
+        ...adapter,
+        isRunning: false,
+        messages: [user],
+      });
+      expect(core.messages).toEqual([user]);
+    });
+
     it("delegates to onCancel", () => {
       const onCancel = vi.fn();
       const messages = [createUserMessage("u1"), createAssistantMessage("a1")];
@@ -537,6 +842,7 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       core.cancelRun();
 
       await new Promise((resolve) => setTimeout(resolve, 0));
+      expectCancelledTurn(core);
       expect(core.composer.text).toBe("");
       expect(core.export().messages.map((m) => m.message.id)).toContain("u1");
     });
@@ -550,12 +856,21 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       });
       const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
       core.composer.setText("something else");
+      const notified = vi.fn(() => core.messages);
+      core.subscribe(notified);
 
       core.cancelRun();
+      const markerId = expectCancelledTurn(core);
+      expect(notified).toHaveLastReturnedWith(core.messages);
 
       await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(expectCancelledTurn(core)).toBe(markerId);
       expect(core.composer.text).toBe("something else");
       expect(core.export().messages.map((m) => m.message.id)).toContain("u1");
+      expect(core.export().messages.map((m) => m.message.id)).not.toContain(
+        markerId,
+      );
+      expect(adapter.setMessages).toHaveBeenLastCalledWith([core.messages[0]]);
     });
 
     it("keeps a message with non-text content in the thread", async () => {
@@ -577,8 +892,10 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       core.cancelRun();
 
       await new Promise((resolve) => setTimeout(resolve, 0));
+      expectCancelledTurn(core);
       expect(core.composer.text).toBe("");
       expect(core.export().messages.map((m) => m.message.id)).toContain("u1");
+      expect(adapter.setMessages).toHaveBeenLastCalledWith([userMessage]);
     });
 
     it("restores the message whole when the composer is free", async () => {
@@ -605,8 +922,10 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
 
       core.cancelRun();
+      expect(core.messages).toEqual([]);
 
       await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(adapter.setMessages).toHaveBeenLastCalledWith([]);
       expect(core.composer.text).toBe("cancel me");
       expect(core.composer.attachments).toEqual([attachment]);
       expect(core.composer.quote).toEqual(quote);

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -964,6 +964,11 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       });
       const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
 
+      // a mounted message subscriber resolves every published id
+      core.subscribe(() => {
+        for (const message of core.messages) core.getBranches(message.id);
+      });
+
       core.cancelRun();
       // the placeholder is gone at once; the prompt stays until the resync
       expect(core.messages).toEqual([userMessage]);

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -281,9 +281,7 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
               ? [user, createAssistantMessage("a1")]
               : change === "user"
                 ? [user, createUserMessage("u2")]
-                : change === "import"
-                  ? [user]
-                  : [];
+                : [user];
           if (change === "session reset") core.unstable_notifySessionReset();
           if (change === "reset") core.reset();
           if (change === "import") core.import(core.export());
@@ -445,30 +443,33 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       expect(adapter.setMessages).toHaveBeenLastCalledWith([]);
     });
 
-    it("sends after the cancelled turn using its user parent without editing", async () => {
-      const { core, adapter, user } = stopBeforeStream();
-      const markerId = expectCancelledTurn(core);
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      core.__internal_setAdapter({
-        ...adapter,
-        isRunning: false,
-        messages: [user],
-      });
-      await core.append({
-        role: "user",
-        createdAt: new Date(),
-        metadata: { custom: {} },
-        parentId: markerId,
-        content: [{ type: "text", text: "next" }],
-        attachments: [],
-        runConfig: {},
-        sourceId: null,
-      });
-      expect(adapter.onNew).toHaveBeenCalledWith(
-        expect.objectContaining({ parentId: "u1" }),
-      );
-      expect(adapter.onEdit).not.toHaveBeenCalled();
-    });
+    it.each(["cancelled turn", "user parent"] as const)(
+      "sends after the cancelled turn as a tail append when the parent is the %s",
+      async (parent) => {
+        const { core, adapter, user } = stopBeforeStream();
+        const markerId = expectCancelledTurn(core);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        core.__internal_setAdapter({
+          ...adapter,
+          isRunning: false,
+          messages: [user],
+        });
+        await core.append({
+          role: "user",
+          createdAt: new Date(),
+          metadata: { custom: {} },
+          parentId: parent === "cancelled turn" ? markerId : "u1",
+          content: [{ type: "text", text: "next" }],
+          attachments: [],
+          runConfig: {},
+          sourceId: null,
+        });
+        expect(adapter.onNew).toHaveBeenCalledWith(
+          expect.objectContaining({ parentId: "u1" }),
+        );
+        expect(adapter.onEdit).not.toHaveBeenCalled();
+      },
+    );
 
     it("dispatches queued sends from the cancelled turn's user parent", async () => {
       const run = vi.fn();


### PR DESCRIPTION
## Problem

Stopping a run before the first chunk arrives is supposed to roll the turn back: `cancelRun` moves the trailing user message into the composer and removes it from the store, so the prompt is ready to edit and resend. That path works. The gap (#7025) is when the composer refuses the move. On `useAISDKRuntime` at `30f3fc8cf`, with the real ordering (`stop()` settles, status flips to `ready`, the `setTimeout(0)` resync flushes):

- composer empty at stop: thread ends `[]`, composer holds the prompt (intended)
- composer holds a draft at stop: thread ends `[user]` with no status, composer keeps the draft (the gap)

In the second case nothing records that a run was started and stopped: no assistant turn, no status, and no retry affordance, because reload is disabled for user messages. The same refused branch is reached when the adapter has no `setMessages` or when the user message carries non-text content parts.

## Solution

When the rollback is refused and a run was in flight, `cancelRun` leaves a cancelled assistant turn under the user message: role `assistant`, empty content, status `{ type: "incomplete", reason: "cancelled" }`, marked `isOptimistic` so it is never exported. It lives only in the runtime's repository. The cancel resync filters it out of `setMessages`, so the host store and anything that persists or exports the feed never see it (the cost that closed #6832). The snapshot pass re-applies it while the host's tail is still that user message and drops it when a new run starts after the stopped one settled, when the tail moves, on repository swap, reset, import, or when either message is deleted locally. Reload on it calls `onReload` with the user message as the parent; a send while it shows reaches `onNew` (or the queue) with the user message as the parent. The default path is unchanged.

## Option 1 vs option 2

okisdev flagged the shape as a product call in #7025: mark the refused branch in core (option 1) or open reload on a trailing user message with no reply (option 2). This PR implements option 1 because it gives every external-store adapter one answer, reuses the existing assistant-only reload affordance, and matches the outcome LocalRuntime already produces for a run stopped before output. If maintainers prefer option 2, I can flip it.

## Disclosures

- `messages` is now refreshed synchronously inside `cancelRun` before subscribers are notified; on main it stayed stale (the empty placeholder kept spinning) until the adapter re-rendered. On the default path the moved prompt stays in `messages` until the resync commits its removal, so a host render in between does not flash it out and back in; the existing free-composer test asserts that sequence.
- A cancel resync that is still pending when `reset()` runs re-sends the repository messages to the host on main too. That race is pre-existing and untouched; only the exclusion of the cancelled turn from it is new.
- The `useAISDKRuntime` test models the real ordering: `Chat.stop()` only aborts, so the host can publish the resync's `setMessages` while its status is still `submitted`. The test rerenders in that state before flipping to `ready`, and the marker is kept across that late flip.
- Core runtime plus a one-line guard in the ai-sdk history hook (`useExternalHistory` skips optimistic nodes with nothing bound instead of reporting an empty telemetry batch). No change under `api-surface/`, no new exports, no adapter option. Changeset: patch for `@assistant-ui/core` and `@assistant-ui/ai-sdk`.
- A second stop while the host still reports the run re-evaluates the rollback: a composer freed in between takes the prompt back; a still-busy composer gets a fresh cancelled turn with a new id. A stop after the host has settled leaves the existing turn alone.
- Bundle size: `pnpm size:check` passes; this change adds roughly 235 B gzip to core `./internal` and 247 B to `./react`, nothing to the root entry, all within tolerance, so `size-budgets.json` is untouched.
- Docs: the external-store page gains a short "Stopping before the first output" subsection describing the rollback and the refused branch.
- #7089 edits the same `cancelRun` region for notification ordering; expect a textual conflict with whichever lands second.

## Verification

- core: 1849 tests pass across 170 files (main 1829); the adapter test file goes from 53 to 73 cases, covering the issue's rows (busy composer, no `setMessages`, non-text content, free composer unchanged), durability across host snapshots, the late status flip, retry before and after the host settles, sends and queued sends while the turn shows, local and host-owned deletion, reset racing the resync, and an idle stop leaving no turn.
- ai-sdk: 278 tests pass across 25 files (main 275), including the issue's two table rows end to end through `useAISDKRuntime` with `chat.messages` asserted unchanged, and the history hook skipping the runtime-only turn.
- With the production file reverted, 23 of the 73 adapter cases fail (20 new and 3 extended); the reset-race and retry-before-settle tests were also mutation-checked against their one-line fixes.
- The adapter tests previously mounted no `MessageRuntime` subscriber, which is how a notify carrying an id the repository no longer held went unnoticed; the free-composer test now mounts a subscriber that resolves `getBranches` for every published id, so that class of crash is covered.
- `tsc` error count in `packages/core` unchanged at the pre-existing baseline; oxlint and oxfmt clean; `api-surface:check`, `declarations:check`, and `size:check` exit 0.
- Review loop: three fresh-context Claude reviews and three astra (gpt-6-astra) reviews; astra signed off on round 3 and the third Claude pass confirmed every fix by probe. The two bot rounds on this PR (claude-fork-review, CodeRabbit, cubic, Rupic) are adjudicated in-thread and addressed in the follow-up commits. Findings fixed along the way: a late host status flip evicting the marker, a marker created on an idle stop, an orphaned marker on parent deletion, `reset()` letting a pending resync commit the marker to the host, and a retry started before the host settled resurfacing the old marker.

Closes #7025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
