### PR TITLE
fix(core): finish voice cleanup after adapter errors

### DIFF
--- a/.changeset/strong-voice-cleanup.md
+++ b/.changeset/strong-voice-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: finish realtime voice cleanup after adapter errors

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -289,6 +289,22 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
     expect(runtime.getVoiceVolume()).toBe(0);
   });
 
+  it("releases handlers registered before voice setup throws", () => {
+    const setupError = new Error("registration failed");
+    const statusCleanup = vi.fn();
+    const voice = createVoiceAdapter();
+    voice.session.onStatusChange = () => statusCleanup;
+    voice.session.onModeChange = () => {
+      throw setupError;
+    };
+    const runtime = new TestRuntime(voice);
+
+    expect(() => runtime.connectVoice()).toThrow(setupError);
+    expect(statusCleanup).toHaveBeenCalledOnce();
+    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+    expect(runtime.voice).toBeUndefined();
+  });
+
   it("rethrows one subscriber error once while disconnecting", () => {
     const voice = createVoiceAdapter();
     const runtime = new TestRuntime(voice);

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -231,6 +231,28 @@ describe("BaseThreadRuntimeCore subscriptions", () => {
 });
 
 describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
+  it("finishes disconnecting when a session cleanup throws", () => {
+    const cleanupError = new Error("cleanup failed");
+    const laterCleanup = vi.fn();
+    const voice = createVoiceAdapter();
+    voice.session.onStatusChange = () => () => {
+      throw cleanupError;
+    };
+    voice.session.onModeChange = () => laterCleanup;
+    const runtime = new TestRuntime(voice);
+    runtime.connectVoice();
+
+    expect(() => runtime.disconnectVoice()).toThrow(cleanupError);
+    expect(laterCleanup).toHaveBeenCalledOnce();
+    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+    expect(runtime.voice).toBeUndefined();
+    expect(runtime.getVoiceVolume()).toBe(0);
+
+    expect(() => runtime.disconnectVoice()).not.toThrow();
+    expect(laterCleanup).toHaveBeenCalledOnce();
+    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+  });
+
   it("continues notifying subscribers when one throws", () => {
     const consoleError = vi
       .spyOn(console, "error")

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -274,6 +274,42 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
     );
   });
 
+  it("rolls back a new session when initialization throws", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const voice = createVoiceAdapter();
+    const runtime = new TestRuntime(voice);
+    const listenerError = new Error("subscriber failed");
+    runtime.subscribe(() => {
+      throw listenerError;
+    });
+
+    expect(() => runtime.connectVoice()).toThrow(listenerError);
+    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+    expect(runtime.voice).toBeUndefined();
+    expect(runtime.getVoiceVolume()).toBe(0);
+  });
+
+  it("rethrows one subscriber error once while disconnecting", () => {
+    const voice = createVoiceAdapter();
+    const runtime = new TestRuntime(voice);
+    runtime.connectVoice();
+    voice.emitTranscript({ role: "assistant", text: "Partial" });
+    const listenerError = new Error("subscriber failed");
+    runtime.subscribe(() => {
+      throw listenerError;
+    });
+
+    let thrown: unknown;
+    try {
+      runtime.disconnectVoice();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBe(listenerError);
+    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+  });
+
   it("continues notifying subscribers when one throws", () => {
     const consoleError = vi
       .spyOn(console, "error")

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -305,6 +305,48 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
     expect(runtime.voice).toBeUndefined();
   });
 
+  it("stops setup when a subscriber disconnects the new session", () => {
+    const voice = createVoiceAdapter();
+    const statusRegistration = vi.spyOn(voice.session, "onStatusChange");
+    const runtime = new TestRuntime(voice);
+    runtime.subscribe(() => {
+      if (runtime.voice) runtime.disconnectVoice();
+    });
+
+    expect(() => runtime.connectVoice()).not.toThrow();
+
+    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+    expect(statusRegistration).not.toHaveBeenCalled();
+    expect(runtime.voice).toBeUndefined();
+  });
+
+  it("releases a handler returned after reentrant disconnect", () => {
+    const statusCleanup = vi.fn();
+    const voice = createVoiceAdapter();
+    let registeringStatus = false;
+    voice.session.onStatusChange = (callback) => {
+      registeringStatus = true;
+      callback({ type: "running" });
+      registeringStatus = false;
+      return statusCleanup;
+    };
+    const modeRegistration = vi.spyOn(voice.session, "onModeChange");
+    const runtime = new TestRuntime(voice);
+    runtime.subscribe(() => {
+      if (registeringStatus) {
+        registeringStatus = false;
+        runtime.disconnectVoice();
+      }
+    });
+
+    expect(() => runtime.connectVoice()).not.toThrow();
+
+    expect(statusCleanup).toHaveBeenCalledOnce();
+    expect(modeRegistration).not.toHaveBeenCalled();
+    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+    expect(runtime.voice).toBeUndefined();
+  });
+
   it("rethrows one subscriber error once while disconnecting", () => {
     const voice = createVoiceAdapter();
     const runtime = new TestRuntime(voice);

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -411,6 +411,65 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
     });
   });
 
+  it("disconnects a session that ends during status registration", () => {
+    const voice = createVoiceAdapter();
+    const statusCleanup = vi.fn();
+    voice.session.onStatusChange = (callback) => {
+      callback({ type: "ended", reason: "finished" });
+      return statusCleanup;
+    };
+    const modeRegistration = vi.spyOn(voice.session, "onModeChange");
+    const runtime = new TestRuntime(voice);
+
+    runtime.connectVoice();
+
+    expect(statusCleanup).toHaveBeenCalledOnce();
+    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+    expect(modeRegistration).not.toHaveBeenCalled();
+    expect(runtime.voice).toBeUndefined();
+
+    runtime.disconnectVoice();
+    expect(statusCleanup).toHaveBeenCalledOnce();
+    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("disconnects an ended session when setup notification throws", () => {
+    const listenerError = new Error("ended notification failed");
+    const cleanupError = new Error("status cleanup failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const voice = createVoiceAdapter();
+    const statusCleanup = vi.fn(() => {
+      throw cleanupError;
+    });
+    let endSession!: () => void;
+    voice.session.onStatusChange = (callback) => {
+      endSession = () => callback({ type: "ended", reason: "finished" });
+      return statusCleanup;
+    };
+    voice.session.onModeChange = () => {
+      endSession();
+      return () => {};
+    };
+    const runtime = new TestRuntime(voice);
+    let wasConnected = false;
+    runtime.subscribe(() => {
+      if (runtime.voice) wasConnected = true;
+      else if (wasConnected) throw listenerError;
+    });
+
+    expect(() => runtime.connectVoice()).toThrow(listenerError);
+
+    expect(statusCleanup).toHaveBeenCalledOnce();
+    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+    expect(runtime.voice).toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Detached voice setup cleanup threw",
+      cleanupError,
+    );
+  });
+
   it("rethrows one subscriber error once while disconnecting", () => {
     const voice = createVoiceAdapter();
     const runtime = new TestRuntime(voice);

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -377,6 +377,40 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
     expect(runtime.voice).toBeUndefined();
   });
 
+  it("does not disconnect a replacement session after setup throws", () => {
+    const setupError = new Error("registration failed");
+    const firstVoice = createVoiceAdapter();
+    const replacementVoice = createVoiceAdapter();
+    firstVoice.adapter.connect = vi
+      .fn()
+      .mockReturnValueOnce(firstVoice.session)
+      .mockReturnValueOnce(replacementVoice.session);
+    let replacing = false;
+    firstVoice.session.onModeChange = (callback) => {
+      replacing = true;
+      callback("listening");
+      throw setupError;
+    };
+    const runtime = new TestRuntime(firstVoice);
+    runtime.subscribe(() => {
+      if (replacing) {
+        replacing = false;
+        runtime.disconnectVoice();
+        runtime.connectVoice();
+      }
+    });
+
+    expect(() => runtime.connectVoice()).toThrow(setupError);
+
+    expect(firstVoice.session.disconnect).toHaveBeenCalledOnce();
+    expect(replacementVoice.session.disconnect).not.toHaveBeenCalled();
+    expect(runtime.voice).toMatchObject({
+      status: replacementVoice.session.status,
+      isMuted: replacementVoice.session.isMuted,
+      mode: "listening",
+    });
+  });
+
   it("rethrows one subscriber error once while disconnecting", () => {
     const voice = createVoiceAdapter();
     const runtime = new TestRuntime(voice);

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -253,6 +253,27 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
     expect(voice.session.disconnect).toHaveBeenCalledOnce();
   });
 
+  it("reconnects after cleanup from the previous session throws", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const cleanupError = new Error("cleanup failed");
+    const voice = createVoiceAdapter();
+    voice.adapter.connect = vi.fn(voice.adapter.connect);
+    voice.session.onStatusChange = () => () => {
+      throw cleanupError;
+    };
+    const runtime = new TestRuntime(voice);
+    runtime.connectVoice();
+
+    expect(() => runtime.connectVoice()).not.toThrow();
+    expect(voice.adapter.connect).toHaveBeenCalledTimes(2);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Voice cleanup threw before reconnect",
+      cleanupError,
+    );
+  });
+
   it("continues notifying subscribers when one throws", () => {
     const consoleError = vi
       .spyOn(console, "error")

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -411,11 +411,12 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
     });
   });
 
-  it("disconnects a session that ends during status registration", () => {
+  it("releases setup handlers without disconnecting a self-ended session", () => {
     const voice = createVoiceAdapter();
     const statusCleanup = vi.fn();
     voice.session.onStatusChange = (callback) => {
-      callback({ type: "ended", reason: "finished" });
+      voice.session.status = { type: "ended", reason: "finished" };
+      callback(voice.session.status);
       return statusCleanup;
     };
     const modeRegistration = vi.spyOn(voice.session, "onModeChange");
@@ -424,16 +425,16 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
     runtime.connectVoice();
 
     expect(statusCleanup).toHaveBeenCalledOnce();
-    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+    expect(voice.session.disconnect).not.toHaveBeenCalled();
     expect(modeRegistration).not.toHaveBeenCalled();
     expect(runtime.voice).toBeUndefined();
 
     runtime.disconnectVoice();
     expect(statusCleanup).toHaveBeenCalledOnce();
-    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+    expect(voice.session.disconnect).not.toHaveBeenCalled();
   });
 
-  it("disconnects an ended session when setup notification throws", () => {
+  it("releases ended-session handlers when setup notification throws", () => {
     const listenerError = new Error("ended notification failed");
     const cleanupError = new Error("status cleanup failed");
     const consoleError = vi
@@ -445,7 +446,10 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
     });
     let endSession!: () => void;
     voice.session.onStatusChange = (callback) => {
-      endSession = () => callback({ type: "ended", reason: "finished" });
+      endSession = () => {
+        voice.session.status = { type: "ended", reason: "finished" };
+        callback(voice.session.status);
+      };
       return statusCleanup;
     };
     voice.session.onModeChange = () => {
@@ -462,12 +466,34 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
     expect(() => runtime.connectVoice()).toThrow(listenerError);
 
     expect(statusCleanup).toHaveBeenCalledOnce();
-    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+    expect(voice.session.disconnect).not.toHaveBeenCalled();
     expect(runtime.voice).toBeUndefined();
     expect(consoleError).toHaveBeenCalledWith(
       "[assistant-ui] Detached voice setup cleanup threw",
       cleanupError,
     );
+  });
+
+  it("does not disconnect a session that ends after setup", () => {
+    const voice = createVoiceAdapter();
+    const statusCleanup = vi.fn();
+    let endSession!: () => void;
+    voice.session.onStatusChange = (callback) => {
+      endSession = () => {
+        voice.session.status = { type: "ended", reason: "finished" };
+        callback(voice.session.status);
+      };
+      return statusCleanup;
+    };
+    const runtime = new TestRuntime(voice);
+    runtime.connectVoice();
+    endSession();
+    expect(runtime.voice).toBeUndefined();
+
+    runtime.disconnectVoice();
+
+    expect(statusCleanup).toHaveBeenCalledOnce();
+    expect(voice.session.disconnect).not.toHaveBeenCalled();
   });
 
   it("rethrows one subscriber error once while disconnecting", () => {

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -347,6 +347,36 @@ describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
     expect(runtime.voice).toBeUndefined();
   });
 
+  it("does not release earlier handlers twice after reentrant disconnect", () => {
+    const statusCleanup = vi.fn();
+    const modeCleanup = vi.fn();
+    const voice = createVoiceAdapter();
+    voice.session.onStatusChange = () => statusCleanup;
+    let registeringMode = false;
+    voice.session.onModeChange = (callback) => {
+      registeringMode = true;
+      callback("speaking");
+      registeringMode = false;
+      return modeCleanup;
+    };
+    const volumeRegistration = vi.spyOn(voice.session, "onVolumeChange");
+    const runtime = new TestRuntime(voice);
+    runtime.subscribe(() => {
+      if (registeringMode) {
+        registeringMode = false;
+        runtime.disconnectVoice();
+      }
+    });
+
+    expect(() => runtime.connectVoice()).not.toThrow();
+
+    expect(statusCleanup).toHaveBeenCalledOnce();
+    expect(modeCleanup).toHaveBeenCalledOnce();
+    expect(volumeRegistration).not.toHaveBeenCalled();
+    expect(voice.session.disconnect).toHaveBeenCalledOnce();
+    expect(runtime.voice).toBeUndefined();
+  });
+
   it("rethrows one subscriber error once while disconnecting", () => {
     const voice = createVoiceAdapter();
     const runtime = new TestRuntime(voice);

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -455,7 +455,7 @@ export abstract class BaseThreadRuntimeCore
     }
   }
 
-  private _finishVoiceAssistantMessage(notify = true) {
+  private _finishVoiceAssistantMessage() {
     const last = this._voiceMessages.at(-1);
     if (last?.role === "assistant" && last.status.type === "running") {
       const idx = this._voiceMessages.length - 1;
@@ -464,12 +464,11 @@ export abstract class BaseThreadRuntimeCore
         status: { type: "complete", reason: "stop" },
       };
       this._markVoiceMessagesDirty();
-      if (notify) this._notifySubscribers();
+      this._notifySubscribers();
     }
   }
 
   public disconnectVoice() {
-    this._finishVoiceAssistantMessage(false);
     this._currentAssistantMsg = null;
     const unsubs = this._voiceUnsubs;
     this._voiceUnsubs = [];

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -323,6 +323,22 @@ export abstract class BaseThreadRuntimeCore
     this._voiceUnsubs = unsubs;
 
     try {
+      const finishDetachedSetup = () => {
+        if (this._voiceSession === session && this._voiceUnsubs === unsubs) {
+          return false;
+        }
+
+        try {
+          notifySubscribers(unsubs.splice(0));
+        } catch (error) {
+          console.error(
+            "[assistant-ui] Detached voice setup cleanup threw",
+            error,
+          );
+        }
+        return true;
+      };
+
       let currentMode: RealtimeVoiceAdapter.Mode = "listening";
 
       this.voice = {
@@ -332,6 +348,7 @@ export abstract class BaseThreadRuntimeCore
       };
       this._voiceVolume = 0;
       this._notifySubscribers();
+      if (finishDetachedSetup()) return;
 
       unsubs.push(
         session.onStatusChange((status) => {
@@ -349,6 +366,7 @@ export abstract class BaseThreadRuntimeCore
           this._notifySubscribers();
         }),
       );
+      if (finishDetachedSetup()) return;
 
       unsubs.push(
         session.onModeChange((mode) => {
@@ -359,6 +377,7 @@ export abstract class BaseThreadRuntimeCore
           }
         }),
       );
+      if (finishDetachedSetup()) return;
 
       unsubs.push(
         session.onVolumeChange((volume) => {
@@ -370,12 +389,14 @@ export abstract class BaseThreadRuntimeCore
           );
         }),
       );
+      if (finishDetachedSetup()) return;
 
       unsubs.push(
         session.onTranscript((transcript) => {
           this._handleVoiceTranscript(transcript);
         }),
       );
+      finishDetachedSetup();
     } catch (error) {
       try {
         this.disconnectVoice();

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -328,14 +328,10 @@ export abstract class BaseThreadRuntimeCore
         return false;
       }
 
-      const shouldDisconnect = this._voiceUnsubs === unsubs;
-      if (shouldDisconnect) this._voiceUnsubs = [];
+      if (this._voiceUnsubs === unsubs) this._voiceUnsubs = [];
 
       try {
-        notifySubscribers([
-          ...unsubs.splice(0),
-          ...(shouldDisconnect ? [() => session.disconnect()] : []),
-        ]);
+        notifySubscribers(unsubs.splice(0));
       } catch (error) {
         console.error(
           "[assistant-ui] Detached voice setup cleanup threw",

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -322,13 +322,20 @@ export abstract class BaseThreadRuntimeCore
     const unsubs: Array<() => void> = [];
     this._voiceUnsubs = unsubs;
 
+    // The cleanup-list identity preserves ownership after an ended status clears the session.
     const finishDetachedSetup = () => {
       if (this._voiceSession === session && this._voiceUnsubs === unsubs) {
         return false;
       }
 
+      const shouldDisconnect = this._voiceUnsubs === unsubs;
+      if (shouldDisconnect) this._voiceUnsubs = [];
+
       try {
-        notifySubscribers(unsubs.splice(0));
+        notifySubscribers([
+          ...unsubs.splice(0),
+          ...(shouldDisconnect ? [() => session.disconnect()] : []),
+        ]);
       } catch (error) {
         console.error(
           "[assistant-ui] Detached voice setup cleanup threw",

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -328,8 +328,6 @@ export abstract class BaseThreadRuntimeCore
         return false;
       }
 
-      if (this._voiceUnsubs === unsubs) this._voiceUnsubs = [];
-
       try {
         notifySubscribers(unsubs.splice(0));
       } catch (error) {

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -491,7 +491,7 @@ export abstract class BaseThreadRuntimeCore
 
   public disconnectVoice() {
     this._currentAssistantMsg = null;
-    const unsubs = this._voiceUnsubs;
+    const unsubs = this._voiceUnsubs.splice(0);
     this._voiceUnsubs = [];
     const session = this._voiceSession;
     this._voiceSession = undefined;

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -36,7 +36,10 @@ import type { RealtimeVoiceAdapter } from "../../adapters/voice";
 import type { ThreadMessageLike } from "../utils/thread-message-like";
 import { notifyEventListeners } from "../../utils/notify-event-listeners";
 import { gateInteractableComposerMetadata } from "../../model-context/interactable-composer-metadata";
-import { BaseSubscribable } from "../../subscribable/subscribable";
+import {
+  BaseSubscribable,
+  notifySubscribers,
+} from "../../subscribable/subscribable";
 
 type BaseThreadAdapters = {
   speech?: SpeechSynthesisAdapter | undefined;
@@ -305,7 +308,14 @@ export abstract class BaseThreadRuntimeCore
     const adapter = this.adapters?.voice;
     if (!adapter) throw new Error("Voice adapter not configured");
 
-    this.disconnectVoice();
+    try {
+      this.disconnectVoice();
+    } catch (error) {
+      console.error(
+        "[assistant-ui] Voice cleanup threw before reconnect",
+        error,
+      );
+    }
 
     const session = adapter.connect({});
     this._voiceSession = session;
@@ -448,22 +458,14 @@ export abstract class BaseThreadRuntimeCore
   }
 
   public disconnectVoice() {
-    let cleanupFailed = false;
-    let cleanupError: unknown;
-    const runCleanup = (cleanup: () => void) => {
-      try {
-        cleanup();
-      } catch (error) {
-        if (cleanupFailed) {
-          console.error(error);
-        } else {
-          cleanupFailed = true;
-          cleanupError = error;
-        }
-      }
-    };
-
-    runCleanup(() => this._finishVoiceAssistantMessage());
+    let finishFailed = false;
+    let finishError: unknown;
+    try {
+      this._finishVoiceAssistantMessage();
+    } catch (error) {
+      finishFailed = true;
+      finishError = error;
+    }
     this._currentAssistantMsg = null;
     const unsubs = this._voiceUnsubs;
     this._voiceUnsubs = [];
@@ -474,18 +476,24 @@ export abstract class BaseThreadRuntimeCore
     this._voiceMessages = [];
     this._markVoiceMessagesDirty();
 
-    for (const unsub of unsubs) runCleanup(unsub);
-    if (session) runCleanup(() => session.disconnect());
-    runCleanup(() =>
-      notifyEventListeners(
-        this._voiceVolumeSubscribers,
-        undefined,
-        "Voice volume",
-      ),
-    );
-    runCleanup(() => this._notifySubscribers());
-
-    if (cleanupFailed) throw cleanupError;
+    notifySubscribers([
+      ...(finishFailed
+        ? [
+            () => {
+              throw finishError;
+            },
+          ]
+        : []),
+      ...unsubs,
+      ...(session ? [() => session.disconnect()] : []),
+      () =>
+        notifyEventListeners(
+          this._voiceVolumeSubscribers,
+          undefined,
+          "Voice volume",
+        ),
+      () => this._notifySubscribers(),
+    ]);
   }
 
   public muteVoice() {

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -502,6 +502,7 @@ export abstract class BaseThreadRuntimeCore
 
   public disconnectVoice() {
     this._currentAssistantMsg = null;
+    // Drain the shared list in place so reentrant setup cannot release the same handles again.
     const unsubs = this._voiceUnsubs.splice(0);
     this._voiceUnsubs = [];
     const session = this._voiceSession;

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -322,23 +322,23 @@ export abstract class BaseThreadRuntimeCore
     const unsubs: Array<() => void> = [];
     this._voiceUnsubs = unsubs;
 
+    const finishDetachedSetup = () => {
+      if (this._voiceSession === session && this._voiceUnsubs === unsubs) {
+        return false;
+      }
+
+      try {
+        notifySubscribers(unsubs.splice(0));
+      } catch (error) {
+        console.error(
+          "[assistant-ui] Detached voice setup cleanup threw",
+          error,
+        );
+      }
+      return true;
+    };
+
     try {
-      const finishDetachedSetup = () => {
-        if (this._voiceSession === session && this._voiceUnsubs === unsubs) {
-          return false;
-        }
-
-        try {
-          notifySubscribers(unsubs.splice(0));
-        } catch (error) {
-          console.error(
-            "[assistant-ui] Detached voice setup cleanup threw",
-            error,
-          );
-        }
-        return true;
-      };
-
       let currentMode: RealtimeVoiceAdapter.Mode = "listening";
 
       this.voice = {
@@ -398,13 +398,17 @@ export abstract class BaseThreadRuntimeCore
       );
       finishDetachedSetup();
     } catch (error) {
-      try {
-        this.disconnectVoice();
-      } catch (cleanupError) {
-        console.error(
-          "[assistant-ui] Voice rollback cleanup threw",
-          cleanupError,
-        );
+      if (this._voiceSession === session && this._voiceUnsubs === unsubs) {
+        try {
+          this.disconnectVoice();
+        } catch (cleanupError) {
+          console.error(
+            "[assistant-ui] Voice rollback cleanup threw",
+            cleanupError,
+          );
+        }
+      } else {
+        finishDetachedSetup();
       }
       throw error;
     }

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -320,62 +320,73 @@ export abstract class BaseThreadRuntimeCore
     const session = adapter.connect({});
     this._voiceSession = session;
     const unsubs: Array<() => void> = [];
-
-    let currentMode: RealtimeVoiceAdapter.Mode = "listening";
-
-    this.voice = {
-      status: session.status,
-      isMuted: session.isMuted,
-      mode: currentMode,
-    };
-    this._voiceVolume = 0;
-    this._notifySubscribers();
-
-    unsubs.push(
-      session.onStatusChange((status) => {
-        if (status.type === "ended") {
-          this._finishVoiceAssistantMessage();
-          this._voiceSession = undefined;
-          this.voice = undefined;
-        } else {
-          this.voice = {
-            status,
-            isMuted: session.isMuted,
-            mode: currentMode,
-          };
-        }
-        this._notifySubscribers();
-      }),
-    );
-
-    unsubs.push(
-      session.onModeChange((mode) => {
-        currentMode = mode;
-        if (this.voice) {
-          this.voice = { ...this.voice, mode };
-          this._notifySubscribers();
-        }
-      }),
-    );
-
-    unsubs.push(
-      session.onVolumeChange((volume) => {
-        this._voiceVolume = volume;
-        notifyEventListeners(
-          this._voiceVolumeSubscribers,
-          undefined,
-          "Voice volume",
-        );
-      }),
-    );
-
-    unsubs.push(
-      session.onTranscript((transcript) => {
-        this._handleVoiceTranscript(transcript);
-      }),
-    );
-
     this._voiceUnsubs = unsubs;
+
+    try {
+      let currentMode: RealtimeVoiceAdapter.Mode = "listening";
+
+      this.voice = {
+        status: session.status,
+        isMuted: session.isMuted,
+        mode: currentMode,
+      };
+      this._voiceVolume = 0;
+      this._notifySubscribers();
+
+      unsubs.push(
+        session.onStatusChange((status) => {
+          if (status.type === "ended") {
+            this._finishVoiceAssistantMessage();
+            this._voiceSession = undefined;
+            this.voice = undefined;
+          } else {
+            this.voice = {
+              status,
+              isMuted: session.isMuted,
+              mode: currentMode,
+            };
+          }
+          this._notifySubscribers();
+        }),
+      );
+
+      unsubs.push(
+        session.onModeChange((mode) => {
+          currentMode = mode;
+          if (this.voice) {
+            this.voice = { ...this.voice, mode };
+            this._notifySubscribers();
+          }
+        }),
+      );
+
+      unsubs.push(
+        session.onVolumeChange((volume) => {
+          this._voiceVolume = volume;
+          notifyEventListeners(
+            this._voiceVolumeSubscribers,
+            undefined,
+            "Voice volume",
+          );
+        }),
+      );
+
+      unsubs.push(
+        session.onTranscript((transcript) => {
+          this._handleVoiceTranscript(transcript);
+        }),
+      );
+    } catch (error) {
+      try {
+        this.disconnectVoice();
+      } catch (cleanupError) {
+        console.error(
+          "[assistant-ui] Voice rollback cleanup threw",
+          cleanupError,
+        );
+      }
+      throw error;
+    }
   }
 
   private _currentAssistantMsg: ThreadAssistantMessage | null = null;
@@ -444,7 +455,7 @@ export abstract class BaseThreadRuntimeCore
     }
   }
 
-  private _finishVoiceAssistantMessage() {
+  private _finishVoiceAssistantMessage(notify = true) {
     const last = this._voiceMessages.at(-1);
     if (last?.role === "assistant" && last.status.type === "running") {
       const idx = this._voiceMessages.length - 1;
@@ -453,19 +464,12 @@ export abstract class BaseThreadRuntimeCore
         status: { type: "complete", reason: "stop" },
       };
       this._markVoiceMessagesDirty();
-      this._notifySubscribers();
+      if (notify) this._notifySubscribers();
     }
   }
 
   public disconnectVoice() {
-    let finishFailed = false;
-    let finishError: unknown;
-    try {
-      this._finishVoiceAssistantMessage();
-    } catch (error) {
-      finishFailed = true;
-      finishError = error;
-    }
+    this._finishVoiceAssistantMessage(false);
     this._currentAssistantMsg = null;
     const unsubs = this._voiceUnsubs;
     this._voiceUnsubs = [];
@@ -477,13 +481,6 @@ export abstract class BaseThreadRuntimeCore
     this._markVoiceMessagesDirty();
 
     notifySubscribers([
-      ...(finishFailed
-        ? [
-            () => {
-              throw finishError;
-            },
-          ]
-        : []),
       ...unsubs,
       ...(session ? [() => session.disconnect()] : []),
       () =>

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -448,22 +448,44 @@ export abstract class BaseThreadRuntimeCore
   }
 
   public disconnectVoice() {
-    this._finishVoiceAssistantMessage();
+    let cleanupFailed = false;
+    let cleanupError: unknown;
+    const runCleanup = (cleanup: () => void) => {
+      try {
+        cleanup();
+      } catch (error) {
+        if (cleanupFailed) {
+          console.error(error);
+        } else {
+          cleanupFailed = true;
+          cleanupError = error;
+        }
+      }
+    };
+
+    runCleanup(() => this._finishVoiceAssistantMessage());
     this._currentAssistantMsg = null;
-    for (const unsub of this._voiceUnsubs) unsub();
+    const unsubs = this._voiceUnsubs;
     this._voiceUnsubs = [];
-    this._voiceSession?.disconnect();
+    const session = this._voiceSession;
     this._voiceSession = undefined;
     this.voice = undefined;
     this._voiceVolume = 0;
-    notifyEventListeners(
-      this._voiceVolumeSubscribers,
-      undefined,
-      "Voice volume",
-    );
     this._voiceMessages = [];
     this._markVoiceMessagesDirty();
-    this._notifySubscribers();
+
+    for (const unsub of unsubs) runCleanup(unsub);
+    if (session) runCleanup(() => session.disconnect());
+    runCleanup(() =>
+      notifyEventListeners(
+        this._voiceVolumeSubscribers,
+        undefined,
+        "Voice volume",
+      ),
+    );
+    runCleanup(() => this._notifySubscribers());
+
+    if (cleanupFailed) throw cleanupError;
   }
 
   public muteVoice() {


### PR DESCRIPTION
## Problem

A throwing realtime voice cleanup can skip later unsubscribes, session disconnection, and state reset. A replacement can also fail during setup after creating a live session.

Both cases reproduce with a session cleanup or runtime subscriber that throws synchronously.

## Root cause

Voice teardown ran adapter callbacks before detaching runtime state and stopped on the first exception. Setup did not attach its partial cleanup list until every handler had registered.

## Change

Detach voice state before adapter cleanup and run every teardown through the shared error aggregation behavior. Reconnect logs cleanup failure from the old session and continues.

New-session setup tracks partial registrations immediately and releases them if setup fails. Because publishing state can synchronously invoke host subscribers, rollback checks session and cleanup-list ownership before disconnecting a still-active session. It releases locally owned handlers without disconnecting a replacement. Disconnect claims each cleanup handle once.

If a host disconnects during setup, the interrupted call returns without creating more handlers. If a host replaces the session and the original registration then throws, that original error propagates while the replacement remains active.

Sessions that report `ended` are not disconnected again, whether that happens during or after setup. The public adapter contract does not require disconnecting an already-ended session to be safe. Interrupted setup still releases its registered handlers, including when a terminal notification or another cleanup throws.

Disconnect publishes the final cleared state once, preventing the same subscriber error from being collected twice.

## Verification

- Confirmed the original cleanup regression fails on unmodified main at the first throwing unsubscribe
- Added regression coverage for full teardown, reconnect, notification and partial-handler setup rollback, terminal status during setup, reentrant disconnect and replacement, idempotent disconnect, and single-error identity
- Paired tests cover terminal status during and after setup without an extra adapter disconnect, plus throwing terminal notifications and handler cleanup. The during-setup tests fail against the previous extra-disconnect implementation.
- `cd packages/core && ./node_modules/.bin/vitest run` (170 files, 1,847 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`
- `pnpm size:check`
- `pnpm changesets:check`
- Focused voice suite: 20 tests, including live-session setup rollback and replacement ownership
- `cd packages/react-google-adk && ./node_modules/.bin/vitest run src/useAdkRuntime.replacement.test.tsx --silent` (five consecutive runs passed, three tests each). The first CI run at `327d6724e` hit the existing cancellation flake tracked in #7032 and was rerun.

## Public surface

- `@assistant-ui/core`: behavior fix with a patch changeset
- Exports, API-reference output, documentation, and templates: unchanged
