### PR TITLE
fix(ui): reset copy feedback after repeated writes

### DIFF
--- a/.changeset/calm-devtools-copy-feedback.md
+++ b/.changeset/calm-devtools-copy-feedback.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+fix: reset clipboard feedback timers after repeated copies

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -59,6 +59,7 @@
     "@types/node": "^26.4.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.7",
+    "jsdom": "^30.0.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "tailwindcss": "^4.3.3",

--- a/packages/react-devtools/src/views/ui/useCopyToClipboard.test.tsx
+++ b/packages/react-devtools/src/views/ui/useCopyToClipboard.test.tsx
@@ -2,45 +2,105 @@
 
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { useCopyToClipboard } from "./useCopyToClipboard";
+
+const mockClipboard = (writeText: (value: string) => Promise<void>) => {
+  const descriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn(writeText) },
+  });
+  onTestFinished(() => {
+    if (descriptor) {
+      Object.defineProperty(navigator, "clipboard", descriptor);
+    } else {
+      delete (navigator as { clipboard?: unknown }).clipboard;
+    }
+  });
+};
+
+const renderCopyHook = async () => {
+  let result!: ReturnType<typeof useCopyToClipboard>;
+  const Probe = () => {
+    result = useCopyToClipboard({ copiedDuration: 1_000 });
+    return null;
+  };
+  const root = createRoot(document.createElement("div"));
+  await act(async () => root.render(<Probe />));
+  return {
+    get result() {
+      return result;
+    },
+    unmount: () => act(async () => root.unmount()),
+  };
+};
 
 describe("useCopyToClipboard", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("keeps copied feedback for the full duration after the latest copy", async () => {
+  it("keeps copied feedback for the full duration after the latest success", async () => {
     vi.useFakeTimers();
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText: vi.fn().mockResolvedValue(undefined) },
-    });
-    let result!: ReturnType<typeof useCopyToClipboard>;
-    const Probe = () => {
-      result = useCopyToClipboard({ copiedDuration: 1_000 });
-      return null;
-    };
-    const container = document.createElement("div");
-    const root = createRoot(container);
-    await act(async () => root.render(<Probe />));
+    mockClipboard(() => Promise.resolve());
+    const hook = await renderCopyHook();
 
     await act(async () => {
-      result.copy("first");
+      hook.result.copy("first");
       await Promise.resolve();
     });
     act(() => vi.advanceTimersByTime(500));
     await act(async () => {
-      result.copy("second");
+      hook.result.copy("second");
       await Promise.resolve();
     });
 
     act(() => vi.advanceTimersByTime(500));
-    expect(result.isCopied).toBe(true);
+    expect(hook.result.isCopied).toBe(true);
 
     act(() => vi.advanceTimersByTime(500));
-    expect(result.isCopied).toBe(false);
+    expect(hook.result.isCopied).toBe(false);
+    await hook.unmount();
+  });
 
-    await act(async () => root.unmount());
+  it("keeps an earlier successful write when a newer write rejects", async () => {
+    let resolveFirst!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockClipboard(
+      vi
+        .fn()
+        .mockReturnValueOnce(firstWrite)
+        .mockRejectedValueOnce(new Error("denied")),
+    );
+    const hook = await renderCopyHook();
+
+    hook.result.copy("first");
+    hook.result.copy("second");
+    await act(async () => Promise.resolve());
+    resolveFirst();
+    await act(async () => firstWrite);
+
+    expect(hook.result.isCopied).toBe(true);
+    await hook.unmount();
+  });
+
+  it("clears timers and ignores pending writes after unmount", async () => {
+    vi.useFakeTimers();
+    let resolveWrite!: () => void;
+    const write = new Promise<void>((resolve) => {
+      resolveWrite = resolve;
+    });
+    mockClipboard(() => write);
+    const hook = await renderCopyHook();
+
+    hook.result.copy("value");
+    await hook.unmount();
+    resolveWrite();
+    await write;
+
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/packages/react-devtools/src/views/ui/useCopyToClipboard.test.tsx
+++ b/packages/react-devtools/src/views/ui/useCopyToClipboard.test.tsx
@@ -65,6 +65,7 @@ describe("useCopyToClipboard", () => {
   });
 
   it("keeps an earlier successful write when a newer write rejects", async () => {
+    vi.useFakeTimers();
     let resolveFirst!: () => void;
     const firstWrite = new Promise<void>((resolve) => {
       resolveFirst = resolve;
@@ -84,6 +85,34 @@ describe("useCopyToClipboard", () => {
     await act(async () => firstWrite);
 
     expect(hook.result.isCopied).toBe(true);
+    await hook.unmount();
+  });
+
+  it("ignores an older write that succeeds after a newer success", async () => {
+    vi.useFakeTimers();
+    let resolveFirst!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockClipboard(
+      vi.fn().mockReturnValueOnce(firstWrite).mockResolvedValueOnce(undefined),
+    );
+    const hook = await renderCopyHook();
+
+    hook.result.copy("first");
+    await act(async () => {
+      hook.result.copy("second");
+      await Promise.resolve();
+    });
+    act(() => vi.advanceTimersByTime(1_000));
+    expect(hook.result.isCopied).toBe(false);
+
+    await act(async () => {
+      resolveFirst();
+      await firstWrite;
+    });
+    expect(hook.result.isCopied).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
     await hook.unmount();
   });
 

--- a/packages/react-devtools/src/views/ui/useCopyToClipboard.test.tsx
+++ b/packages/react-devtools/src/views/ui/useCopyToClipboard.test.tsx
@@ -88,7 +88,22 @@ describe("useCopyToClipboard", () => {
     await hook.unmount();
   });
 
-  it("clears timers and ignores pending writes after unmount", async () => {
+  it("clears an active feedback timer when unmounted", async () => {
+    vi.useFakeTimers();
+    mockClipboard(() => Promise.resolve());
+    const hook = await renderCopyHook();
+
+    await act(async () => {
+      hook.result.copy("value");
+      await Promise.resolve();
+    });
+    expect(vi.getTimerCount()).toBe(1);
+
+    await hook.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("ignores pending writes after unmount", async () => {
     vi.useFakeTimers();
     let resolveWrite!: () => void;
     const write = new Promise<void>((resolve) => {

--- a/packages/react-devtools/src/views/ui/useCopyToClipboard.test.tsx
+++ b/packages/react-devtools/src/views/ui/useCopyToClipboard.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useCopyToClipboard } from "./useCopyToClipboard";
+
+describe("useCopyToClipboard", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps copied feedback for the full duration after the latest copy", async () => {
+    vi.useFakeTimers();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    let result!: ReturnType<typeof useCopyToClipboard>;
+    const Probe = () => {
+      result = useCopyToClipboard({ copiedDuration: 1_000 });
+      return null;
+    };
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    await act(async () => root.render(<Probe />));
+
+    await act(async () => {
+      result.copy("first");
+      await Promise.resolve();
+    });
+    act(() => vi.advanceTimersByTime(500));
+    await act(async () => {
+      result.copy("second");
+      await Promise.resolve();
+    });
+
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.isCopied).toBe(true);
+
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.isCopied).toBe(false);
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/react-devtools/src/views/ui/useCopyToClipboard.test.tsx
+++ b/packages/react-devtools/src/views/ui/useCopyToClipboard.test.tsx
@@ -88,34 +88,6 @@ describe("useCopyToClipboard", () => {
     await hook.unmount();
   });
 
-  it("ignores an older write that succeeds after a newer success", async () => {
-    vi.useFakeTimers();
-    let resolveFirst!: () => void;
-    const firstWrite = new Promise<void>((resolve) => {
-      resolveFirst = resolve;
-    });
-    mockClipboard(
-      vi.fn().mockReturnValueOnce(firstWrite).mockResolvedValueOnce(undefined),
-    );
-    const hook = await renderCopyHook();
-
-    hook.result.copy("first");
-    await act(async () => {
-      hook.result.copy("second");
-      await Promise.resolve();
-    });
-    act(() => vi.advanceTimersByTime(1_000));
-    expect(hook.result.isCopied).toBe(false);
-
-    await act(async () => {
-      resolveFirst();
-      await firstWrite;
-    });
-    expect(hook.result.isCopied).toBe(false);
-    expect(vi.getTimerCount()).toBe(0);
-    await hook.unmount();
-  });
-
   it("clears timers and ignores pending writes after unmount", async () => {
     vi.useFakeTimers();
     let resolveWrite!: () => void;

--- a/packages/react-devtools/src/views/ui/useCopyToClipboard.ts
+++ b/packages/react-devtools/src/views/ui/useCopyToClipboard.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export const useCopyToClipboard = ({
   copiedDuration = 2000,
@@ -6,16 +6,35 @@ export const useCopyToClipboard = ({
   copiedDuration?: number;
 } = {}) => {
   const [isCopied, setIsCopied] = useState(false);
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const copyGeneration = useRef(0);
+
+  useEffect(
+    () => () => {
+      copyGeneration.current += 1;
+      clearTimeout(copiedTimer.current);
+    },
+    [],
+  );
 
   const copy = useCallback(
     (value: string) => {
       if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
         return;
       }
+      const generation = ++copyGeneration.current;
       navigator.clipboard.writeText(value).then(
         () => {
+          if (generation !== copyGeneration.current) return;
+
+          clearTimeout(copiedTimer.current);
           setIsCopied(true);
-          window.setTimeout(() => setIsCopied(false), copiedDuration);
+          copiedTimer.current = window.setTimeout(() => {
+            copiedTimer.current = undefined;
+            setIsCopied(false);
+          }, copiedDuration);
         },
         () => {},
       );

--- a/packages/react-devtools/src/views/ui/useCopyToClipboard.ts
+++ b/packages/react-devtools/src/views/ui/useCopyToClipboard.ts
@@ -7,8 +7,6 @@ export const useCopyToClipboard = ({
 } = {}) => {
   const [isCopied, setIsCopied] = useState(false);
   const copiedTimer = useRef<number | undefined>(undefined);
-  const copyGeneration = useRef(0);
-  const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
 
   useEffect(() => {
@@ -24,11 +22,8 @@ export const useCopyToClipboard = ({
       if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
         return;
       }
-      const generation = ++copyGeneration.current;
       navigator.clipboard.writeText(value).then(
         () => {
-          if (generation < latestSuccessfulCopy.current) return;
-          latestSuccessfulCopy.current = generation;
           if (!isMounted.current) return;
 
           window.clearTimeout(copiedTimer.current);

--- a/packages/react-devtools/src/views/ui/useCopyToClipboard.ts
+++ b/packages/react-devtools/src/views/ui/useCopyToClipboard.ts
@@ -9,25 +9,24 @@ export const useCopyToClipboard = ({
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
-  const copyGeneration = useRef(0);
+  const isMounted = useRef(true);
 
-  useEffect(
-    () => () => {
-      copyGeneration.current += 1;
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
       clearTimeout(copiedTimer.current);
-    },
-    [],
-  );
+    };
+  }, []);
 
   const copy = useCallback(
     (value: string) => {
       if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
         return;
       }
-      const generation = ++copyGeneration.current;
       navigator.clipboard.writeText(value).then(
         () => {
-          if (generation !== copyGeneration.current) return;
+          if (!isMounted.current) return;
 
           clearTimeout(copiedTimer.current);
           setIsCopied(true);

--- a/packages/react-devtools/src/views/ui/useCopyToClipboard.ts
+++ b/packages/react-devtools/src/views/ui/useCopyToClipboard.ts
@@ -9,6 +9,8 @@ export const useCopyToClipboard = ({
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const copyGeneration = useRef(0);
+  const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
 
   useEffect(() => {
@@ -24,8 +26,11 @@ export const useCopyToClipboard = ({
       if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
         return;
       }
+      const generation = ++copyGeneration.current;
       navigator.clipboard.writeText(value).then(
         () => {
+          if (generation < latestSuccessfulCopy.current) return;
+          latestSuccessfulCopy.current = generation;
           if (!isMounted.current) return;
 
           clearTimeout(copiedTimer.current);

--- a/packages/react-devtools/src/views/ui/useCopyToClipboard.ts
+++ b/packages/react-devtools/src/views/ui/useCopyToClipboard.ts
@@ -6,9 +6,7 @@ export const useCopyToClipboard = ({
   copiedDuration?: number;
 } = {}) => {
   const [isCopied, setIsCopied] = useState(false);
-  const copiedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined,
-  );
+  const copiedTimer = useRef<number | undefined>(undefined);
   const copyGeneration = useRef(0);
   const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
@@ -17,7 +15,7 @@ export const useCopyToClipboard = ({
     isMounted.current = true;
     return () => {
       isMounted.current = false;
-      clearTimeout(copiedTimer.current);
+      window.clearTimeout(copiedTimer.current);
     };
   }, []);
 
@@ -33,7 +31,7 @@ export const useCopyToClipboard = ({
           latestSuccessfulCopy.current = generation;
           if (!isMounted.current) return;
 
-          clearTimeout(copiedTimer.current);
+          window.clearTimeout(copiedTimer.current);
           setIsCopied(true);
           copiedTimer.current = window.setTimeout(() => {
             copiedTimer.current = undefined;

--- a/packages/ui/src/components/react/assistant-ui/elements/markdown-text.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/markdown-text.test.tsx
@@ -45,6 +45,7 @@ vi.mock("@assistant-ui/react-markdown", async (importOriginal) => {
 });
 
 import { MarkdownText } from "./markdown-text";
+// Minimal's Markdown override bypasses template sync, so its inline copy hook is covered here.
 import { MarkdownText as MinimalMarkdownText } from "../../../../../../../templates/minimal/components/assistant-ui/elements/markdown-text";
 
 afterEach(() => {

--- a/packages/ui/src/components/react/assistant-ui/elements/markdown-text.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/markdown-text.test.tsx
@@ -1,7 +1,13 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import type { MarkdownTextPrimitiveProps } from "@assistant-ui/react-markdown";
 import type { ComponentType } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   components: undefined as MarkdownTextPrimitiveProps["components"],
@@ -39,10 +45,90 @@ vi.mock("@assistant-ui/react-markdown", async (importOriginal) => {
 });
 
 import { MarkdownText } from "./markdown-text";
+import { MarkdownText as MinimalMarkdownText } from "../../../../../../../templates/minimal/components/assistant-ui/elements/markdown-text";
 
 afterEach(() => {
   cleanup();
   mocks.components = undefined;
+  vi.useRealTimers();
+});
+
+describe.each([
+  ["shared", MarkdownText],
+  ["minimal template", MinimalMarkdownText],
+] as const)("%s markdown copy feedback", (_name, Component) => {
+  const mockClipboard = (writeText: () => Promise<void>) => {
+    const descriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    onTestFinished(() => {
+      if (descriptor) Object.defineProperty(navigator, "clipboard", descriptor);
+      else delete (navigator as { clipboard?: unknown }).clipboard;
+    });
+  };
+
+  it("resets feedback when another pending copy succeeds", async () => {
+    vi.useFakeTimers();
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+    const first = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const second = new Promise<void>((resolve) => {
+      resolveSecond = resolve;
+    });
+    mockClipboard(
+      vi.fn().mockReturnValueOnce(first).mockReturnValueOnce(second),
+    );
+    render(<Component />);
+    const button = screen.getByRole("button", { name: "Copy" });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    await act(async () => {
+      resolveFirst();
+      await first;
+    });
+    act(() => vi.advanceTimersByTime(1000));
+    await act(async () => {
+      resolveSecond();
+      await second;
+    });
+    expect(vi.getTimerCount()).toBe(1);
+    act(() => vi.advanceTimersByTime(2000));
+    expect(button.querySelector(".lucide-check")).not.toBeNull();
+    act(() => vi.advanceTimersByTime(1000));
+    expect(button.querySelector(".lucide-check")).toBeNull();
+  });
+
+  it("clears active feedback on unmount", async () => {
+    vi.useFakeTimers();
+    mockClipboard(() => Promise.resolve());
+    const view = render(<Component />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    await act(async () => Promise.resolve());
+    expect(vi.getTimerCount()).toBe(1);
+    view.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not schedule feedback for a write finishing after unmount", async () => {
+    vi.useFakeTimers();
+    let finish!: () => void;
+    const write = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    mockClipboard(() => write);
+    const view = render(<Component />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    view.unmount();
+    await act(async () => {
+      finish();
+      await write;
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });
 
 describe("MarkdownText component overrides", () => {

--- a/packages/ui/src/components/react/ui/base/code-block.tsx
+++ b/packages/ui/src/components/react/ui/base/code-block.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useRef, useState, type ComponentProps, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -30,20 +36,39 @@ function CopyButton({
   className?: string;
 }) {
   const [copied, setCopied] = useState(false);
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const copyGeneration = useRef(0);
+
+  useEffect(
+    () => () => {
+      copyGeneration.current += 1;
+      clearTimeout(copyTimer.current);
+    },
+    [],
+  );
 
   return (
     <button
       type="button"
       aria-label="Copy code"
       onClick={async () => {
+        const generation = ++copyGeneration.current;
         try {
           await navigator.clipboard.writeText(getText());
         } catch {
           return;
         }
+        if (generation !== copyGeneration.current) return;
+
         onCopied?.();
         setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        clearTimeout(copyTimer.current);
+        copyTimer.current = setTimeout(() => {
+          copyTimer.current = undefined;
+          setCopied(false);
+        }, 1500);
       }}
       className={cn(
         "text-muted-foreground hover:text-foreground grid size-6 shrink-0 place-items-center rounded-sm transition-colors",

--- a/packages/ui/src/components/react/ui/base/code-block.tsx
+++ b/packages/ui/src/components/react/ui/base/code-block.tsx
@@ -39,6 +39,8 @@ function CopyButton({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const copyGeneration = useRef(0);
+  const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
 
   useEffect(() => {
@@ -54,11 +56,14 @@ function CopyButton({
       type="button"
       aria-label="Copy code"
       onClick={async () => {
+        const generation = ++copyGeneration.current;
         try {
           await navigator.clipboard.writeText(getText());
         } catch {
           return;
         }
+        if (generation < latestSuccessfulCopy.current) return;
+        latestSuccessfulCopy.current = generation;
         onCopied?.();
         if (!isMounted.current) return;
         setCopied(true);

--- a/packages/ui/src/components/react/ui/base/code-block.tsx
+++ b/packages/ui/src/components/react/ui/base/code-block.tsx
@@ -59,8 +59,6 @@ function CopyButton({
         } catch {
           return;
         }
-        if (!isMounted.current) return;
-
         onCopied?.();
         if (!isMounted.current) return;
         setCopied(true);

--- a/packages/ui/src/components/react/ui/base/code-block.tsx
+++ b/packages/ui/src/components/react/ui/base/code-block.tsx
@@ -39,8 +39,6 @@ function CopyButton({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
-  const copyGeneration = useRef(0);
-  const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
 
   useEffect(() => {
@@ -56,14 +54,11 @@ function CopyButton({
       type="button"
       aria-label="Copy code"
       onClick={async () => {
-        const generation = ++copyGeneration.current;
         try {
           await navigator.clipboard.writeText(getText());
         } catch {
           return;
         }
-        if (generation < latestSuccessfulCopy.current) return;
-        latestSuccessfulCopy.current = generation;
         onCopied?.();
         if (!isMounted.current) return;
         setCopied(true);

--- a/packages/ui/src/components/react/ui/base/code-block.tsx
+++ b/packages/ui/src/components/react/ui/base/code-block.tsx
@@ -39,30 +39,30 @@ function CopyButton({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
-  const copyGeneration = useRef(0);
+  const isMounted = useRef(true);
 
-  useEffect(
-    () => () => {
-      copyGeneration.current += 1;
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
       clearTimeout(copyTimer.current);
-    },
-    [],
-  );
+    };
+  }, []);
 
   return (
     <button
       type="button"
       aria-label="Copy code"
       onClick={async () => {
-        const generation = ++copyGeneration.current;
         try {
           await navigator.clipboard.writeText(getText());
         } catch {
           return;
         }
-        if (generation !== copyGeneration.current) return;
+        if (!isMounted.current) return;
 
         onCopied?.();
+        if (!isMounted.current) return;
         setCopied(true);
         clearTimeout(copyTimer.current);
         copyTimer.current = setTimeout(() => {

--- a/packages/ui/src/components/react/ui/base/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/base/command-tabs.tsx
@@ -48,6 +48,8 @@ export function CommandTabs({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const copyGeneration = useRef(0);
+  const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
 
   const commandsRef = useRef(commands);
@@ -136,11 +138,14 @@ export function CommandTabs({
           type="button"
           aria-label="Copy command"
           onClick={async () => {
+            const generation = ++copyGeneration.current;
             try {
               await navigator.clipboard.writeText(command);
             } catch {
               return;
             }
+            if (generation < latestSuccessfulCopy.current) return;
+            latestSuccessfulCopy.current = generation;
             if (!isMounted.current) return;
 
             setCopied(true);

--- a/packages/ui/src/components/react/ui/base/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/base/command-tabs.tsx
@@ -48,9 +48,18 @@ export function CommandTabs({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const copyGeneration = useRef(0);
 
   const commandsRef = useRef(commands);
   commandsRef.current = commands;
+
+  useEffect(
+    () => () => {
+      copyGeneration.current += 1;
+      clearTimeout(copyTimer.current);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!storageKey) return;
@@ -127,11 +136,14 @@ export function CommandTabs({
           type="button"
           aria-label="Copy command"
           onClick={async () => {
+            const generation = ++copyGeneration.current;
             try {
               await navigator.clipboard.writeText(command);
             } catch {
               return;
             }
+            if (generation !== copyGeneration.current) return;
+
             setCopied(true);
             clearTimeout(copyTimer.current);
             copyTimer.current = setTimeout(() => setCopied(false), 1500);

--- a/packages/ui/src/components/react/ui/base/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/base/command-tabs.tsx
@@ -48,18 +48,18 @@ export function CommandTabs({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
-  const copyGeneration = useRef(0);
+  const isMounted = useRef(true);
 
   const commandsRef = useRef(commands);
   commandsRef.current = commands;
 
-  useEffect(
-    () => () => {
-      copyGeneration.current += 1;
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
       clearTimeout(copyTimer.current);
-    },
-    [],
-  );
+    };
+  }, []);
 
   useEffect(() => {
     if (!storageKey) return;
@@ -136,13 +136,12 @@ export function CommandTabs({
           type="button"
           aria-label="Copy command"
           onClick={async () => {
-            const generation = ++copyGeneration.current;
             try {
               await navigator.clipboard.writeText(command);
             } catch {
               return;
             }
-            if (generation !== copyGeneration.current) return;
+            if (!isMounted.current) return;
 
             setCopied(true);
             clearTimeout(copyTimer.current);

--- a/packages/ui/src/components/react/ui/base/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/base/command-tabs.tsx
@@ -48,8 +48,6 @@ export function CommandTabs({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
-  const copyGeneration = useRef(0);
-  const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
 
   const commandsRef = useRef(commands);
@@ -138,14 +136,11 @@ export function CommandTabs({
           type="button"
           aria-label="Copy command"
           onClick={async () => {
-            const generation = ++copyGeneration.current;
             try {
               await navigator.clipboard.writeText(command);
             } catch {
               return;
             }
-            if (generation < latestSuccessfulCopy.current) return;
-            latestSuccessfulCopy.current = generation;
             if (!isMounted.current) return;
 
             setCopied(true);

--- a/packages/ui/src/components/react/ui/copy-feedback.test.tsx
+++ b/packages/ui/src/components/react/ui/copy-feedback.test.tsx
@@ -1,0 +1,113 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { CodeBlock as BaseCodeBlock } from "./base/code-block";
+import { CommandTabs as BaseCommandTabs } from "./base/command-tabs";
+import { CodeBlock as RadixCodeBlock } from "./radix/code-block";
+import { CommandTabs as RadixCommandTabs } from "./radix/command-tabs";
+
+vi.mock("react-shiki", () => ({ useShikiHighlighter: () => null }));
+
+const mockClipboard = (writeText: (value: string) => Promise<void>) => {
+  const descriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn(writeText) },
+  });
+  onTestFinished(() => {
+    if (descriptor) {
+      Object.defineProperty(navigator, "clipboard", descriptor);
+    } else {
+      delete (navigator as { clipboard?: unknown }).clipboard;
+    }
+  });
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe.each([
+  ["Base", BaseCodeBlock],
+  ["Radix", RadixCodeBlock],
+] as const)("%s CodeBlock copy feedback", (_name, CodeBlock) => {
+  it("preserves an earlier successful write after a newer rejection", async () => {
+    let resolveFirst!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockClipboard(
+      vi
+        .fn()
+        .mockReturnValueOnce(firstWrite)
+        .mockRejectedValueOnce(new Error("denied")),
+    );
+    const onCopied = vi.fn();
+    const view = render(
+      <CodeBlock title="Example" onCopied={onCopied}>
+        <pre>value</pre>
+      </CodeBlock>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+    await act(async () => Promise.resolve());
+    resolveFirst();
+    await act(async () => firstWrite);
+
+    expect(onCopied).toHaveBeenCalledOnce();
+    view.unmount();
+  });
+
+  it("does not schedule feedback when onCopied unmounts the component", async () => {
+    vi.useFakeTimers();
+    mockClipboard(() => Promise.resolve());
+    let view!: ReturnType<typeof render>;
+    const onCopied = vi.fn(() => view.unmount());
+    view = render(
+      <CodeBlock title="Example" onCopied={onCopied}>
+        <pre>value</pre>
+      </CodeBlock>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+    await act(async () => Promise.resolve());
+
+    expect(onCopied).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe.each([
+  ["Base", BaseCommandTabs],
+  ["Radix", RadixCommandTabs],
+] as const)("%s CommandTabs copy feedback", (_name, CommandTabs) => {
+  it("clears an active feedback timer when unmounted", async () => {
+    vi.useFakeTimers();
+    mockClipboard(() => Promise.resolve());
+    const view = render(<CommandTabs commands={{ npm: "npm install" }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
+    await act(async () => Promise.resolve());
+    expect(vi.getTimerCount()).toBe(1);
+
+    view.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("ignores a pending write after unmount", async () => {
+    vi.useFakeTimers();
+    let resolveWrite!: () => void;
+    const write = new Promise<void>((resolve) => {
+      resolveWrite = resolve;
+    });
+    mockClipboard(() => write);
+    const view = render(<CommandTabs commands={{ npm: "npm install" }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
+    view.unmount();
+    resolveWrite();
+    await write;
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/ui/src/components/react/ui/copy-feedback.test.tsx
+++ b/packages/ui/src/components/react/ui/copy-feedback.test.tsx
@@ -90,6 +90,11 @@ describe.each([
     await act(async () => firstWrite);
 
     expect(onCopied).toHaveBeenCalledOnce();
+    expect(
+      screen
+        .getByRole("button", { name: "Copy code" })
+        .querySelector(".lucide-check"),
+    ).not.toBeNull();
     view.unmount();
   });
 

--- a/packages/ui/src/components/react/ui/copy-feedback.test.tsx
+++ b/packages/ui/src/components/react/ui/copy-feedback.test.tsx
@@ -5,7 +5,17 @@ import { CommandTabs as BaseCommandTabs } from "./base/command-tabs";
 import { CodeBlock as RadixCodeBlock } from "./radix/code-block";
 import { CommandTabs as RadixCommandTabs } from "./radix/command-tabs";
 
-vi.mock("react-shiki", () => ({ useShikiHighlighter: () => null }));
+const mocks = vi.hoisted(() => ({
+  useShikiHighlighter: vi.fn(() => null),
+}));
+
+vi.mock("react-shiki", async (importOriginal) => {
+  const original = await importOriginal<typeof import("react-shiki")>();
+  return {
+    ...original,
+    useShikiHighlighter: mocks.useShikiHighlighter,
+  };
+});
 
 const mockClipboard = (writeText: (value: string) => Promise<void>) => {
   const descriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
@@ -31,6 +41,7 @@ describe.each([
   ["Radix", RadixCodeBlock],
 ] as const)("%s CodeBlock copy feedback", (_name, CodeBlock) => {
   it("preserves an earlier successful write after a newer rejection", async () => {
+    vi.useFakeTimers();
     let resolveFirst!: () => void;
     const firstWrite = new Promise<void>((resolve) => {
       resolveFirst = resolve;
@@ -55,6 +66,37 @@ describe.each([
     await act(async () => firstWrite);
 
     expect(onCopied).toHaveBeenCalledOnce();
+    view.unmount();
+  });
+
+  it("ignores an older write that succeeds after a newer success", async () => {
+    vi.useFakeTimers();
+    let resolveFirst!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockClipboard(
+      vi.fn().mockReturnValueOnce(firstWrite).mockResolvedValueOnce(undefined),
+    );
+    const onCopied = vi.fn();
+    const view = render(
+      <CodeBlock title="Example" onCopied={onCopied}>
+        <pre>value</pre>
+      </CodeBlock>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+    await act(async () => Promise.resolve());
+    expect(onCopied).toHaveBeenCalledOnce();
+    act(() => vi.advanceTimersByTime(1_500));
+
+    await act(async () => {
+      resolveFirst();
+      await firstWrite;
+    });
+    expect(onCopied).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
     view.unmount();
   });
 
@@ -106,6 +148,30 @@ describe.each([
   ["Base", BaseCommandTabs],
   ["Radix", RadixCommandTabs],
 ] as const)("%s CommandTabs copy feedback", (_name, CommandTabs) => {
+  it("ignores an older write that succeeds after a newer success", async () => {
+    vi.useFakeTimers();
+    let resolveFirst!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockClipboard(
+      vi.fn().mockReturnValueOnce(firstWrite).mockResolvedValueOnce(undefined),
+    );
+    const view = render(<CommandTabs commands={{ npm: "npm install" }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
+    await act(async () => Promise.resolve());
+    act(() => vi.advanceTimersByTime(1_500));
+
+    await act(async () => {
+      resolveFirst();
+      await firstWrite;
+    });
+    expect(vi.getTimerCount()).toBe(0);
+    view.unmount();
+  });
+
   it("clears an active feedback timer when unmounted", async () => {
     vi.useFakeTimers();
     mockClipboard(() => Promise.resolve());

--- a/packages/ui/src/components/react/ui/copy-feedback.test.tsx
+++ b/packages/ui/src/components/react/ui/copy-feedback.test.tsx
@@ -75,6 +75,31 @@ describe.each([
     expect(onCopied).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it("calls onCopied when a pending write finishes after unmount", async () => {
+    vi.useFakeTimers();
+    let resolveWrite!: () => void;
+    const write = new Promise<void>((resolve) => {
+      resolveWrite = resolve;
+    });
+    mockClipboard(() => write);
+    const onCopied = vi.fn();
+    const view = render(
+      <CodeBlock title="Example" onCopied={onCopied}>
+        <pre>value</pre>
+      </CodeBlock>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+    view.unmount();
+    await act(async () => {
+      resolveWrite();
+      await write;
+    });
+
+    expect(onCopied).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });
 
 describe.each([

--- a/packages/ui/src/components/react/ui/copy-feedback.test.tsx
+++ b/packages/ui/src/components/react/ui/copy-feedback.test.tsx
@@ -69,37 +69,6 @@ describe.each([
     view.unmount();
   });
 
-  it("ignores an older write that succeeds after a newer success", async () => {
-    vi.useFakeTimers();
-    let resolveFirst!: () => void;
-    const firstWrite = new Promise<void>((resolve) => {
-      resolveFirst = resolve;
-    });
-    mockClipboard(
-      vi.fn().mockReturnValueOnce(firstWrite).mockResolvedValueOnce(undefined),
-    );
-    const onCopied = vi.fn();
-    const view = render(
-      <CodeBlock title="Example" onCopied={onCopied}>
-        <pre>value</pre>
-      </CodeBlock>,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
-    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
-    await act(async () => Promise.resolve());
-    expect(onCopied).toHaveBeenCalledOnce();
-    act(() => vi.advanceTimersByTime(1_500));
-
-    await act(async () => {
-      resolveFirst();
-      await firstWrite;
-    });
-    expect(onCopied).toHaveBeenCalledOnce();
-    expect(vi.getTimerCount()).toBe(0);
-    view.unmount();
-  });
-
   it("does not schedule feedback when onCopied unmounts the component", async () => {
     vi.useFakeTimers();
     mockClipboard(() => Promise.resolve());
@@ -148,30 +117,6 @@ describe.each([
   ["Base", BaseCommandTabs],
   ["Radix", RadixCommandTabs],
 ] as const)("%s CommandTabs copy feedback", (_name, CommandTabs) => {
-  it("ignores an older write that succeeds after a newer success", async () => {
-    vi.useFakeTimers();
-    let resolveFirst!: () => void;
-    const firstWrite = new Promise<void>((resolve) => {
-      resolveFirst = resolve;
-    });
-    mockClipboard(
-      vi.fn().mockReturnValueOnce(firstWrite).mockResolvedValueOnce(undefined),
-    );
-    const view = render(<CommandTabs commands={{ npm: "npm install" }} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
-    fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
-    await act(async () => Promise.resolve());
-    act(() => vi.advanceTimersByTime(1_500));
-
-    await act(async () => {
-      resolveFirst();
-      await firstWrite;
-    });
-    expect(vi.getTimerCount()).toBe(0);
-    view.unmount();
-  });
-
   it("clears an active feedback timer when unmounted", async () => {
     vi.useFakeTimers();
     mockClipboard(() => Promise.resolve());

--- a/packages/ui/src/components/react/ui/copy-feedback.test.tsx
+++ b/packages/ui/src/components/react/ui/copy-feedback.test.tsx
@@ -40,6 +40,30 @@ describe.each([
   ["Base", BaseCodeBlock],
   ["Radix", RadixCodeBlock],
 ] as const)("%s CodeBlock copy feedback", (_name, CodeBlock) => {
+  it("keeps feedback visible for a full interval after a second success", async () => {
+    vi.useFakeTimers();
+    mockClipboard(() => Promise.resolve());
+    const view = render(
+      <CodeBlock title="Example">
+        <pre>value</pre>
+      </CodeBlock>,
+    );
+    const button = screen.getByRole("button", { name: "Copy code" });
+
+    fireEvent.click(button);
+    await act(async () => Promise.resolve());
+    act(() => vi.advanceTimersByTime(1000));
+    fireEvent.click(button);
+    await act(async () => Promise.resolve());
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => vi.advanceTimersByTime(500));
+    expect(button.querySelector(".lucide-check")).not.toBeNull();
+    act(() => vi.advanceTimersByTime(1000));
+    expect(button.querySelector(".lucide-check")).toBeNull();
+    view.unmount();
+  });
+
   it("preserves an earlier successful write after a newer rejection", async () => {
     vi.useFakeTimers();
     let resolveFirst!: () => void;
@@ -117,6 +141,26 @@ describe.each([
   ["Base", BaseCommandTabs],
   ["Radix", RadixCommandTabs],
 ] as const)("%s CommandTabs copy feedback", (_name, CommandTabs) => {
+  it("keeps feedback visible for a full interval after a second success", async () => {
+    vi.useFakeTimers();
+    mockClipboard(() => Promise.resolve());
+    const view = render(<CommandTabs commands={{ npm: "npm install" }} />);
+    const button = screen.getByRole("button", { name: "Copy command" });
+
+    fireEvent.click(button);
+    await act(async () => Promise.resolve());
+    act(() => vi.advanceTimersByTime(1000));
+    fireEvent.click(button);
+    await act(async () => Promise.resolve());
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => vi.advanceTimersByTime(500));
+    expect(button.querySelector(".lucide-check")).not.toBeNull();
+    act(() => vi.advanceTimersByTime(1000));
+    expect(button.querySelector(".lucide-check")).toBeNull();
+    view.unmount();
+  });
+
   it("clears an active feedback timer when unmounted", async () => {
     vi.useFakeTimers();
     mockClipboard(() => Promise.resolve());

--- a/packages/ui/src/components/react/ui/radix/code-block.tsx
+++ b/packages/ui/src/components/react/ui/radix/code-block.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useRef, useState, type ComponentProps, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -30,20 +36,39 @@ function CopyButton({
   className?: string;
 }) {
   const [copied, setCopied] = useState(false);
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const copyGeneration = useRef(0);
+
+  useEffect(
+    () => () => {
+      copyGeneration.current += 1;
+      clearTimeout(copyTimer.current);
+    },
+    [],
+  );
 
   return (
     <button
       type="button"
       aria-label="Copy code"
       onClick={async () => {
+        const generation = ++copyGeneration.current;
         try {
           await navigator.clipboard.writeText(getText());
         } catch {
           return;
         }
+        if (generation !== copyGeneration.current) return;
+
         onCopied?.();
         setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        clearTimeout(copyTimer.current);
+        copyTimer.current = setTimeout(() => {
+          copyTimer.current = undefined;
+          setCopied(false);
+        }, 1500);
       }}
       className={cn(
         "text-muted-foreground hover:text-foreground grid size-6 shrink-0 place-items-center rounded-sm transition-colors",

--- a/packages/ui/src/components/react/ui/radix/code-block.tsx
+++ b/packages/ui/src/components/react/ui/radix/code-block.tsx
@@ -39,6 +39,8 @@ function CopyButton({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const copyGeneration = useRef(0);
+  const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
 
   useEffect(() => {
@@ -54,11 +56,14 @@ function CopyButton({
       type="button"
       aria-label="Copy code"
       onClick={async () => {
+        const generation = ++copyGeneration.current;
         try {
           await navigator.clipboard.writeText(getText());
         } catch {
           return;
         }
+        if (generation < latestSuccessfulCopy.current) return;
+        latestSuccessfulCopy.current = generation;
         onCopied?.();
         if (!isMounted.current) return;
         setCopied(true);

--- a/packages/ui/src/components/react/ui/radix/code-block.tsx
+++ b/packages/ui/src/components/react/ui/radix/code-block.tsx
@@ -59,8 +59,6 @@ function CopyButton({
         } catch {
           return;
         }
-        if (!isMounted.current) return;
-
         onCopied?.();
         if (!isMounted.current) return;
         setCopied(true);

--- a/packages/ui/src/components/react/ui/radix/code-block.tsx
+++ b/packages/ui/src/components/react/ui/radix/code-block.tsx
@@ -39,8 +39,6 @@ function CopyButton({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
-  const copyGeneration = useRef(0);
-  const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
 
   useEffect(() => {
@@ -56,14 +54,11 @@ function CopyButton({
       type="button"
       aria-label="Copy code"
       onClick={async () => {
-        const generation = ++copyGeneration.current;
         try {
           await navigator.clipboard.writeText(getText());
         } catch {
           return;
         }
-        if (generation < latestSuccessfulCopy.current) return;
-        latestSuccessfulCopy.current = generation;
         onCopied?.();
         if (!isMounted.current) return;
         setCopied(true);

--- a/packages/ui/src/components/react/ui/radix/code-block.tsx
+++ b/packages/ui/src/components/react/ui/radix/code-block.tsx
@@ -39,30 +39,30 @@ function CopyButton({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
-  const copyGeneration = useRef(0);
+  const isMounted = useRef(true);
 
-  useEffect(
-    () => () => {
-      copyGeneration.current += 1;
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
       clearTimeout(copyTimer.current);
-    },
-    [],
-  );
+    };
+  }, []);
 
   return (
     <button
       type="button"
       aria-label="Copy code"
       onClick={async () => {
-        const generation = ++copyGeneration.current;
         try {
           await navigator.clipboard.writeText(getText());
         } catch {
           return;
         }
-        if (generation !== copyGeneration.current) return;
+        if (!isMounted.current) return;
 
         onCopied?.();
+        if (!isMounted.current) return;
         setCopied(true);
         clearTimeout(copyTimer.current);
         copyTimer.current = setTimeout(() => {

--- a/packages/ui/src/components/react/ui/radix/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/radix/command-tabs.tsx
@@ -48,6 +48,8 @@ export function CommandTabs({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const copyGeneration = useRef(0);
+  const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
 
   const commandsRef = useRef(commands);
@@ -136,11 +138,14 @@ export function CommandTabs({
           type="button"
           aria-label="Copy command"
           onClick={async () => {
+            const generation = ++copyGeneration.current;
             try {
               await navigator.clipboard.writeText(command);
             } catch {
               return;
             }
+            if (generation < latestSuccessfulCopy.current) return;
+            latestSuccessfulCopy.current = generation;
             if (!isMounted.current) return;
 
             setCopied(true);

--- a/packages/ui/src/components/react/ui/radix/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/radix/command-tabs.tsx
@@ -48,9 +48,18 @@ export function CommandTabs({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const copyGeneration = useRef(0);
 
   const commandsRef = useRef(commands);
   commandsRef.current = commands;
+
+  useEffect(
+    () => () => {
+      copyGeneration.current += 1;
+      clearTimeout(copyTimer.current);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!storageKey) return;
@@ -127,11 +136,14 @@ export function CommandTabs({
           type="button"
           aria-label="Copy command"
           onClick={async () => {
+            const generation = ++copyGeneration.current;
             try {
               await navigator.clipboard.writeText(command);
             } catch {
               return;
             }
+            if (generation !== copyGeneration.current) return;
+
             setCopied(true);
             clearTimeout(copyTimer.current);
             copyTimer.current = setTimeout(() => setCopied(false), 1500);

--- a/packages/ui/src/components/react/ui/radix/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/radix/command-tabs.tsx
@@ -48,18 +48,18 @@ export function CommandTabs({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
-  const copyGeneration = useRef(0);
+  const isMounted = useRef(true);
 
   const commandsRef = useRef(commands);
   commandsRef.current = commands;
 
-  useEffect(
-    () => () => {
-      copyGeneration.current += 1;
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
       clearTimeout(copyTimer.current);
-    },
-    [],
-  );
+    };
+  }, []);
 
   useEffect(() => {
     if (!storageKey) return;
@@ -136,13 +136,12 @@ export function CommandTabs({
           type="button"
           aria-label="Copy command"
           onClick={async () => {
-            const generation = ++copyGeneration.current;
             try {
               await navigator.clipboard.writeText(command);
             } catch {
               return;
             }
-            if (generation !== copyGeneration.current) return;
+            if (!isMounted.current) return;
 
             setCopied(true);
             clearTimeout(copyTimer.current);

--- a/packages/ui/src/components/react/ui/radix/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/radix/command-tabs.tsx
@@ -48,8 +48,6 @@ export function CommandTabs({
   const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
-  const copyGeneration = useRef(0);
-  const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
 
   const commandsRef = useRef(commands);
@@ -138,14 +136,11 @@ export function CommandTabs({
           type="button"
           aria-label="Copy command"
           onClick={async () => {
-            const generation = ++copyGeneration.current;
             try {
               await navigator.clipboard.writeText(command);
             } catch {
               return;
             }
-            if (generation < latestSuccessfulCopy.current) return;
-            latestSuccessfulCopy.current = generation;
             if (!isMounted.current) return;
 
             setCopied(true);

--- a/packages/ui/src/hooks/use-copy-to-clipboard.test.tsx
+++ b/packages/ui/src/hooks/use-copy-to-clipboard.test.tsx
@@ -1,18 +1,30 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { useCopyToClipboard } from "./use-copy-to-clipboard";
+
+const mockClipboard = (writeText: (value: string) => Promise<void>) => {
+  const descriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn(writeText) },
+  });
+  onTestFinished(() => {
+    if (descriptor) {
+      Object.defineProperty(navigator, "clipboard", descriptor);
+    } else {
+      delete (navigator as { clipboard?: unknown }).clipboard;
+    }
+  });
+};
 
 describe("useCopyToClipboard", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("keeps copied feedback for the full duration after the latest copy", async () => {
+  it("keeps copied feedback for the full duration after the latest success", async () => {
     vi.useFakeTimers();
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText: vi.fn().mockResolvedValue(undefined) },
-    });
+    mockClipboard(() => Promise.resolve());
     const { result } = renderHook(() =>
       useCopyToClipboard({ copiedDuration: 1_000 }),
     );
@@ -32,5 +44,62 @@ describe("useCopyToClipboard", () => {
 
     act(() => vi.advanceTimersByTime(500));
     expect(result.current.isCopied).toBe(false);
+  });
+
+  it("keeps an earlier successful write when a newer write rejects", async () => {
+    let resolveFirst!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockClipboard(
+      vi
+        .fn()
+        .mockReturnValueOnce(firstWrite)
+        .mockRejectedValueOnce(new Error("denied")),
+    );
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    result.current.copyToClipboard("first");
+    result.current.copyToClipboard("second");
+    await act(async () => Promise.resolve());
+    expect(result.current.isCopied).toBe(false);
+
+    await act(async () => {
+      resolveFirst();
+      await firstWrite;
+    });
+    expect(result.current.isCopied).toBe(true);
+  });
+
+  it("clears active feedback timers when unmounted", async () => {
+    vi.useFakeTimers();
+    mockClipboard(() => Promise.resolve());
+    const { result, unmount } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      result.current.copyToClipboard("value");
+      await Promise.resolve();
+    });
+    expect(vi.getTimerCount()).toBe(1);
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("ignores clipboard success after unmount", async () => {
+    vi.useFakeTimers();
+    let resolveWrite!: () => void;
+    const write = new Promise<void>((resolve) => {
+      resolveWrite = resolve;
+    });
+    mockClipboard(() => write);
+    const { result, unmount } = renderHook(() => useCopyToClipboard());
+
+    result.current.copyToClipboard("value");
+    unmount();
+    resolveWrite();
+    await write;
+
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/packages/ui/src/hooks/use-copy-to-clipboard.test.tsx
+++ b/packages/ui/src/hooks/use-copy-to-clipboard.test.tsx
@@ -72,35 +72,6 @@ describe("useCopyToClipboard", () => {
     expect(result.current.isCopied).toBe(true);
   });
 
-  it("ignores an older write that succeeds after a newer success", async () => {
-    vi.useFakeTimers();
-    let resolveFirst!: () => void;
-    const firstWrite = new Promise<void>((resolve) => {
-      resolveFirst = resolve;
-    });
-    mockClipboard(
-      vi.fn().mockReturnValueOnce(firstWrite).mockResolvedValueOnce(undefined),
-    );
-    const { result } = renderHook(() =>
-      useCopyToClipboard({ copiedDuration: 1_000 }),
-    );
-
-    result.current.copyToClipboard("first");
-    await act(async () => {
-      result.current.copyToClipboard("second");
-      await Promise.resolve();
-    });
-    act(() => vi.advanceTimersByTime(1_000));
-    expect(result.current.isCopied).toBe(false);
-
-    await act(async () => {
-      resolveFirst();
-      await firstWrite;
-    });
-    expect(result.current.isCopied).toBe(false);
-    expect(vi.getTimerCount()).toBe(0);
-  });
-
   it("clears active feedback timers when unmounted", async () => {
     vi.useFakeTimers();
     mockClipboard(() => Promise.resolve());

--- a/packages/ui/src/hooks/use-copy-to-clipboard.test.tsx
+++ b/packages/ui/src/hooks/use-copy-to-clipboard.test.tsx
@@ -47,6 +47,7 @@ describe("useCopyToClipboard", () => {
   });
 
   it("keeps an earlier successful write when a newer write rejects", async () => {
+    vi.useFakeTimers();
     let resolveFirst!: () => void;
     const firstWrite = new Promise<void>((resolve) => {
       resolveFirst = resolve;
@@ -69,6 +70,35 @@ describe("useCopyToClipboard", () => {
       await firstWrite;
     });
     expect(result.current.isCopied).toBe(true);
+  });
+
+  it("ignores an older write that succeeds after a newer success", async () => {
+    vi.useFakeTimers();
+    let resolveFirst!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockClipboard(
+      vi.fn().mockReturnValueOnce(firstWrite).mockResolvedValueOnce(undefined),
+    );
+    const { result } = renderHook(() =>
+      useCopyToClipboard({ copiedDuration: 1_000 }),
+    );
+
+    result.current.copyToClipboard("first");
+    await act(async () => {
+      result.current.copyToClipboard("second");
+      await Promise.resolve();
+    });
+    act(() => vi.advanceTimersByTime(1_000));
+    expect(result.current.isCopied).toBe(false);
+
+    await act(async () => {
+      resolveFirst();
+      await firstWrite;
+    });
+    expect(result.current.isCopied).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("clears active feedback timers when unmounted", async () => {

--- a/packages/ui/src/hooks/use-copy-to-clipboard.test.tsx
+++ b/packages/ui/src/hooks/use-copy-to-clipboard.test.tsx
@@ -1,0 +1,36 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useCopyToClipboard } from "./use-copy-to-clipboard";
+
+describe("useCopyToClipboard", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps copied feedback for the full duration after the latest copy", async () => {
+    vi.useFakeTimers();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    const { result } = renderHook(() =>
+      useCopyToClipboard({ copiedDuration: 1_000 }),
+    );
+
+    await act(async () => {
+      result.current.copyToClipboard("first");
+      await Promise.resolve();
+    });
+    act(() => vi.advanceTimersByTime(500));
+    await act(async () => {
+      result.current.copyToClipboard("second");
+      await Promise.resolve();
+    });
+
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current.isCopied).toBe(true);
+
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current.isCopied).toBe(false);
+  });
+});

--- a/packages/ui/src/hooks/use-copy-to-clipboard.ts
+++ b/packages/ui/src/hooks/use-copy-to-clipboard.ts
@@ -13,25 +13,24 @@ export const useCopyToClipboard = ({
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
-  const copyGeneration = useRef(0);
+  const isMounted = useRef(true);
 
-  useEffect(
-    () => () => {
-      copyGeneration.current += 1;
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
       clearTimeout(copiedTimer.current);
-    },
-    [],
-  );
+    };
+  }, []);
 
   const copyToClipboard = (value: string) => {
     if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
       return;
     }
 
-    const generation = ++copyGeneration.current;
     navigator.clipboard.writeText(value).then(
       () => {
-        if (generation !== copyGeneration.current) return;
+        if (!isMounted.current) return;
 
         clearTimeout(copiedTimer.current);
         setIsCopied(true);

--- a/packages/ui/src/hooks/use-copy-to-clipboard.ts
+++ b/packages/ui/src/hooks/use-copy-to-clipboard.ts
@@ -13,8 +13,6 @@ export const useCopyToClipboard = ({
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
-  const copyGeneration = useRef(0);
-  const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
 
   useEffect(() => {
@@ -30,11 +28,8 @@ export const useCopyToClipboard = ({
       return;
     }
 
-    const generation = ++copyGeneration.current;
     navigator.clipboard.writeText(value).then(
       () => {
-        if (generation < latestSuccessfulCopy.current) return;
-        latestSuccessfulCopy.current = generation;
         if (!isMounted.current) return;
 
         clearTimeout(copiedTimer.current);

--- a/packages/ui/src/hooks/use-copy-to-clipboard.ts
+++ b/packages/ui/src/hooks/use-copy-to-clipboard.ts
@@ -13,6 +13,8 @@ export const useCopyToClipboard = ({
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const copyGeneration = useRef(0);
+  const latestSuccessfulCopy = useRef(0);
   const isMounted = useRef(true);
 
   useEffect(() => {
@@ -28,8 +30,11 @@ export const useCopyToClipboard = ({
       return;
     }
 
+    const generation = ++copyGeneration.current;
     navigator.clipboard.writeText(value).then(
       () => {
+        if (generation < latestSuccessfulCopy.current) return;
+        latestSuccessfulCopy.current = generation;
         if (!isMounted.current) return;
 
         clearTimeout(copiedTimer.current);

--- a/packages/ui/src/hooks/use-copy-to-clipboard.ts
+++ b/packages/ui/src/hooks/use-copy-to-clipboard.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export type UseCopyToClipboardOptions = {
   copiedDuration?: number;
@@ -10,16 +10,35 @@ export const useCopyToClipboard = ({
   copiedDuration = 3000,
 }: UseCopyToClipboardOptions = {}) => {
   const [isCopied, setIsCopied] = useState<boolean>(false);
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const copyGeneration = useRef(0);
+
+  useEffect(
+    () => () => {
+      copyGeneration.current += 1;
+      clearTimeout(copiedTimer.current);
+    },
+    [],
+  );
 
   const copyToClipboard = (value: string) => {
     if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
       return;
     }
 
+    const generation = ++copyGeneration.current;
     navigator.clipboard.writeText(value).then(
       () => {
+        if (generation !== copyGeneration.current) return;
+
+        clearTimeout(copiedTimer.current);
         setIsCopied(true);
-        setTimeout(() => setIsCopied(false), copiedDuration);
+        copiedTimer.current = setTimeout(() => {
+          copiedTimer.current = undefined;
+          setIsCopied(false);
+        }, copiedDuration);
       },
       () => {},
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4375,6 +4375,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.7
         version: 19.2.7(@types/react@19.2.18)
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
       react:
         specifier: ^19.2.8
         version: 19.2.8

--- a/templates/minimal/components/assistant-ui/elements/markdown-text.tsx
+++ b/templates/minimal/components/assistant-ui/elements/markdown-text.tsx
@@ -9,7 +9,7 @@ import {
   useIsMarkdownCodeBlock,
 } from "@assistant-ui/react-markdown";
 import remarkGfm from "remark-gfm";
-import { type FC, memo, useState } from "react";
+import { type FC, memo, useEffect, useRef, useState } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 
 import { TooltipIconButton } from "@/components/assistant-ui/elements/tooltip-icon-button";
@@ -58,6 +58,18 @@ const useCopyToClipboard = ({
   copiedDuration?: number;
 } = {}) => {
   const [isCopied, setIsCopied] = useState<boolean>(false);
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+      clearTimeout(copiedTimer.current);
+    };
+  }, []);
 
   const copyToClipboard = (value: string) => {
     if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
@@ -66,8 +78,14 @@ const useCopyToClipboard = ({
 
     navigator.clipboard.writeText(value).then(
       () => {
+        if (!isMounted.current) return;
+
+        clearTimeout(copiedTimer.current);
         setIsCopied(true);
-        setTimeout(() => setIsCopied(false), copiedDuration);
+        copiedTimer.current = setTimeout(() => {
+          copiedTimer.current = undefined;
+          setIsCopied(false);
+        }, copiedDuration);
       },
       () => {},
     );


### PR DESCRIPTION
## Problem

Copy feedback can disappear too early when someone copies twice before the first feedback timer expires. For example, with a one-second duration, copying at 0 ms and again at 500 ms makes the first timer hide the second success at 1,000 ms instead of keeping it visible until 1,500 ms. Pending clipboard writes and timers can also settle after the component has unmounted.

## Root cause

The copy helpers scheduled an independent timeout after every successful clipboard write. Most surfaces did not cancel the previous timeout, and none guarded asynchronous completion after unmount.

## Change

Keep one feedback timer per mounted instance and clear it before scheduling the next successful copy interval, matching the existing action-bar copy pattern. Rejected writes leave any pending successful write alone. Code-block writes still invoke the public callback if the component unmounts while the clipboard request is pending, while a mounted guard prevents late completions from scheduling internal state or timers. Unmounting also clears the active timer.

The same lifecycle is applied to the shared UI hook, the minimal template's inline Markdown copy hook, Base and Radix code blocks, Base and Radix command tabs, and the devtools copy hook so copied feedback behaves consistently across these surfaces. The minimal template intentionally omits the shared syntax-highlighter wiring, so its inline hook needs the same lifecycle independently of template syncing.

## Verification

- Confirmed the new repeated-copy regression test fails against the previous implementation and passes with this change
- The minimal template's repeated-copy, active-timer unmount, and pending-write unmount tests all failed before its fix and pass afterward
- Minimal's inline hook is exercised through its Markdown component in the UI runner. That runner uses the shared TooltipIconButton and utility aliases, so these are copy-feedback regression tests, not an end-to-end build of the scaffold.
- `cd packages/ui && ./node_modules/.bin/vitest run` (22 files, 754 passed, 16 skipped), including repeated successful copies on both CodeBlock and CommandTabs flavors
- `pnpm --filter @assistant-ui/react-devtools test` (32 files, 129 passed)
- `pnpm --filter @assistant-ui/react-devtools build`
- `pnpm lint`
- `pnpm size:check`
- `pnpm workspace-ranges:check`
- `pnpm changesets:check`
- `git diff --check`
- `bash scripts/sync-templates.sh`

## Public surface

- `@assistant-ui/react-devtools`: copy feedback behavior updated with a patch changeset
- `@assistant-ui/ui`: private registry source updated for both UI flavors
- Minimal template: matching copy-feedback lifecycle, without changing layout or syntax-highlighting dependencies
- Exports, API-reference output, and documentation: unchanged
