### PR TITLE
feat(core): refresh interactable schemas after configuration changes

### DIFF
--- a/.changeset/fresh-interactable-schemas.md
+++ b/.changeset/fresh-interactable-schemas.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: refresh interactable schemas after configuration changes

--- a/packages/core/src/react/client/Interactables.test.ts
+++ b/packages/core/src/react/client/Interactables.test.ts
@@ -343,7 +343,9 @@ describe("Interactables registration", () => {
     await flushMicrotasks();
 
     first();
-    root.getValue().register(reg("n1", { stateSchema: schemaB }));
+    const replacement = root
+      .getValue()
+      .register(reg("n1", { stateSchema: schemaB }));
 
     const parameters =
       registeredModelContextProvider?.getModelContext?.().tools?.update_note
@@ -359,6 +361,7 @@ describe("Interactables registration", () => {
     });
 
     second();
+    replacement();
   });
 
   it("installs the update tool UI once per name and removes it with the last anchor", () => {

--- a/packages/core/src/react/client/Interactables.test.ts
+++ b/packages/core/src/react/client/Interactables.test.ts
@@ -10,7 +10,12 @@ import type { ThreadMessage } from "../../types/message";
 const clientHolder: { client: unknown } = { client: null };
 const clientListeners = new Set<() => void>();
 let registeredModelContextProvider:
-  | { subscribe?: (callback: () => void) => () => void }
+  | {
+      getModelContext?: () => {
+        tools?: Record<string, { parameters?: unknown }>;
+      };
+      subscribe?: (callback: () => void) => () => void;
+    }
   | undefined;
 
 const replaceClient = (client: unknown) => {
@@ -319,6 +324,41 @@ describe("Interactables registration", () => {
     second();
     await flushMicrotasks();
     expect(stateOf(root, "n1")).toBeUndefined();
+  });
+
+  it("refreshes cached tool parameters while another anchor remains", async () => {
+    const schemaA = {
+      type: "object" as const,
+      properties: { first: { type: "string" } },
+    };
+    const schemaB = {
+      type: "object" as const,
+      properties: { second: { type: "number" } },
+    };
+    root = mount({ threadMessages: [createCall("n1")] });
+    const first = root.getValue().register(reg("n1", { stateSchema: schemaA }));
+    const second = root
+      .getValue()
+      .register(reg("n1", { stateSchema: schemaA }));
+    await flushMicrotasks();
+
+    first();
+    root.getValue().register(reg("n1", { stateSchema: schemaB }));
+
+    const parameters =
+      registeredModelContextProvider?.getModelContext?.().tools?.update_note
+        ?.parameters;
+    expect(parameters).toMatchObject({
+      properties: {
+        id: { type: "string" },
+        second: { type: "number" },
+      },
+    });
+    expect(parameters).not.toMatchObject({
+      properties: { first: expect.anything() },
+    });
+
+    second();
   });
 
   it("installs the update tool UI once per name and removes it with the last anchor", () => {

--- a/packages/core/src/react/client/Interactables.ts
+++ b/packages/core/src/react/client/Interactables.ts
@@ -88,6 +88,9 @@ const useInteractablesResource = ({
 
   const subscribersRef = useRef(new Set<() => void>());
   const partialSchemaCacheRef = useRef(new Map<string, PartialJSONSchema>());
+  const partialSchemaSourceRef = useRef(
+    new Map<string, Unstable_InteractableRegistration["stateSchema"]>(),
+  );
   const streamBaselinesRef = useRef(
     new Map<string, { targetId: string; state: unknown }>(),
   );
@@ -409,7 +412,9 @@ const useInteractablesResource = ({
       }
 
       // The same id re-registers once per anchor (its create call + each update_*).
-      if (!partialSchemaCacheRef.current.has(def.id)) {
+      if (partialSchemaSourceRef.current.get(def.id) !== def.stateSchema) {
+        partialSchemaSourceRef.current.set(def.id, def.stateSchema);
+        partialSchemaCacheRef.current.delete(def.id);
         try {
           const jsonSchema = toJSONSchema(def.stateSchema);
           partialSchemaCacheRef.current.set(
@@ -497,6 +502,7 @@ const useInteractablesResource = ({
               detachedAppStateRef.current.set(def.id, existing.state);
             }
           }
+          partialSchemaSourceRef.current.delete(def.id);
           partialSchemaCacheRef.current.delete(def.id);
           const definitions = nullProtoRecord(prev.definitions);
           const persistence = nullProtoRecord(prev.persistence);

--- a/packages/core/src/react/interactables-legacy/useAssistantInteractable.test.tsx
+++ b/packages/core/src/react/interactables-legacy/useAssistantInteractable.test.tsx
@@ -104,4 +104,29 @@ describe("useAssistantInteractable", () => {
       expect.objectContaining({ stateSchema: changedSchema }),
     );
   });
+
+  it("keeps unsupported standard schemas from failing during render", async () => {
+    const createSchema = () => ({
+      "~standard": {
+        version: 1 as const,
+        vendor: "test",
+        validate: (value: unknown) => ({ value }),
+      },
+    });
+
+    const hook = renderHook(
+      ({ stateSchema }) =>
+        useAssistantInteractable("panel", {
+          id: "panel-1",
+          description: "A panel",
+          stateSchema,
+          initialState: {},
+        }),
+      { initialProps: { stateSchema: createSchema() } },
+    );
+    await waitFor(() => expect(mocks.register).toHaveBeenCalledTimes(1));
+
+    hook.rerender({ stateSchema: createSchema() });
+    expect(mocks.register).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/core/src/react/interactables-legacy/useAssistantInteractable.test.tsx
+++ b/packages/core/src/react/interactables-legacy/useAssistantInteractable.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const unregister = vi.fn();
+  const register = vi.fn(() => unregister);
+  return {
+    register,
+    unregister,
+    aui: { interactables: { register } },
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => mocks.aui,
+}));
+
+import { useAssistantInteractable } from "./useAssistantInteractable";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useAssistantInteractable", () => {
+  it("refreshes the registration when its schema changes", async () => {
+    const schemaA = {
+      type: "object" as const,
+      properties: { first: { type: "string" } },
+    };
+    const schemaB = {
+      type: "object" as const,
+      properties: { second: { type: "number" } },
+    };
+    const initialA = { first: "one" };
+    const initialB = { second: 2 };
+
+    const hook = renderHook(
+      ({ stateSchema, initialState }) =>
+        useAssistantInteractable("panel", {
+          id: "panel-1",
+          description: "A panel",
+          stateSchema,
+          initialState,
+        }),
+      { initialProps: { stateSchema: schemaA, initialState: initialA } },
+    );
+    await waitFor(() => expect(mocks.register).toHaveBeenCalledTimes(1));
+
+    hook.rerender({ stateSchema: schemaB, initialState: initialB });
+
+    await waitFor(() => expect(mocks.register).toHaveBeenCalledTimes(2));
+    expect(mocks.unregister).toHaveBeenCalledTimes(1);
+    expect(mocks.register).toHaveBeenLastCalledWith(
+      expect.objectContaining({ stateSchema: schemaB, initialState: initialB }),
+    );
+
+    hook.rerender({
+      stateSchema: {
+        type: "object",
+        properties: { second: { type: "number" } },
+      },
+      initialState: { second: 2 },
+    });
+    expect(mocks.register).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/react/interactables-legacy/useAssistantInteractable.test.tsx
+++ b/packages/core/src/react/interactables-legacy/useAssistantInteractable.test.tsx
@@ -26,7 +26,7 @@ afterEach(() => {
 });
 
 describe("useAssistantInteractable", () => {
-  it("refreshes the registration when its schema changes", async () => {
+  it("refreshes the registration when its JSON schema changes", async () => {
     const schemaA = {
       type: "object" as const,
       properties: { first: { type: "string" } },
@@ -63,8 +63,45 @@ describe("useAssistantInteractable", () => {
         type: "object",
         properties: { second: { type: "number" } },
       },
-      initialState: { second: 2 },
+      initialState: { second: 3 },
     });
     expect(mocks.register).toHaveBeenCalledTimes(2);
+  });
+
+  it("stabilizes equivalent rebuilt standard schemas", async () => {
+    const createSchema = (property: string) => ({
+      "~standard": {
+        version: 1 as const,
+        vendor: "test",
+        validate: (value: unknown) => ({ value }),
+        toJSONSchema: () => ({
+          type: "object" as const,
+          properties: { [property]: { type: "string" as const } },
+        }),
+      },
+    });
+    const firstSchema = createSchema("value");
+
+    const hook = renderHook(
+      ({ stateSchema }) =>
+        useAssistantInteractable("panel", {
+          id: "panel-1",
+          description: "A panel",
+          stateSchema,
+          initialState: {},
+        }),
+      { initialProps: { stateSchema: firstSchema } },
+    );
+    await waitFor(() => expect(mocks.register).toHaveBeenCalledTimes(1));
+
+    hook.rerender({ stateSchema: createSchema("value") });
+    expect(mocks.register).toHaveBeenCalledTimes(1);
+
+    const changedSchema = createSchema("other");
+    hook.rerender({ stateSchema: changedSchema });
+    await waitFor(() => expect(mocks.register).toHaveBeenCalledTimes(2));
+    expect(mocks.register).toHaveBeenLastCalledWith(
+      expect.objectContaining({ stateSchema: changedSchema }),
+    );
   });
 });

--- a/packages/core/src/react/interactables-legacy/useAssistantInteractable.ts
+++ b/packages/core/src/react/interactables-legacy/useAssistantInteractable.ts
@@ -1,8 +1,6 @@
 import { useEffect, useId, useRef } from "react";
 import { useAui } from "@assistant-ui/store";
-import { toJSONSchema } from "assistant-stream";
-import type { ReadonlyJSONValue } from "assistant-stream/utils";
-import { useJSONEqualValue } from "../utils/useJSONEqual";
+import { useJSONSchemaDependency } from "../utils/useJSONSchemaDependency";
 import type { InteractableStateSchema } from "./scopes";
 
 /**
@@ -41,9 +39,7 @@ export const useAssistantInteractable = (
 
   const stateSchemaRef = useRef(config.stateSchema);
   stateSchemaRef.current = config.stateSchema;
-  const normalizedStateSchema = useJSONEqualValue(
-    toJSONSchema(config.stateSchema) as ReadonlyJSONValue,
-  );
+  const normalizedStateSchema = useJSONSchemaDependency(config.stateSchema);
   const initialStateRef = useRef(config.initialState);
   initialStateRef.current = config.initialState;
 

--- a/packages/core/src/react/interactables-legacy/useAssistantInteractable.ts
+++ b/packages/core/src/react/interactables-legacy/useAssistantInteractable.ts
@@ -1,5 +1,6 @@
-import { useEffect, useId } from "react";
+import { useEffect, useId, useRef } from "react";
 import { useAui } from "@assistant-ui/store";
+import { toJSONSchema } from "assistant-stream";
 import { useJSONEqualValue } from "../utils/useJSONEqual";
 import type { InteractableStateSchema } from "./scopes";
 
@@ -37,16 +38,21 @@ export const useAssistantInteractable = (
   const autoId = useId().replace(/[^a-zA-Z0-9]/g, "");
   const id = config.id ?? autoId;
 
-  const stateSchema = useJSONEqualValue(config.stateSchema);
-  const initialState = useJSONEqualValue(config.initialState);
+  const stateSchemaRef = useRef(config.stateSchema);
+  stateSchemaRef.current = config.stateSchema;
+  const normalizedStateSchema = useJSONEqualValue(
+    toJSONSchema(config.stateSchema),
+  );
+  const initialStateRef = useRef(config.initialState);
+  initialStateRef.current = config.initialState;
 
   useEffect(() => {
     return aui.interactables.register({
       id,
       name,
       description: config.description,
-      stateSchema,
-      initialState,
+      stateSchema: stateSchemaRef.current,
+      initialState: initialStateRef.current,
       selected: config.selected,
     });
   }, [
@@ -54,8 +60,7 @@ export const useAssistantInteractable = (
     id,
     name,
     config.description,
-    stateSchema,
-    initialState,
+    normalizedStateSchema,
     config.selected,
   ]);
 

--- a/packages/core/src/react/interactables-legacy/useAssistantInteractable.ts
+++ b/packages/core/src/react/interactables-legacy/useAssistantInteractable.ts
@@ -1,5 +1,6 @@
-import { useEffect, useId, useRef } from "react";
+import { useEffect, useId } from "react";
 import { useAui } from "@assistant-ui/store";
+import { useJSONEqualValue } from "../utils/useJSONEqual";
 import type { InteractableStateSchema } from "./scopes";
 
 /**
@@ -36,21 +37,27 @@ export const useAssistantInteractable = (
   const autoId = useId().replace(/[^a-zA-Z0-9]/g, "");
   const id = config.id ?? autoId;
 
-  const stateSchemaRef = useRef(config.stateSchema);
-  stateSchemaRef.current = config.stateSchema;
-  const initialStateRef = useRef(config.initialState);
-  initialStateRef.current = config.initialState;
+  const stateSchema = useJSONEqualValue(config.stateSchema);
+  const initialState = useJSONEqualValue(config.initialState);
 
   useEffect(() => {
     return aui.interactables.register({
       id,
       name,
       description: config.description,
-      stateSchema: stateSchemaRef.current,
-      initialState: initialStateRef.current,
+      stateSchema,
+      initialState,
       selected: config.selected,
     });
-  }, [aui, id, name, config.description, config.selected]);
+  }, [
+    aui,
+    id,
+    name,
+    config.description,
+    stateSchema,
+    initialState,
+    config.selected,
+  ]);
 
   return id;
 };

--- a/packages/core/src/react/interactables-legacy/useAssistantInteractable.ts
+++ b/packages/core/src/react/interactables-legacy/useAssistantInteractable.ts
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef } from "react";
 import { useAui } from "@assistant-ui/store";
 import { toJSONSchema } from "assistant-stream";
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import { useJSONEqualValue } from "../utils/useJSONEqual";
 import type { InteractableStateSchema } from "./scopes";
 
@@ -41,7 +42,7 @@ export const useAssistantInteractable = (
   const stateSchemaRef = useRef(config.stateSchema);
   stateSchemaRef.current = config.stateSchema;
   const normalizedStateSchema = useJSONEqualValue(
-    toJSONSchema(config.stateSchema),
+    toJSONSchema(config.stateSchema) as ReadonlyJSONValue,
   );
   const initialStateRef = useRef(config.initialState);
   initialStateRef.current = config.initialState;

--- a/packages/core/src/react/model-context/useInteractable.test.tsx
+++ b/packages/core/src/react/model-context/useInteractable.test.tsx
@@ -118,4 +118,60 @@ describe("unstable_useInteractable", () => {
       expect.objectContaining({ stateSchema: changedSchema }),
     );
   });
+
+  it("keeps unsupported standard schemas from failing during render", async () => {
+    const createSchema = () => ({
+      "~standard": {
+        version: 1 as const,
+        vendor: "test",
+        validate: (value: unknown) => ({ value }),
+      },
+    });
+
+    const hook = renderHook(
+      ({ stateSchema }) =>
+        unstable_useInteractable("panel", {
+          id: "panel-1",
+          description: "A panel",
+          stateSchema,
+          initialState: {},
+        }),
+      { initialProps: { stateSchema: createSchema() } },
+    );
+    await waitFor(() => expect(mocks.register).toHaveBeenCalledTimes(1));
+
+    hook.rerender({ stateSchema: createSchema() });
+    expect(mocks.register).toHaveBeenCalledTimes(1);
+  });
+
+  it("converts a referentially stable schema only once", async () => {
+    const toJSONSchema = vi.fn(() => ({
+      type: "object" as const,
+      properties: { value: { type: "string" as const } },
+    }));
+    const stateSchema = {
+      "~standard": {
+        version: 1 as const,
+        vendor: "test",
+        validate: (value: unknown) => ({ value }),
+        toJSONSchema,
+      },
+    };
+
+    const hook = renderHook(
+      ({ initialState }) =>
+        unstable_useInteractable("panel", {
+          id: "panel-1",
+          description: "A panel",
+          stateSchema,
+          initialState,
+        }),
+      { initialProps: { initialState: { value: "first" } } },
+    );
+    await waitFor(() => expect(mocks.register).toHaveBeenCalledTimes(1));
+
+    hook.rerender({ initialState: { value: "second" } });
+    expect(toJSONSchema).toHaveBeenCalledTimes(1);
+    expect(mocks.register).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/core/src/react/model-context/useInteractable.test.tsx
+++ b/packages/core/src/react/model-context/useInteractable.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const unregister = vi.fn();
+  const register = vi.fn(() => unregister);
+  return {
+    register,
+    unregister,
+    aui: { unstable_interactables: { register } },
+    state: { optional: { part: undefined }, thread: { messages: [] } },
+    methods: {
+      setState: vi.fn(),
+      isPending: false,
+      error: undefined,
+      flush: vi.fn(async () => undefined),
+    },
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => mocks.aui,
+  useAuiState: (selector: (state: typeof mocks.state) => unknown) =>
+    selector(mocks.state),
+}));
+
+vi.mock("./useInteractableState", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./useInteractableState")>()),
+  unstable_useInteractableState: () => [undefined, mocks.methods],
+}));
+
+import { unstable_useInteractable } from "./useInteractable";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("unstable_useInteractable", () => {
+  it("refreshes the registration when its schema changes", async () => {
+    const schemaA = {
+      type: "object" as const,
+      properties: { first: { type: "string" } },
+    };
+    const schemaB = {
+      type: "object" as const,
+      properties: { second: { type: "number" } },
+    };
+    const initialA = { first: "one" };
+    const initialB = { second: 2 };
+
+    const hook = renderHook(
+      ({ stateSchema, initialState }) =>
+        unstable_useInteractable("panel", {
+          id: "panel-1",
+          description: "A panel",
+          stateSchema,
+          initialState,
+        }),
+      { initialProps: { stateSchema: schemaA, initialState: initialA } },
+    );
+    await waitFor(() => expect(mocks.register).toHaveBeenCalledTimes(1));
+
+    hook.rerender({ stateSchema: schemaB, initialState: initialB });
+
+    await waitFor(() => expect(mocks.register).toHaveBeenCalledTimes(2));
+    expect(mocks.unregister).toHaveBeenCalledTimes(1);
+    expect(mocks.register).toHaveBeenLastCalledWith(
+      expect.objectContaining({ stateSchema: schemaB, initialState: initialB }),
+    );
+
+    hook.rerender({
+      stateSchema: {
+        type: "object",
+        properties: { second: { type: "number" } },
+      },
+      initialState: { second: 2 },
+    });
+    expect(mocks.register).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/react/model-context/useInteractable.test.tsx
+++ b/packages/core/src/react/model-context/useInteractable.test.tsx
@@ -40,7 +40,7 @@ afterEach(() => {
 });
 
 describe("unstable_useInteractable", () => {
-  it("refreshes the registration when its schema changes", async () => {
+  it("refreshes the registration when its JSON schema changes", async () => {
     const schemaA = {
       type: "object" as const,
       properties: { first: { type: "string" } },
@@ -77,8 +77,45 @@ describe("unstable_useInteractable", () => {
         type: "object",
         properties: { second: { type: "number" } },
       },
-      initialState: { second: 2 },
+      initialState: { second: 3 },
     });
     expect(mocks.register).toHaveBeenCalledTimes(2);
+  });
+
+  it("stabilizes equivalent rebuilt standard schemas", async () => {
+    const createSchema = (property: string) => ({
+      "~standard": {
+        version: 1 as const,
+        vendor: "test",
+        validate: (value: unknown) => ({ value }),
+        toJSONSchema: () => ({
+          type: "object" as const,
+          properties: { [property]: { type: "string" as const } },
+        }),
+      },
+    });
+    const firstSchema = createSchema("value");
+
+    const hook = renderHook(
+      ({ stateSchema }) =>
+        unstable_useInteractable("panel", {
+          id: "panel-1",
+          description: "A panel",
+          stateSchema,
+          initialState: {},
+        }),
+      { initialProps: { stateSchema: firstSchema } },
+    );
+    await waitFor(() => expect(mocks.register).toHaveBeenCalledTimes(1));
+
+    hook.rerender({ stateSchema: createSchema("value") });
+    expect(mocks.register).toHaveBeenCalledTimes(1);
+
+    const changedSchema = createSchema("other");
+    hook.rerender({ stateSchema: changedSchema });
+    await waitFor(() => expect(mocks.register).toHaveBeenCalledTimes(2));
+    expect(mocks.register).toHaveBeenLastCalledWith(
+      expect.objectContaining({ stateSchema: changedSchema }),
+    );
   });
 });

--- a/packages/core/src/react/model-context/useInteractable.ts
+++ b/packages/core/src/react/model-context/useInteractable.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useMemo, useRef } from "react";
+import { useEffect, useId, useMemo } from "react";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import type { Unstable_InteractableStateSchema } from "../types/scopes/interactables";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
@@ -9,7 +9,7 @@ import {
   interactableToolName,
 } from "../../model-context/interactable-composer-metadata";
 import { unstable_useInteractableState as useInteractableState } from "./useInteractableState";
-import { useJSONEqual } from "../utils/useJSONEqual";
+import { useJSONEqual, useJSONEqualValue } from "../utils/useJSONEqual";
 
 /**
  * The state type described by an interactable's `stateSchema`. Resolves the
@@ -114,10 +114,8 @@ const useInteractable = <TSchema extends Unstable_InteractableStateSchema>(
       ? "thread"
       : undefined;
 
-  const stateSchemaRef = useRef(config.stateSchema);
-  stateSchemaRef.current = config.stateSchema;
-  const initialStateRef = useRef(config.initialState);
-  initialStateRef.current = config.initialState;
+  const stateSchema = useJSONEqualValue(config.stateSchema);
+  const initialState = useJSONEqualValue(config.initialState);
 
   const interactables = useAuiState(() => aui.unstable_interactables);
 
@@ -126,8 +124,8 @@ const useInteractable = <TSchema extends Unstable_InteractableStateSchema>(
       id,
       name,
       description: config.description,
-      stateSchema: stateSchemaRef.current,
-      initialState: initialStateRef.current,
+      stateSchema,
+      initialState,
       updateRender: config.updateRender,
       ...(internalScope ? { scope: internalScope } : {}),
     } as Parameters<typeof interactables.register>[0] & {
@@ -138,6 +136,8 @@ const useInteractable = <TSchema extends Unstable_InteractableStateSchema>(
     id,
     name,
     config.description,
+    stateSchema,
+    initialState,
     internalScope,
     config.updateRender,
   ]);

--- a/packages/core/src/react/model-context/useInteractable.ts
+++ b/packages/core/src/react/model-context/useInteractable.ts
@@ -3,6 +3,7 @@
 import { useEffect, useId, useMemo, useRef } from "react";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import { toJSONSchema } from "assistant-stream";
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import type { Unstable_InteractableStateSchema } from "../types/scopes/interactables";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
 import {
@@ -118,7 +119,7 @@ const useInteractable = <TSchema extends Unstable_InteractableStateSchema>(
   const stateSchemaRef = useRef(config.stateSchema);
   stateSchemaRef.current = config.stateSchema;
   const normalizedStateSchema = useJSONEqualValue(
-    toJSONSchema(config.stateSchema),
+    toJSONSchema(config.stateSchema) as ReadonlyJSONValue,
   );
   const initialStateRef = useRef(config.initialState);
   initialStateRef.current = config.initialState;

--- a/packages/core/src/react/model-context/useInteractable.ts
+++ b/packages/core/src/react/model-context/useInteractable.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useId, useMemo } from "react";
+import { useEffect, useId, useMemo, useRef } from "react";
 import { useAui, useAuiState } from "@assistant-ui/store";
+import { toJSONSchema } from "assistant-stream";
 import type { Unstable_InteractableStateSchema } from "../types/scopes/interactables";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
 import {
@@ -114,8 +115,13 @@ const useInteractable = <TSchema extends Unstable_InteractableStateSchema>(
       ? "thread"
       : undefined;
 
-  const stateSchema = useJSONEqualValue(config.stateSchema);
-  const initialState = useJSONEqualValue(config.initialState);
+  const stateSchemaRef = useRef(config.stateSchema);
+  stateSchemaRef.current = config.stateSchema;
+  const normalizedStateSchema = useJSONEqualValue(
+    toJSONSchema(config.stateSchema),
+  );
+  const initialStateRef = useRef(config.initialState);
+  initialStateRef.current = config.initialState;
 
   const interactables = useAuiState(() => aui.unstable_interactables);
 
@@ -124,8 +130,8 @@ const useInteractable = <TSchema extends Unstable_InteractableStateSchema>(
       id,
       name,
       description: config.description,
-      stateSchema,
-      initialState,
+      stateSchema: stateSchemaRef.current,
+      initialState: initialStateRef.current,
       updateRender: config.updateRender,
       ...(internalScope ? { scope: internalScope } : {}),
     } as Parameters<typeof interactables.register>[0] & {
@@ -136,8 +142,7 @@ const useInteractable = <TSchema extends Unstable_InteractableStateSchema>(
     id,
     name,
     config.description,
-    stateSchema,
-    initialState,
+    normalizedStateSchema,
     internalScope,
     config.updateRender,
   ]);

--- a/packages/core/src/react/model-context/useInteractable.ts
+++ b/packages/core/src/react/model-context/useInteractable.ts
@@ -2,8 +2,6 @@
 
 import { useEffect, useId, useMemo, useRef } from "react";
 import { useAui, useAuiState } from "@assistant-ui/store";
-import { toJSONSchema } from "assistant-stream";
-import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import type { Unstable_InteractableStateSchema } from "../types/scopes/interactables";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
 import {
@@ -11,7 +9,8 @@ import {
   interactableToolName,
 } from "../../model-context/interactable-composer-metadata";
 import { unstable_useInteractableState as useInteractableState } from "./useInteractableState";
-import { useJSONEqual, useJSONEqualValue } from "../utils/useJSONEqual";
+import { useJSONEqual } from "../utils/useJSONEqual";
+import { useJSONSchemaDependency } from "../utils/useJSONSchemaDependency";
 
 /**
  * The state type described by an interactable's `stateSchema`. Resolves the
@@ -118,9 +117,7 @@ const useInteractable = <TSchema extends Unstable_InteractableStateSchema>(
 
   const stateSchemaRef = useRef(config.stateSchema);
   stateSchemaRef.current = config.stateSchema;
-  const normalizedStateSchema = useJSONEqualValue(
-    toJSONSchema(config.stateSchema) as ReadonlyJSONValue,
-  );
+  const normalizedStateSchema = useJSONSchemaDependency(config.stateSchema);
   const initialStateRef = useRef(config.initialState);
   initialStateRef.current = config.initialState;
 

--- a/packages/core/src/react/utils/useJSONEqual.ts
+++ b/packages/core/src/react/utils/useJSONEqual.ts
@@ -1,7 +1,8 @@
 import { useRef } from "react";
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import { isJSONValueEqual } from "../../utils/json/is-json-equal";
 
-export function useJSONEqualValue<T>(value: T): T {
+export function useJSONEqualValue<T extends ReadonlyJSONValue>(value: T): T {
   const prev = useRef(value);
   if (prev.current !== value && !isJSONValueEqual(prev.current, value)) {
     prev.current = value;

--- a/packages/core/src/react/utils/useJSONEqual.ts
+++ b/packages/core/src/react/utils/useJSONEqual.ts
@@ -1,6 +1,14 @@
 import { useRef } from "react";
 import { isJSONValueEqual } from "../../utils/json/is-json-equal";
 
+export function useJSONEqualValue<T>(value: T): T {
+  const prev = useRef(value);
+  if (prev.current !== value && !isJSONValueEqual(prev.current, value)) {
+    prev.current = value;
+  }
+  return prev.current;
+}
+
 /**
  * Like `useShallow`, but with JSON deep-equality. Use when a selector derives an
  * equal-but-fresh value on every store update — e.g. folding over

--- a/packages/core/src/react/utils/useJSONSchemaDependency.ts
+++ b/packages/core/src/react/utils/useJSONSchemaDependency.ts
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+import { toJSONSchema } from "assistant-stream";
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
+import { isJSONValue } from "../../utils/json/is-json";
+import type { Unstable_InteractableStateSchema } from "../types/scopes/interactables";
+import { useJSONEqualValue } from "./useJSONEqual";
+
+export function useJSONSchemaDependency(
+  schema: Unstable_InteractableStateSchema,
+): ReadonlyJSONValue {
+  const normalizedSchema = useMemo(() => {
+    try {
+      const jsonSchema = toJSONSchema(schema);
+      return isJSONValue(jsonSchema) ? jsonSchema : null;
+    } catch {
+      return null;
+    }
+  }, [schema]);
+
+  return useJSONEqualValue(normalizedSchema);
+}

--- a/packages/core/src/react/utils/useJSONSchemaDependency.ts
+++ b/packages/core/src/react/utils/useJSONSchemaDependency.ts
@@ -13,6 +13,7 @@ export function useJSONSchemaDependency(
       const jsonSchema = toJSONSchema(schema);
       return isJSONValue(jsonSchema) ? jsonSchema : null;
     } catch {
+      // Opaque schemas share one fallback so rebuilt instances do not churn registration.
       return null;
     }
   }, [schema]);


### PR DESCRIPTION
## Problem

Changing an interactable's `stateSchema` after mount leaves the registered definition on the previous schema. The model-facing update tool can therefore keep validating against stale state after a dynamically configured UI change.

On current main, rerendering either the current or legacy hook with a changed schema produced one registration instead of two. Multiple anchors made the stale model-facing schema persist even after re-registration.

## Root cause

Both hooks copied the latest schema into a ref, but their registration effects did not depend on the schema. Registration snapshots the supplied definition, so updating the ref alone cannot refresh it. The current registry also cached partial schemas only by interactable id, so a surviving anchor could retain the previous tool parameters.

## Change

A shared hook safely normalizes each supplied schema to JSON Schema, memoizes conversion by schema identity, and stabilizes structurally equivalent results. Current and legacy interactables now re-register when the normalized schema actually changes, including Standard Schema inputs, without churning when an equivalent schema is rebuilt inline. Unsupported schemas keep the existing permissive registry fallback instead of throwing during render.

The current registry tracks the schema source for each cached partial schema and rebuilds model-facing parameters when that source changes, including while another anchor remains registered. The original schema object remains registered so its validation behavior is preserved.

`initialState` keeps its existing ref behavior and does not trigger re-registration, so changing defaults cannot reset live state.

## Verification

- focused interactable suites: 63 tests passed
- full `@assistant-ui/core` suite: 1,843 tests passed
- `aui-build` for `@assistant-ui/core`
- focused Oxlint and Oxfmt checks
- bundle-size budget check

The changed-schema regressions fail on `origin/main` because each hook registers only once. Added coverage also proves equivalent rebuilt schemas remain stable, unsupported Standard Schemas do not fail render, stable schemas convert once, and multi-anchor model-context parameters refresh.

## Public surface

`@assistant-ui/core` receives a patch changeset. No exports or API signatures change.