### PR TITLE
fix(cloud-ai-sdk): title long threads from their opening messages

### DIFF
--- a/.changeset/cloud-thread-title-oldest-messages.md
+++ b/.changeset/cloud-thread-title-oldest-messages.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: title long threads from their opening messages instead of the newest page

--- a/packages/cloud-ai-sdk/src/threads/generateThreadTitle.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/generateThreadTitle.test.ts
@@ -17,10 +17,20 @@ const titleStream = (title: string) =>
     },
   });
 
-const createCloud = (messages: unknown[]) => {
-  const list = vi.fn().mockResolvedValue({ messages });
+const createCloud = (messages: ReturnType<typeof cloudMessage>[]) => {
+  const list = vi.fn(
+    async (_threadId: string, query?: { limit?: number; after?: string }) => {
+      const start = query?.after
+        ? messages.findIndex((message) => message.id === query.after) + 1
+        : 0;
+      return { messages: messages.slice(start, start + (query?.limit ?? 200)) };
+    },
+  );
   const update = vi.fn().mockResolvedValue(undefined);
-  const stream = vi.fn().mockResolvedValue(titleStream("Weather chat"));
+  const stream = vi.fn(
+    async (_options: Parameters<AssistantCloud["runs"]["stream"]>[0]) =>
+      titleStream("Weather chat"),
+  );
   const cloud = {
     threads: { messages: { list }, update },
     runs: { stream },
@@ -30,7 +40,7 @@ const createCloud = (messages: unknown[]) => {
 
 describe("generateThreadTitle", () => {
   it("feeds the title model the conversation in chronological order", async () => {
-    const { cloud, stream, update } = createCloud([
+    const { cloud, list, stream, update } = createCloud([
       cloudMessage("m2", "assistant", "Sunny with light wind."),
       cloudMessage("m1", "user", "What is the weather today?"),
     ]);
@@ -38,6 +48,7 @@ describe("generateThreadTitle", () => {
     const title = await generateThreadTitle(cloud, "thread-1");
 
     expect(title).toBe("Weather chat");
+    expect(list).toHaveBeenCalledExactlyOnceWith("thread-1", { limit: 200 });
     expect(stream).toHaveBeenCalledExactlyOnceWith({
       thread_id: "thread-1",
       assistant_id: "system/thread_title",
@@ -55,5 +66,72 @@ describe("generateThreadTitle", () => {
     expect(update).toHaveBeenCalledExactlyOnceWith("thread-1", {
       title: "Weather chat",
     });
+  });
+
+  it("titles a long thread from its oldest 200 messages", async () => {
+    const messages = Array.from({ length: 450 }, (_, index) => {
+      const id = 450 - index;
+      return cloudMessage(
+        `m${id}`,
+        id % 2 ? "user" : "assistant",
+        `Message m${id}`,
+      );
+    });
+    const { cloud, list, stream } = createCloud(messages);
+
+    expect(await generateThreadTitle(cloud, "thread-1")).toBe("Weather chat");
+
+    expect(list.mock.calls).toEqual([
+      ["thread-1", { limit: 200 }],
+      ["thread-1", { limit: 200, after: "m251" }],
+      ["thread-1", { limit: 200, after: "m51" }],
+    ]);
+    expect(stream).toHaveBeenCalledTimes(1);
+    expect(stream.mock.calls[0]![0].messages).toEqual(
+      Array.from({ length: 200 }, (_, index) => ({
+        role: index % 2 ? "assistant" : "user",
+        content: [{ type: "text", text: `Message m${index + 1}` }],
+      })),
+    );
+  });
+
+  it("retries an empty first page before generating a title", async () => {
+    vi.useFakeTimers();
+    try {
+      const { cloud, list, stream } = createCloud([
+        cloudMessage("m1", "user", "Hello"),
+      ]);
+      list.mockResolvedValueOnce({ messages: [] });
+
+      const title = generateThreadTitle(cloud, "thread-1");
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(await title).toBe("Weather chat");
+      expect(stream).toHaveBeenCalledTimes(1);
+      expect(list.mock.calls).toEqual([
+        ["thread-1", { limit: 200 }],
+        ["thread-1", { limit: 200 }],
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops when a cursor replays already-seen messages", async () => {
+    const messages = Array.from({ length: 200 }, (_, index) =>
+      cloudMessage(`m${200 - index}`, "user", `Message m${200 - index}`),
+    );
+    const { cloud, list, stream } = createCloud(messages);
+    list
+      .mockResolvedValueOnce({ messages })
+      .mockResolvedValueOnce({ messages });
+
+    expect(await generateThreadTitle(cloud, "thread-1")).toBe("Weather chat");
+    expect(list.mock.calls).toEqual([
+      ["thread-1", { limit: 200 }],
+      ["thread-1", { limit: 200, after: "m1" }],
+    ]);
+    expect(stream).toHaveBeenCalledTimes(1);
+    expect(stream.mock.calls[0]![0].messages).toHaveLength(200);
   });
 });

--- a/packages/cloud-ai-sdk/src/threads/generateThreadTitle.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/generateThreadTitle.test.ts
@@ -17,7 +17,9 @@ const titleStream = (title: string) =>
     },
   });
 
-const createCloud = (messages: ReturnType<typeof cloudMessage>[]) => {
+const createCloud = (
+  messages: { id: string; format: string; content: object }[],
+) => {
   const list = vi.fn(
     async (_threadId: string, query?: { limit?: number; after?: string }) => {
       const start = query?.after
@@ -93,6 +95,25 @@ describe("generateThreadTitle", () => {
         content: [{ type: "text", text: `Message m${index + 1}` }],
       })),
     );
+  });
+
+  it("titles a thread whose opening messages are in another format", async () => {
+    const messages = Array.from({ length: 250 }, (_, index) => {
+      const id = 250 - index;
+      return id > 200
+        ? cloudMessage(`m${id}`, "user", `Message m${id}`)
+        : { id: `m${id}`, format: "aui/v0", content: { role: "user" } };
+    });
+    const { cloud, stream } = createCloud(messages);
+
+    expect(await generateThreadTitle(cloud, "thread-1")).toBe("Weather chat");
+
+    const input = stream.mock.calls[0]![0].messages;
+    expect(input).toHaveLength(50);
+    expect(input[0]).toEqual({
+      role: "user",
+      content: [{ type: "text", text: "Message m201" }],
+    });
   });
 
   it("retries an empty first page before generating a title", async () => {

--- a/packages/cloud-ai-sdk/src/threads/generateThreadTitle.ts
+++ b/packages/cloud-ai-sdk/src/threads/generateThreadTitle.ts
@@ -1,50 +1,33 @@
 import {
+  CloudMessagePersistence,
   generateThreadTitle as generateCloudThreadTitle,
   type AssistantCloud,
 } from "assistant-cloud";
 import { MESSAGE_FORMAT } from "../chat/MessagePersistence";
 
-const TITLE_MESSAGE_PAGE_SIZE = 200;
+const TITLE_MESSAGE_LIMIT = 200;
 
 export async function generateThreadTitle(
   cloud: AssistantCloud,
   threadId: string,
 ): Promise<string | null> {
+  // `load` walks every page of the thread by cursor; the id mapping it fills
+  // on this throwaway instance is unused.
+  const persistence = new CloudMessagePersistence(cloud);
+
   // Recent writes can lag behind thread creation, so retry briefly.
-  const loadFirstPage = async () => {
+  const loadMessages = async () => {
     for (let attempt = 0; attempt < 2; attempt += 1) {
-      const { messages } = await cloud.threads.messages.list(threadId, {
-        limit: TITLE_MESSAGE_PAGE_SIZE,
-      });
+      const messages = await persistence.load(threadId);
       if (messages.length > 0) return messages;
       await new Promise((resolve) => setTimeout(resolve, 300));
     }
-    const { messages } = await cloud.threads.messages.list(threadId, {
-      limit: TITLE_MESSAGE_PAGE_SIZE,
-    });
-    return messages;
+    return persistence.load(threadId);
   };
 
-  let page = await loadFirstPage();
-  const loadedMessages: typeof page = [];
-  const seen = new Set<string>();
-  while (true) {
-    const last = page.at(-1);
-    if (!last) break;
-    const fresh = page.filter((message) => !seen.has(message.id));
-    if (fresh.length === 0) break;
-    for (const message of fresh) seen.add(message.id);
-    loadedMessages.push(...fresh);
-    if (page.length < TITLE_MESSAGE_PAGE_SIZE) break;
-    ({ messages: page } = await cloud.threads.messages.list(threadId, {
-      limit: TITLE_MESSAGE_PAGE_SIZE,
-      after: last.id,
-    }));
-  }
-
-  // Pages arrive newest-first; walk to the opening exchange and reverse only
-  // the oldest 200 messages so the title input is bounded and chronological.
-  const messages = loadedMessages.slice(-TITLE_MESSAGE_PAGE_SIZE).reverse();
+  // Pages arrive newest-first; keep only the opening messages and reverse
+  // them so the title input is bounded and chronological.
+  const messages = (await loadMessages()).slice(-TITLE_MESSAGE_LIMIT).reverse();
   if (messages.length === 0) return null;
 
   const aiSdkMessages = messages.filter(

--- a/packages/cloud-ai-sdk/src/threads/generateThreadTitle.ts
+++ b/packages/cloud-ai-sdk/src/threads/generateThreadTitle.ts
@@ -4,24 +4,47 @@ import {
 } from "assistant-cloud";
 import { MESSAGE_FORMAT } from "../chat/MessagePersistence";
 
+const TITLE_MESSAGE_PAGE_SIZE = 200;
+
 export async function generateThreadTitle(
   cloud: AssistantCloud,
   threadId: string,
 ): Promise<string | null> {
   // Recent writes can lag behind thread creation, so retry briefly.
-  const loadMessages = async () => {
+  const loadFirstPage = async () => {
     for (let attempt = 0; attempt < 2; attempt += 1) {
-      const { messages } = await cloud.threads.messages.list(threadId);
+      const { messages } = await cloud.threads.messages.list(threadId, {
+        limit: TITLE_MESSAGE_PAGE_SIZE,
+      });
       if (messages.length > 0) return messages;
       await new Promise((resolve) => setTimeout(resolve, 300));
     }
-    const { messages } = await cloud.threads.messages.list(threadId);
+    const { messages } = await cloud.threads.messages.list(threadId, {
+      limit: TITLE_MESSAGE_PAGE_SIZE,
+    });
     return messages;
   };
 
-  // The list endpoint returns newest-first; the title model needs the
-  // conversation in chronological order.
-  const messages = (await loadMessages()).slice().reverse();
+  let page = await loadFirstPage();
+  const loadedMessages: typeof page = [];
+  const seen = new Set<string>();
+  while (true) {
+    const last = page.at(-1);
+    if (!last) break;
+    const fresh = page.filter((message) => !seen.has(message.id));
+    if (fresh.length === 0) break;
+    for (const message of fresh) seen.add(message.id);
+    loadedMessages.push(...fresh);
+    if (page.length < TITLE_MESSAGE_PAGE_SIZE) break;
+    ({ messages: page } = await cloud.threads.messages.list(threadId, {
+      limit: TITLE_MESSAGE_PAGE_SIZE,
+      after: last.id,
+    }));
+  }
+
+  // Pages arrive newest-first; walk to the opening exchange and reverse only
+  // the oldest 200 messages so the title input is bounded and chronological.
+  const messages = loadedMessages.slice(-TITLE_MESSAGE_PAGE_SIZE).reverse();
   if (messages.length === 0) return null;
 
   const aiSdkMessages = messages.filter(

--- a/packages/cloud-ai-sdk/src/threads/generateThreadTitle.ts
+++ b/packages/cloud-ai-sdk/src/threads/generateThreadTitle.ts
@@ -25,16 +25,17 @@ export async function generateThreadTitle(
     return persistence.load(threadId);
   };
 
-  // Pages arrive newest-first; keep only the opening messages and reverse
-  // them so the title input is bounded and chronological.
-  const messages = (await loadMessages()).slice(-TITLE_MESSAGE_LIMIT).reverse();
-  if (messages.length === 0) return null;
-
-  const aiSdkMessages = messages.filter(
-    (msg) =>
-      msg.format === MESSAGE_FORMAT ||
-      (msg.content && Array.isArray(msg.content.parts)),
-  );
+  // Pages arrive newest-first; filter first so a thread whose opening rows
+  // are in another format still titles, then keep the oldest usable messages
+  // in chronological order.
+  const aiSdkMessages = (await loadMessages())
+    .filter(
+      (msg) =>
+        msg.format === MESSAGE_FORMAT ||
+        (msg.content && Array.isArray(msg.content.parts)),
+    )
+    .slice(-TITLE_MESSAGE_LIMIT)
+    .reverse();
   if (aiSdkMessages.length === 0) return null;
 
   const convertedMessages = aiSdkMessages


### PR DESCRIPTION
Thread titles for long conversations were generated from the wrong end of the thread. The Cloud messages list returns newest-first and caps a page at 200 rows; `generateThreadTitle` fetched that one page and reversed it, so any thread past 200 messages was titled from its most recent messages instead of the opening exchange.

`generateThreadTitle` now loads the thread through `CloudMessagePersistence.load`, which already walks every page with the `after` cursor at `limit: 200` and carries the replayed-cursor guard, then keeps the oldest 200 messages and feeds those in chronological order. There is one copy of the cursor semantics. The empty-first-page retry, the format filter, and the conversion are unchanged. No public surface change; `api-surface/` is byte-identical.

## Disclosures

- Request cost: titling an N-message thread now costs ceil(N/200) list calls. This is acceptable because title generation runs once per thread, normally right after the first response when the thread is a single page, and it is the same cost `CloudMessagePersistence.load` already pays on every thread open.
- The walk cannot stop early. The route only returns newest-first with a message-id cursor that moves older, so the oldest rows are always on the last page. Follow-up for assistant-cloud: an ascending selector or `before` cursor on `messageListQuerySchema` in `apps/api/src/endpoints/threads/listThreads.ts` would make this a single request.
- A thread of exactly 200 messages issues one extra empty-page request before stopping (same as `CloudMessagePersistence.load`).
- The route contract (`format`, `limit` 1..200, `after` only) was read from assistant-cloud `main`, not probed against a live deployment.
- The client-side format filter runs before the 200-message window, so a thread whose opening rows are in another format still titles from its oldest usable messages. `format` is deliberately not sent to the server: the local filter is looser than a server-side one (it also accepts any row whose content carries `parts`), and a server-side format would also convert `aui/v0` rows, changing what the title model sees.
- The shared loader holds the whole thread in memory before the window is taken. That is the same buffer thread loading already holds on every thread open, and bounding it would mean a second copy of the walk.

## Verification

- `@assistant-ui/cloud-ai-sdk` vitest: 144/144 under AI SDK v7 and peer-v6 (5 title tests, was 1: chronological order, >200-message head selection with cursor sequence, mixed-format opening rows, empty-first-page retry, cursor replay termination).
- `assistant-cloud` vitest: 192/192.
- `tsc --noEmit` on both cloud-ai-sdk configs, oxlint, oxfmt clean.
- `api-surface:check` clean (byte-identical), `declarations:check` clean, `size:check` ok (entry about +25 B gzip against the local base build, within tolerance).
- Review rounds: fresh-context Claude sign-off with one should-fix applied (redundant test assertions removed); astra sign-off with no findings, including a docs-lockstep check (no docs page documents page size or ordering). First bot round: the fork review's reuse request was applied in the second commit and its filter-before-window correction in the third.

Closes #6965

🤖 Generated with [Claude Code](https://claude.com/claude-code)
