### PR TITLE
fix(react-a2a): retry agent card discovery

### DIFF
--- a/.changeset/fresh-a2a-agent-card.md
+++ b/.changeset/fresh-a2a-agent-card.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: retry agent card discovery after transient failures

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -799,14 +799,17 @@ describe("A2AThreadRuntimeCore", () => {
     it("retries agent card discovery after a transient failure", async () => {
       let now = 1_000;
       vi.spyOn(Date, "now").mockImplementation(() => now);
+      let resolveRecovery!: (card: A2AAgentCard) => void;
       const transportOrder: string[] = [];
       const getAgentCard = vi
         .fn()
         .mockRejectedValueOnce(new Error("temporary failure"))
-        .mockResolvedValue({
-          name: "Agent",
-          capabilities: { streaming: false },
-        } as A2AAgentCard);
+        .mockImplementationOnce(
+          () =>
+            new Promise<A2AAgentCard>((resolve) => {
+              resolveRecovery = resolve;
+            }),
+        );
       const sendMessage = vi.fn().mockImplementation(async () => {
         transportOrder.push("sync");
         return {
@@ -823,11 +826,17 @@ describe("A2AThreadRuntimeCore", () => {
       await core.append(createUserAppendMessage("First"));
       now += 5_000;
       await core.append(createUserAppendMessage("Second"));
+      resolveRecovery({
+        name: "Agent",
+        capabilities: { streaming: false },
+      } as A2AAgentCard);
+      await vi.waitFor(() => expect(core.getAgentCard()).toBeDefined());
+      await core.append(createUserAppendMessage("Third"));
 
       expect(getAgentCard).toHaveBeenCalledTimes(2);
-      expect(streamMessage).toHaveBeenCalledOnce();
+      expect(streamMessage).toHaveBeenCalledTimes(2);
       expect(sendMessage).toHaveBeenCalledOnce();
-      expect(transportOrder).toEqual(["stream", "sync"]);
+      expect(transportOrder).toEqual(["stream", "stream", "sync"]);
     });
 
     it("does not repeat failed discovery during the retry delay", async () => {
@@ -843,6 +852,42 @@ describe("A2AThreadRuntimeCore", () => {
 
       expect(getAgentCard).toHaveBeenCalledOnce();
       expect(streamMessage).toHaveBeenCalledTimes(2);
+    });
+
+    it("backs off persistent failures without blocking later sends", async () => {
+      let now = 1_000;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
+      let rejectSecond!: (error: Error) => void;
+      const getAgentCard = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("first failure"))
+        .mockImplementationOnce(
+          () =>
+            new Promise<A2AAgentCard>((_resolve, reject) => {
+              rejectSecond = reject;
+            }),
+        )
+        .mockRejectedValue(new Error("still unavailable"));
+      const streamMessage = vi.fn().mockImplementation(async function* () {
+        yield statusUpdateEvent("completed");
+      });
+      const core = createCore({ getAgentCard, streamMessage });
+
+      await core.append(createUserAppendMessage("First"));
+      now = 6_000;
+      await core.append(createUserAppendMessage("Second"));
+      expect(streamMessage).toHaveBeenCalledTimes(2);
+      rejectSecond(new Error("second failure"));
+      await vi.waitFor(() => expect(getAgentCard).toHaveBeenCalledTimes(2));
+
+      now = 15_999;
+      await core.append(createUserAppendMessage("Third"));
+      expect(getAgentCard).toHaveBeenCalledTimes(2);
+
+      now = 16_000;
+      await core.append(createUserAppendMessage("Fourth"));
+      expect(getAgentCard).toHaveBeenCalledTimes(3);
+      expect(streamMessage).toHaveBeenCalledTimes(4);
     });
 
     it("waits for agent capabilities before choosing the first send method", async () => {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -797,6 +797,9 @@ describe("A2AThreadRuntimeCore", () => {
 
   describe("sync fallback", () => {
     it("retries agent card discovery after a transient failure", async () => {
+      let now = 1_000;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
+      const transportOrder: string[] = [];
       const getAgentCard = vi
         .fn()
         .mockRejectedValueOnce(new Error("temporary failure"))
@@ -804,21 +807,42 @@ describe("A2AThreadRuntimeCore", () => {
           name: "Agent",
           capabilities: { streaming: false },
         } as A2AAgentCard);
-      const sendMessage = vi.fn().mockResolvedValue({
-        id: "t1",
-        status: { state: "completed" },
-      } satisfies A2ATask);
+      const sendMessage = vi.fn().mockImplementation(async () => {
+        transportOrder.push("sync");
+        return {
+          id: "t1",
+          status: { state: "completed" },
+        } satisfies A2ATask;
+      });
       const streamMessage = vi.fn().mockImplementation(async function* () {
+        transportOrder.push("stream");
         yield statusUpdateEvent("completed");
       });
       const core = createCore({ getAgentCard, sendMessage, streamMessage });
 
       await core.append(createUserAppendMessage("First"));
+      now += 5_000;
       await core.append(createUserAppendMessage("Second"));
 
       expect(getAgentCard).toHaveBeenCalledTimes(2);
       expect(streamMessage).toHaveBeenCalledOnce();
       expect(sendMessage).toHaveBeenCalledOnce();
+      expect(transportOrder).toEqual(["stream", "sync"]);
+    });
+
+    it("does not repeat failed discovery during the retry delay", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(1_000);
+      const getAgentCard = vi.fn().mockRejectedValue(new Error("unavailable"));
+      const streamMessage = vi.fn().mockImplementation(async function* () {
+        yield statusUpdateEvent("completed");
+      });
+      const core = createCore({ getAgentCard, streamMessage });
+
+      await core.append(createUserAppendMessage("First"));
+      await core.append(createUserAppendMessage("Second"));
+
+      expect(getAgentCard).toHaveBeenCalledOnce();
+      expect(streamMessage).toHaveBeenCalledTimes(2);
     });
 
     it("waits for agent capabilities before choosing the first send method", async () => {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -796,6 +796,31 @@ describe("A2AThreadRuntimeCore", () => {
   // --- Sync (non-streaming) fallback ---
 
   describe("sync fallback", () => {
+    it("retries agent card discovery after a transient failure", async () => {
+      const getAgentCard = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("temporary failure"))
+        .mockResolvedValue({
+          name: "Agent",
+          capabilities: { streaming: false },
+        } as A2AAgentCard);
+      const sendMessage = vi.fn().mockResolvedValue({
+        id: "t1",
+        status: { state: "completed" },
+      } satisfies A2ATask);
+      const streamMessage = vi.fn().mockImplementation(async function* () {
+        yield statusUpdateEvent("completed");
+      });
+      const core = createCore({ getAgentCard, sendMessage, streamMessage });
+
+      await core.append(createUserAppendMessage("First"));
+      await core.append(createUserAppendMessage("Second"));
+
+      expect(getAgentCard).toHaveBeenCalledTimes(2);
+      expect(streamMessage).toHaveBeenCalledOnce();
+      expect(sendMessage).toHaveBeenCalledOnce();
+    });
+
     it("waits for agent capabilities before choosing the first send method", async () => {
       let resolveAgentCard!: (value: A2AAgentCard) => void;
       const getAgentCard = vi.fn(

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -33,7 +33,8 @@ import {
   taskStateToMessageStatus,
 } from "./conversions";
 
-const AGENT_CARD_RETRY_DELAY_MS = 5_000;
+const INITIAL_AGENT_CARD_RETRY_DELAY_MS = 5_000;
+const MAX_AGENT_CARD_RETRY_DELAY_MS = 5 * 60_000;
 
 export type A2AThreadRuntimeCoreOptions = {
   client: A2AClient;
@@ -97,6 +98,8 @@ export class A2AThreadRuntimeCore {
   private _loadRequested = false;
   private _agentCardPromise: Promise<void> | undefined;
   private _agentCardRetryAfter = 0;
+  private _agentCardRetryDelay = INITIAL_AGENT_CARD_RETRY_DELAY_MS;
+  private _agentCardDiscoveryFailed = false;
 
   private lastOptionsContextId: string | undefined;
 
@@ -208,10 +211,17 @@ export class A2AThreadRuntimeCore {
       (agentCard) => {
         this.agentCardValue = agentCard;
         this._agentCardRetryAfter = 0;
+        this._agentCardRetryDelay = INITIAL_AGENT_CARD_RETRY_DELAY_MS;
+        this._agentCardDiscoveryFailed = false;
         this.notifyUpdate();
       },
       () => {
-        this._agentCardRetryAfter = Date.now() + AGENT_CARD_RETRY_DELAY_MS;
+        this._agentCardDiscoveryFailed = true;
+        this._agentCardRetryAfter = Date.now() + this._agentCardRetryDelay;
+        this._agentCardRetryDelay = Math.min(
+          this._agentCardRetryDelay * 2,
+          MAX_AGENT_CARD_RETRY_DELAY_MS,
+        );
         this._agentCardPromise = undefined;
       },
     );
@@ -219,8 +229,10 @@ export class A2AThreadRuntimeCore {
   }
 
   private async waitForAgentCard(signal: AbortSignal): Promise<boolean> {
+    const shouldWait = !this._agentCardDiscoveryFailed;
     const load = this.loadAgentCard();
     if (signal.aborted) return false;
+    if (!shouldWait) return true;
 
     let onAbort!: () => void;
     const abort = new Promise<void>((resolve) => {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -25,12 +25,15 @@ import type {
   A2ATaskArtifactUpdateEvent,
   A2ATaskStatusUpdateEvent,
 } from "./types";
+
 import {
   a2aMessageToContent,
   isTerminalTaskState,
   threadMessageToA2AMessage,
   taskStateToMessageStatus,
 } from "./conversions";
+
+const AGENT_CARD_RETRY_DELAY_MS = 5_000;
 
 export type A2AThreadRuntimeCoreOptions = {
   client: A2AClient;
@@ -93,6 +96,7 @@ export class A2AThreadRuntimeCore {
   private _loadPromise: Promise<void> | undefined;
   private _loadRequested = false;
   private _agentCardPromise: Promise<void> | undefined;
+  private _agentCardRetryAfter = 0;
 
   private lastOptionsContextId: string | undefined;
 
@@ -198,12 +202,16 @@ export class A2AThreadRuntimeCore {
   }
 
   private loadAgentCard(): Promise<void> {
+    if (Date.now() < this._agentCardRetryAfter) return Promise.resolve();
+
     this._agentCardPromise ??= this.client.getAgentCard().then(
       (agentCard) => {
         this.agentCardValue = agentCard;
+        this._agentCardRetryAfter = 0;
         this.notifyUpdate();
       },
       () => {
+        this._agentCardRetryAfter = Date.now() + AGENT_CARD_RETRY_DELAY_MS;
         this._agentCardPromise = undefined;
       },
     );

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -198,13 +198,15 @@ export class A2AThreadRuntimeCore {
   }
 
   private loadAgentCard(): Promise<void> {
-    this._agentCardPromise ??= this.client
-      .getAgentCard()
-      .then((agentCard) => {
+    this._agentCardPromise ??= this.client.getAgentCard().then(
+      (agentCard) => {
         this.agentCardValue = agentCard;
         this.notifyUpdate();
-      })
-      .catch(() => undefined);
+      },
+      () => {
+        this._agentCardPromise = undefined;
+      },
+    );
     return this._agentCardPromise;
   }
 

--- a/packages/react-a2a/src/useA2ARuntime.test.tsx
+++ b/packages/react-a2a/src/useA2ARuntime.test.tsx
@@ -74,7 +74,21 @@ const createFetchMock = () =>
           : input.url;
     if (url.endsWith("/.well-known/agent-card.json")) {
       return new Response(
-        JSON.stringify({ capabilities: { streaming: true } }),
+        JSON.stringify({
+          name: "Test Agent",
+          version: "1.0",
+          supported_interfaces: [
+            {
+              url: "https://agent.test",
+              protocol_binding: "HTTP+JSON",
+              protocol_version: "1.0",
+            },
+          ],
+          capabilities: { streaming: true },
+          default_input_modes: ["text"],
+          default_output_modes: ["text"],
+          skills: [],
+        }),
         {
           status: 200,
           headers: { "Content-Type": "application/json" },

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -47,8 +47,8 @@
   },
   "@assistant-ui/react-a2a": {
     ".": {
-      "min": 27557,
-      "gzip": 8344
+      "min": 28519,
+      "gzip": 8633
     }
   },
   "@assistant-ui/react-ag-ui": {


### PR DESCRIPTION
## Problem

After one transient agent-card discovery failure, an A2A runtime can keep using the streaming fallback even after the endpoint recovers. Retrying on every send, however, would add failed network latency to every message when an endpoint stays unavailable.

The current implementation reproduces the permanent failure with a first discovery that rejects and a later card that declares streaming false.

## Root cause

The runtime converted discovery rejection into a fulfilled cached promise, so the failed lookup stayed memoized for the lifetime of the runtime.

## Change

Keep successful discovery memoized. After a failure, later discovery attempts run in the background so message sends continue immediately through the existing fallback even if the endpoint remains unavailable. Retries use capped exponential backoff, starting at five seconds and increasing to five minutes, so persistent failures do not create a request or latency loop.

The regression asserts the ordered transport choice is streaming before recovery and synchronous after recovery. The managed-client fixture now returns a valid agent card rather than depending on a parsing failure.

Update the measured package size budget for the additional retry state.

## Verification

- Confirmed the regression fails on unmodified main because discovery runs once and the synchronous transport is never selected
- Added coverage for the retry delay, capped exponential backoff, non-blocking persistent failures, later recovery, and ordered transport selection
- `pnpm --filter @assistant-ui/react-a2a test` (4 files, 298 tests)
- `pnpm --filter @assistant-ui/react-a2a build`
- `pnpm lint`
- `pnpm size:check`
- `pnpm changesets:check`

## Public surface

- `@assistant-ui/react-a2a`: behavior fix with a patch changeset
- Size budget: updated for the changed package build
- Exports, API-reference output, documentation, and templates: unchanged
