### PR TITLE
fix(core): finish dictation cleanup after adapter errors

### DIFF
--- a/.changeset/tidy-dictation-cleanup.md
+++ b/.changeset/tidy-dictation-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: finish dictation cleanup after adapter errors

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -641,13 +641,17 @@ export abstract class BaseComposerRuntimeCore
     }
 
     if (this._dictationSession) {
-      for (const unsub of this._dictationUnsubscribes) {
-        unsub();
-      }
-      this._dictationUnsubscribes = [];
       const oldSession = this._dictationSession;
+      let cleanupFailed = false;
+      let cleanupError: unknown;
+      try {
+        this._cleanupDictation();
+      } catch (error) {
+        cleanupFailed = true;
+        cleanupError = error;
+      }
       oldSession.stop().catch(() => {});
-      this._dictationSession = undefined;
+      if (cleanupFailed) throw cleanupError;
     }
 
     const inputDisabled = adapter.disableInputDuringDictation ?? false;
@@ -733,7 +737,10 @@ export abstract class BaseComposerRuntimeCore
     const session = this._dictationSession;
     const sessionId = this._activeDictationSessionId;
     const cleanup = () => this._cleanupDictation({ sessionId });
-    void session.stop().then(cleanup, cleanup);
+    void session
+      .stop()
+      .then(cleanup, cleanup)
+      .catch((error) => console.error(error));
   }
 
   private _cleanupDictation(options?: { sessionId: number | undefined }): void {
@@ -743,20 +750,37 @@ export abstract class BaseComposerRuntimeCore
     if (isStaleSession || this._isCleaningDictation) return;
 
     this._isCleaningDictation = true;
-    try {
-      for (const unsub of this._dictationUnsubscribes) {
-        unsub();
+    let cleanupFailed = false;
+    let cleanupError: unknown;
+    const runCleanup = (cleanup: () => void) => {
+      try {
+        cleanup();
+      } catch (error) {
+        if (cleanupFailed) {
+          console.error(error);
+        } else {
+          cleanupFailed = true;
+          cleanupError = error;
+        }
       }
+    };
+
+    try {
+      const unsubscribes = this._dictationUnsubscribes;
       this._dictationUnsubscribes = [];
       this._dictationSession = undefined;
       this._activeDictationSessionId = undefined;
       this._dictation = undefined;
       this._dictationBaseText = "";
       this._currentInterimText = "";
-      this._notifySubscribers();
+
+      for (const unsubscribe of unsubscribes) runCleanup(unsubscribe);
+      runCleanup(() => this._notifySubscribers());
     } finally {
       this._isCleaningDictation = false;
     }
+
+    if (cleanupFailed) throw cleanupError;
   }
 
   private _eventSubscribers = new Map<

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -217,8 +217,13 @@ export abstract class BaseComposerRuntimeCore
     if (!this.canSend || this._isSending) return;
 
     if (this._dictationSession) {
-      this._dictationSession.cancel();
-      this._cleanupDictation();
+      try {
+        this._dictationSession.cancel();
+      } catch (error) {
+        console.error("[assistant-ui] Dictation session cancel threw", error);
+      } finally {
+        this._cleanupDictation();
+      }
     }
 
     const adapter = this.getAttachmentAdapter();
@@ -643,7 +648,7 @@ export abstract class BaseComposerRuntimeCore
     if (this._dictationSession) {
       const oldSession = this._dictationSession;
       this._cleanupDictation({ notify: false });
-      oldSession.stop().catch(() => {});
+      this._stopDictationSession(oldSession);
     }
 
     const inputDisabled = adapter.disableInputDuringDictation ?? false;
@@ -729,9 +734,25 @@ export abstract class BaseComposerRuntimeCore
     const session = this._dictationSession;
     const sessionId = this._activeDictationSessionId;
     const cleanup = () => this._cleanupDictation({ sessionId });
-    void session.stop().then(cleanup, (error) => {
+    this._stopDictationSession(session, cleanup);
+  }
+
+  private _stopDictationSession(
+    session: DictationAdapter.Session,
+    onSettled: () => void = () => {},
+  ): void {
+    let task: Promise<void>;
+    try {
+      task = session.stop();
+    } catch (error) {
+      console.error("[assistant-ui] Dictation session stop threw", error);
+      onSettled();
+      return;
+    }
+
+    void task.then(onSettled, (error) => {
       console.error("[assistant-ui] Dictation session stop rejected", error);
-      cleanup();
+      onSettled();
     });
   }
 

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -642,16 +642,8 @@ export abstract class BaseComposerRuntimeCore
 
     if (this._dictationSession) {
       const oldSession = this._dictationSession;
-      let cleanupFailed = false;
-      let cleanupError: unknown;
-      try {
-        this._cleanupDictation();
-      } catch (error) {
-        cleanupFailed = true;
-        cleanupError = error;
-      }
+      this._cleanupDictation({ notify: false });
       oldSession.stop().catch(() => {});
-      if (cleanupFailed) throw cleanupError;
     }
 
     const inputDisabled = adapter.disableInputDuringDictation ?? false;
@@ -737,31 +729,27 @@ export abstract class BaseComposerRuntimeCore
     const session = this._dictationSession;
     const sessionId = this._activeDictationSessionId;
     const cleanup = () => this._cleanupDictation({ sessionId });
-    void session
-      .stop()
-      .then(cleanup, cleanup)
-      .catch((error) => console.error(error));
+    void session.stop().then(cleanup, (error) => {
+      console.error("[assistant-ui] Dictation session stop rejected", error);
+      cleanup();
+    });
   }
 
-  private _cleanupDictation(options?: { sessionId: number | undefined }): void {
+  private _cleanupDictation(options?: {
+    sessionId?: number | undefined;
+    notify?: boolean | undefined;
+  }): void {
     const isStaleSession =
       options?.sessionId !== undefined &&
       options.sessionId !== this._activeDictationSessionId;
     if (isStaleSession || this._isCleaningDictation) return;
 
     this._isCleaningDictation = true;
-    let cleanupFailed = false;
-    let cleanupError: unknown;
     const runCleanup = (cleanup: () => void) => {
       try {
         cleanup();
       } catch (error) {
-        if (cleanupFailed) {
-          console.error(error);
-        } else {
-          cleanupFailed = true;
-          cleanupError = error;
-        }
+        console.error("[assistant-ui] Dictation cleanup threw", error);
       }
     };
 
@@ -775,12 +763,12 @@ export abstract class BaseComposerRuntimeCore
       this._currentInterimText = "";
 
       for (const unsubscribe of unsubscribes) runCleanup(unsubscribe);
-      runCleanup(() => this._notifySubscribers());
+      if (options?.notify !== false) {
+        runCleanup(() => this._notifySubscribers());
+      }
     } finally {
       this._isCleaningDictation = false;
     }
-
-    if (cleanupFailed) throw cleanupError;
   }
 
   private _eventSubscribers = new Map<

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -645,6 +645,7 @@ export abstract class BaseComposerRuntimeCore
       throw new Error("Dictation adapter not configured");
     }
 
+    const isReplacing = this._dictationSession !== undefined;
     if (this._dictationSession) {
       const oldSession = this._dictationSession;
       this._cleanupDictation({ notify: false });
@@ -656,7 +657,22 @@ export abstract class BaseComposerRuntimeCore
     this._dictationBaseText = this._text;
     this._currentInterimText = "";
 
-    const session = adapter.listen();
+    let session: DictationAdapter.Session;
+    try {
+      session = adapter.listen();
+    } catch (error) {
+      if (isReplacing) {
+        try {
+          this._notifySubscribers();
+        } catch (notifyError) {
+          console.error(
+            "[assistant-ui] Dictation replacement rollback notification threw",
+            notifyError,
+          );
+        }
+      }
+      throw error;
+    }
     this._dictationSession = session;
     const sessionId = ++this._dictationSessionIdCounter;
     this._activeDictationSessionId = sessionId;

--- a/packages/core/src/tests/base-composer-runtime-core.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core.test.ts
@@ -399,6 +399,34 @@ describe("BaseComposerRuntimeCore", () => {
     composer.stopDictation();
   });
 
+  it("publishes cleared state when replacement session creation throws", () => {
+    const listenError = new Error("listen failed");
+    const firstSession: DictationAdapter.Session = {
+      status: { type: "running" },
+      stop: vi.fn().mockResolvedValue(undefined),
+      cancel: vi.fn(),
+      onSpeech: () => () => {},
+      onSpeechStart: () => () => {},
+      onSpeechEnd: () => () => {},
+    };
+    const listen = vi
+      .fn()
+      .mockReturnValueOnce(firstSession)
+      .mockImplementationOnce(() => {
+        throw listenError;
+      });
+    composer.setDictationAdapter({ listen });
+    const states: Array<string | undefined> = [];
+    composer.subscribe(() => states.push(composer.dictation?.status.type));
+    composer.startDictation();
+    states.length = 0;
+
+    expect(() => composer.startDictation()).toThrow(listenError);
+
+    expect(composer.dictation).toBeUndefined();
+    expect(states).toEqual([undefined]);
+  });
+
   it("replaces dictation without publishing an intermediate cleared state", async () => {
     const session = (): DictationAdapter.Session => ({
       status: { type: "running" },

--- a/packages/core/src/tests/base-composer-runtime-core.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core.test.ts
@@ -253,6 +253,33 @@ describe("BaseComposerRuntimeCore", () => {
     }
   });
 
+  it("finishes dictation cleanup when an unsubscribe throws", async () => {
+    const cleanupError = new Error("cleanup failed");
+    const laterCleanup = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const session: DictationAdapter.Session = {
+      status: { type: "running" },
+      stop: vi.fn().mockResolvedValue(undefined),
+      cancel: vi.fn(),
+      onSpeech: vi.fn(() => () => {
+        throw cleanupError;
+      }),
+      onSpeechStart: vi.fn(() => laterCleanup),
+      onSpeechEnd: vi.fn(() => () => {}),
+    };
+    composer.setDictationAdapter({ listen: () => session });
+
+    composer.startDictation();
+    composer.stopDictation();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(laterCleanup).toHaveBeenCalledOnce();
+    expect(composer.dictation).toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(cleanupError);
+  });
+
   describe("CreateAttachment (external source)", () => {
     const makeCreateAttachment = (
       overrides?: Partial<CreateAttachment>,

--- a/packages/core/src/tests/base-composer-runtime-core.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { BaseComposerRuntimeCore } from "../runtime/base/base-composer-runtime-core";
 import type { AttachmentAdapter } from "../adapters/attachment";
 import type { DictationAdapter } from "../adapters/speech";
@@ -226,9 +226,14 @@ describe("BaseComposerRuntimeCore", () => {
   });
 
   it("handles rejected dictation shutdowns", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    onTestFinished(() => consoleError.mockRestore());
+    const stopError = new Error("shutdown failed");
     const session: DictationAdapter.Session = {
       status: { type: "running" },
-      stop: vi.fn().mockRejectedValue(new Error("shutdown failed")),
+      stop: vi.fn().mockRejectedValue(stopError),
       cancel: vi.fn(),
       onSpeechStart: vi.fn(() => () => {}),
       onSpeechEnd: vi.fn(() => () => {}),
@@ -248,6 +253,10 @@ describe("BaseComposerRuntimeCore", () => {
       expect(session.stop).toHaveBeenCalledOnce();
       expect(composer.dictation).toBeUndefined();
       expect(unhandledRejection).not.toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui] Dictation session stop rejected",
+        stopError,
+      );
     } finally {
       process.off("unhandledRejection", unhandledRejection);
     }
@@ -259,6 +268,7 @@ describe("BaseComposerRuntimeCore", () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
+    onTestFinished(() => consoleError.mockRestore());
     const session: DictationAdapter.Session = {
       status: { type: "running" },
       stop: vi.fn().mockResolvedValue(undefined),
@@ -277,7 +287,65 @@ describe("BaseComposerRuntimeCore", () => {
 
     expect(laterCleanup).toHaveBeenCalledOnce();
     expect(composer.dictation).toBeUndefined();
-    expect(consoleError).toHaveBeenCalledWith(cleanupError);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Dictation cleanup threw",
+      cleanupError,
+    );
+  });
+
+  it("sends after a dictation unsubscribe throws", async () => {
+    const cleanupError = new Error("cleanup failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    onTestFinished(() => consoleError.mockRestore());
+    composer.setDictationAdapter({
+      listen: () => ({
+        status: { type: "running" },
+        stop: vi.fn().mockResolvedValue(undefined),
+        cancel: vi.fn(),
+        onSpeech: () => () => {
+          throw cleanupError;
+        },
+        onSpeechStart: () => () => {},
+        onSpeechEnd: () => () => {},
+      }),
+    });
+    composer.setText("send me");
+    composer.startDictation();
+
+    await composer.send();
+
+    expect(composer.sentMessages).toHaveLength(1);
+    expect(composer.sentMessages[0]?.content).toEqual([
+      { type: "text", text: "send me" },
+    ]);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Dictation cleanup threw",
+      cleanupError,
+    );
+  });
+
+  it("replaces dictation without publishing an intermediate cleared state", async () => {
+    const session = (): DictationAdapter.Session => ({
+      status: { type: "running" },
+      stop: vi.fn().mockResolvedValue(undefined),
+      cancel: vi.fn(),
+      onSpeech: () => () => {},
+      onSpeechStart: () => () => {},
+      onSpeechEnd: () => () => {},
+    });
+    composer.setDictationAdapter({ listen: session });
+    const states: Array<string | undefined> = [];
+    composer.subscribe(() => states.push(composer.dictation?.status.type));
+    composer.startDictation();
+    states.length = 0;
+
+    composer.startDictation();
+
+    expect(states).toEqual(["running"]);
+    composer.stopDictation();
+    await Promise.resolve();
   });
 
   describe("CreateAttachment (external source)", () => {

--- a/packages/core/src/tests/base-composer-runtime-core.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core.test.ts
@@ -262,6 +262,34 @@ describe("BaseComposerRuntimeCore", () => {
     }
   });
 
+  it("handles synchronously throwing dictation shutdowns", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    onTestFinished(() => consoleError.mockRestore());
+    const stopError = new Error("shutdown failed");
+    const session: DictationAdapter.Session = {
+      status: { type: "running" },
+      stop: vi.fn(() => {
+        throw stopError;
+      }),
+      cancel: vi.fn(),
+      onSpeechStart: vi.fn(() => () => {}),
+      onSpeechEnd: vi.fn(() => () => {}),
+      onSpeech: vi.fn(() => () => {}),
+    };
+    composer.setDictationAdapter({ listen: () => session });
+    composer.startDictation();
+
+    expect(() => composer.stopDictation()).not.toThrow();
+
+    expect(composer.dictation).toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Dictation session stop threw",
+      stopError,
+    );
+  });
+
   it("finishes dictation cleanup when an unsubscribe throws", async () => {
     const cleanupError = new Error("cleanup failed");
     const laterCleanup = vi.fn();
@@ -295,6 +323,7 @@ describe("BaseComposerRuntimeCore", () => {
 
   it("sends after a dictation unsubscribe throws", async () => {
     const cleanupError = new Error("cleanup failed");
+    const cancelError = new Error("cancel failed");
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -303,7 +332,9 @@ describe("BaseComposerRuntimeCore", () => {
       listen: () => ({
         status: { type: "running" },
         stop: vi.fn().mockResolvedValue(undefined),
-        cancel: vi.fn(),
+        cancel: vi.fn(() => {
+          throw cancelError;
+        }),
         onSpeech: () => () => {
           throw cleanupError;
         },
@@ -321,9 +352,51 @@ describe("BaseComposerRuntimeCore", () => {
       { type: "text", text: "send me" },
     ]);
     expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Dictation session cancel threw",
+      cancelError,
+    );
+    expect(consoleError).toHaveBeenCalledWith(
       "[assistant-ui] Dictation cleanup threw",
       cleanupError,
     );
+  });
+
+  it("starts replacement dictation when the old session stop throws", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    onTestFinished(() => consoleError.mockRestore());
+    const stopError = new Error("shutdown failed");
+    const firstSession: DictationAdapter.Session = {
+      status: { type: "running" },
+      stop: vi.fn(() => {
+        throw stopError;
+      }),
+      cancel: vi.fn(),
+      onSpeech: () => () => {},
+      onSpeechStart: () => () => {},
+      onSpeechEnd: () => () => {},
+    };
+    const secondSession: DictationAdapter.Session = {
+      ...firstSession,
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const listen = vi
+      .fn()
+      .mockReturnValueOnce(firstSession)
+      .mockReturnValueOnce(secondSession);
+    composer.setDictationAdapter({ listen });
+    composer.startDictation();
+
+    expect(() => composer.startDictation()).not.toThrow();
+
+    expect(listen).toHaveBeenCalledTimes(2);
+    expect(composer.dictation).toBeDefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Dictation session stop threw",
+      stopError,
+    );
+    composer.stopDictation();
   });
 
   it("replaces dictation without publishing an intermediate cleared state", async () => {


### PR DESCRIPTION
## Problem

A throwing dictation unsubscribe can skip later cleanup and leave stale runtime state. Synchronous adapter errors from cancel or stop can also escape into send, replacement, event, or timer paths.

These failures reproduce with dictation sessions whose cleanup, cancel, or stop methods throw.

## Root cause

Dictation state was detached only after sequential adapter cleanup completed, and stop handling assumed the adapter always returned a rejecting promise instead of throwing synchronously.

## Change

Detach dictation state before cleanup, run every unsubscribe, and contain each adapter cleanup error with contextual logging. Sending continues after a throwing cancel, and both synchronous and asynchronous stop failures still complete cleanup.

Replacement uses the same cleanup mechanism, suppresses the intermediate cleared-state notification, and proceeds even when the old session stop throws. If starting the replacement session fails, subscribers receive the final cleared state before the original setup error is rethrown.

## Verification

- Confirmed the original regression fails on unmodified main because later cleanup is skipped and dictation remains active
- Added regression coverage for throwing unsubscribe, send after cancel failure, synchronous and rejected stop, replacement setup failure, notification behavior, and test cleanup
- `pnpm --filter @assistant-ui/core test` (170 files, 1,841 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`
- `pnpm size:check`
- `pnpm changesets:check`

## Public surface

- `@assistant-ui/core`: behavior fix with a patch changeset
- Exports, API-reference output, documentation, and templates: unchanged
