### PR TITLE
feat(cloud): name the sdk packages on every request with an Aui-Sdk header

### DIFF
--- a/.changeset/sdk-header-buildutils.md
+++ b/.changeset/sdk-header-buildutils.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-buildutils": patch
+---
+
+feat: define `__AUI_PACKAGE_VERSION__` from the built package's version in both builds and ship its ambient declaration through the shared tsconfig base

--- a/.changeset/sdk-header-cloud.md
+++ b/.changeset/sdk-header-cloud.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+feat: send the `Aui-Sdk` header on every request, naming the client version and the integrations registered through `registerSdk`

--- a/.changeset/sdk-header-integrations.md
+++ b/.changeset/sdk-header-integrations.md
@@ -2,6 +2,9 @@
 "@assistant-ui/core": patch
 "@assistant-ui/ai-sdk": patch
 "@assistant-ui/cloud-ai-sdk": patch
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-google-adk": patch
 ---
 
 feat: register the package as an integration on the `assistant-cloud` client so the cloud can tell which packages talk to a project

--- a/.changeset/sdk-header-integrations.md
+++ b/.changeset/sdk-header-integrations.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/ai-sdk": patch
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+feat: register the package as an integration on the `assistant-cloud` client so the cloud can tell which packages talk to a project

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ How a package couples to its upstream decides how it bumps; the posture is chose
 
 ## Build & release
 
-Every publishable package builds with `aui-build` (`@assistant-ui/x-buildutils`). Do not add a per-package build config or use tsup, unbuild, swc, or the tsc CLI. Exports maps are ESM-only and types-first (`"types"` before `"default"`), with `type: module` and `sideEffects: false`.
+Every publishable package builds with `aui-build` (`@assistant-ui/x-buildutils`). Do not add a per-package build config or use tsup, unbuild, swc, or the tsc CLI. Exports maps are ESM-only and types-first (`"types"` before `"default"`), with `type: module` and `sideEffects: false`. `aui-build` defines `__AUI_PACKAGE_VERSION__` from the package's own version at build time; read it through a `typeof` guard with a `"0.0.0"` fallback, since vitest and unbundled runs do not define it.
 
 `packages/ui/src/components/react/assistant-ui/elements` is the canonical UI source. Templates and examples alias it through tsconfig (`@/components/*`, `@/hooks/*`, `@/lib/utils`) and carry no byte-equal copies of it — except `minimal`, which ships its own (examples may still hold intentional forks). `pnpm sync-templates` keeps minimal's copies byte-equal with the source; declare intentional divergence in the `OVERRIDES` array in `scripts/sync-templates.sh`.
 

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -17,6 +17,7 @@ type AISDKMessageLike = {
 type AISDKStorageFormat = Omit<UIMessage, "id">;
 
 declare class AssistantCloud {
+  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -28,13 +29,17 @@ declare class AssistantCloud {
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
   constructor(config: AssistantCloudConfig);
+  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
+  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
+  registerSdk(sdk: SdkIdentity): void;
+  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }
@@ -196,6 +201,7 @@ declare class AssistantCloudRuns {
     api: string;
     headers: () => Promise<{
       Accept: string;
+      "Aui-Sdk": string;
     }>;
     body: {
       assistant_id: string;
@@ -778,6 +784,11 @@ type SamplingCallData = {
   duration_ms?: number;
 };
 
+type SdkIdentity = {
+  name: string;
+  version: string;
+};
+
 type Span$1 = Span & ReadableSpan;
 
 interface SpanExporter {
@@ -894,7 +905,7 @@ declare namespace entry_ai_sdk_exports {
 }
 
 declare namespace entry_root_exports {
-  export { AssistantCloud, AssistantCloudEvent, AssistantCloudEventKind, AssistantCloudEvents, AssistantCloudRunReport, AssistantCloudRunReportToolCall, AssistantCloudScoreBody, AssistantCloudScoreResponse, AssistantCloudScores, AssistantCloudTelemetryConfig, AssistantCloudThreadMessageFeedbackBody, AssistantCloudThreadMessageFeedbackResponse, CloudAPIError, CloudEngagementReporter, CloudMessage, CloudMessagePersistence, CloudResponseError, CloudRunReportInit, CloudRunReporter, EngagementEventIds, EngagementIdResolver, GeneratePresignedDownloadUrlResponse, McpSamplingHandler, MessageFormatAdapter, RunMessageTelemetry, RunReportInit, RunReportOutcome, RunReportStepInit, RunTelemetryToolCallInit, RunTelemetryUsage, RunTelemetryUsageInit, SamplingCallData, createFormattedPersistence, createRunReport, createRunTelemetryToolCall, createSamplingCollector, deriveRunOutcome, describeRunError, extractRunTelemetryModelId, generateThreadTitle, normalizeRunTelemetryUsage, readAnonymousRefreshToken, truncateRunTelemetryText, wrapSamplingHandler };
+  export { AssistantCloud, AssistantCloudEvent, AssistantCloudEventKind, AssistantCloudEvents, AssistantCloudRunReport, AssistantCloudRunReportToolCall, AssistantCloudScoreBody, AssistantCloudScoreResponse, AssistantCloudScores, AssistantCloudTelemetryConfig, AssistantCloudThreadMessageFeedbackBody, AssistantCloudThreadMessageFeedbackResponse, CloudAPIError, CloudEngagementReporter, CloudMessage, CloudMessagePersistence, CloudResponseError, CloudRunReportInit, CloudRunReporter, EngagementEventIds, EngagementIdResolver, GeneratePresignedDownloadUrlResponse, McpSamplingHandler, MessageFormatAdapter, RunMessageTelemetry, RunReportInit, RunReportOutcome, RunReportStepInit, RunTelemetryToolCallInit, RunTelemetryUsage, RunTelemetryUsageInit, SamplingCallData, SdkIdentity, createFormattedPersistence, createRunReport, createRunTelemetryToolCall, createSamplingCollector, deriveRunOutcome, describeRunError, extractRunTelemetryModelId, generateThreadTitle, normalizeRunTelemetryUsage, readAnonymousRefreshToken, truncateRunTelemetryText, wrapSamplingHandler };
 }
 
 declare namespace entry_telemetry_exports {

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -17,7 +17,6 @@ type AISDKMessageLike = {
 type AISDKStorageFormat = Omit<UIMessage, "id">;
 
 declare class AssistantCloud {
-  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -28,18 +27,17 @@ declare class AssistantCloud {
   readonly events: AssistantCloudEvents;
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
   constructor(config: AssistantCloudConfig);
-  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
-  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
+  readonly sdkHeader: () => string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
-  registerSdk(sdk: SdkIdentity): void;
-  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -89,7 +89,6 @@ type AssistantChatTransportInitOptions<UI_MESSAGE extends UIMessage> = HttpChatT
 };
 
 declare class AssistantCloud {
-  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -100,18 +99,17 @@ declare class AssistantCloud {
   readonly events: AssistantCloudEvents;
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
   constructor(config: AssistantCloudConfig);
-  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
-  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
+  readonly sdkHeader: () => string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
-  registerSdk(sdk: SdkIdentity): void;
-  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -89,6 +89,7 @@ type AssistantChatTransportInitOptions<UI_MESSAGE extends UIMessage> = HttpChatT
 };
 
 declare class AssistantCloud {
+  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -100,13 +101,17 @@ declare class AssistantCloud {
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
   constructor(config: AssistantCloudConfig);
+  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
+  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
+  registerSdk(sdk: SdkIdentity): void;
+  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }
@@ -268,6 +273,7 @@ declare class AssistantCloudRuns {
     api: string;
     headers: () => Promise<{
       Accept: string;
+      "Aui-Sdk": string;
     }>;
     body: {
       assistant_id: string;
@@ -1610,6 +1616,11 @@ type SamplingCallData = {
 interface ScopeRegistry {
   [key: string]: { methods: any; meta?: any; events?: any };
 }
+
+type SdkIdentity = {
+  name: string;
+  version: string;
+};
 
 type SendOptions = {
   startRun?: boolean;

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -5,6 +5,7 @@ import "@standard-schema/spec";
 import { ChatInit } from "ai";
 
 declare class AssistantCloud {
+  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -16,13 +17,17 @@ declare class AssistantCloud {
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
   constructor(config: AssistantCloudConfig);
+  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
+  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
+  registerSdk(sdk: SdkIdentity): void;
+  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }
@@ -184,6 +189,7 @@ declare class AssistantCloudRuns {
     api: string;
     headers: () => Promise<{
       Accept: string;
+      "Aui-Sdk": string;
     }>;
     body: {
       assistant_id: string;
@@ -515,6 +521,11 @@ type SamplingCallData = {
   reasoning_tokens?: number;
   cached_input_tokens?: number;
   duration_ms?: number;
+};
+
+type SdkIdentity = {
+  name: string;
+  version: string;
 };
 
 type ThreadStatus = "archived" | "regular";

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -5,7 +5,6 @@ import "@standard-schema/spec";
 import { ChatInit } from "ai";
 
 declare class AssistantCloud {
-  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -16,18 +15,17 @@ declare class AssistantCloud {
   readonly events: AssistantCloudEvents;
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
   constructor(config: AssistantCloudConfig);
-  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
-  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
+  readonly sdkHeader: () => string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
-  registerSdk(sdk: SdkIdentity): void;
-  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -110,7 +110,6 @@ type AssistantClientAccessor<K extends ClientNames> = ClientSchemas[K]["methods"
 };
 
 declare class AssistantCloud {
-  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -121,18 +120,17 @@ declare class AssistantCloud {
   readonly events: AssistantCloudEvents;
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
   constructor(config: AssistantCloudConfig);
-  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
-  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
+  readonly sdkHeader: () => string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
-  registerSdk(sdk: SdkIdentity): void;
-  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -110,6 +110,7 @@ type AssistantClientAccessor<K extends ClientNames> = ClientSchemas[K]["methods"
 };
 
 declare class AssistantCloud {
+  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -121,13 +122,17 @@ declare class AssistantCloud {
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
   constructor(config: AssistantCloudConfig);
+  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
+  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
+  registerSdk(sdk: SdkIdentity): void;
+  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }
@@ -289,6 +294,7 @@ declare class AssistantCloudRuns {
     api: string;
     headers: () => Promise<{
       Accept: string;
+      "Aui-Sdk": string;
     }>;
     body: {
       assistant_id: string;
@@ -1219,6 +1225,7 @@ type CloudThreadListAdapter = {
 
 type CloudThreadListAdapterOptions = {
   cloud?: AssistantCloud | undefined;
+  sdk?: SdkIdentity | undefined;
   create?: (() => Promise<ThreadData$1>) | undefined;
   delete?: ((threadId: string) => Promise<void>) | undefined;
 };
@@ -4213,6 +4220,11 @@ type ScopeStates = {
 
 type ScopesConfig = {
   [K in ClientNames]?: ClientElement<K> | DerivedElement<K>;
+};
+
+type SdkIdentity = {
+  name: string;
+  version: string;
 };
 
 type SendCommandsRequestBody = {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -89,7 +89,6 @@ type AssistantChatTransportInitOptions<UI_MESSAGE extends UIMessage> = HttpChatT
 };
 
 declare class AssistantCloud {
-  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -100,18 +99,17 @@ declare class AssistantCloud {
   readonly events: AssistantCloudEvents;
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
   constructor(config: AssistantCloudConfig);
-  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
-  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
+  readonly sdkHeader: () => string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
-  registerSdk(sdk: SdkIdentity): void;
-  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -89,6 +89,7 @@ type AssistantChatTransportInitOptions<UI_MESSAGE extends UIMessage> = HttpChatT
 };
 
 declare class AssistantCloud {
+  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -100,13 +101,17 @@ declare class AssistantCloud {
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
   constructor(config: AssistantCloudConfig);
+  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
+  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
+  registerSdk(sdk: SdkIdentity): void;
+  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }
@@ -268,6 +273,7 @@ declare class AssistantCloudRuns {
     api: string;
     headers: () => Promise<{
       Accept: string;
+      "Aui-Sdk": string;
     }>;
     body: {
       assistant_id: string;
@@ -1610,6 +1616,11 @@ type SamplingCallData = {
 interface ScopeRegistry {
   [key: string]: { methods: any; meta?: any; events?: any };
 }
+
+type SdkIdentity = {
+  name: string;
+  version: string;
+};
 
 type SendOptions = {
   startRun?: boolean;

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -13,7 +13,6 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
 declare class AssistantCloud {
-  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -24,18 +23,17 @@ declare class AssistantCloud {
   readonly events: AssistantCloudEvents;
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
   constructor(config: AssistantCloudConfig);
-  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
-  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
+  readonly sdkHeader: () => string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
-  registerSdk(sdk: SdkIdentity): void;
-  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -13,6 +13,7 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
 declare class AssistantCloud {
+  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -24,13 +25,17 @@ declare class AssistantCloud {
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
   constructor(config: AssistantCloudConfig);
+  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
+  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
+  registerSdk(sdk: SdkIdentity): void;
+  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }
@@ -192,6 +197,7 @@ declare class AssistantCloudRuns {
     api: string;
     headers: () => Promise<{
       Accept: string;
+      "Aui-Sdk": string;
     }>;
     body: {
       assistant_id: string;
@@ -1357,6 +1363,11 @@ type SamplingCallData = {
   reasoning_tokens?: number;
   cached_input_tokens?: number;
   duration_ms?: number;
+};
+
+type SdkIdentity = {
+  name: string;
+  version: string;
 };
 
 type SendOptions = {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -382,6 +382,7 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
 declare class AssistantCloud {
+  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -393,13 +394,17 @@ declare class AssistantCloud {
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
   constructor(config: AssistantCloudConfig);
+  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
+  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
+  registerSdk(sdk: SdkIdentity): void;
+  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }
@@ -561,6 +566,7 @@ declare class AssistantCloudRuns {
     api: string;
     headers: () => Promise<{
       Accept: string;
+      "Aui-Sdk": string;
     }>;
     body: {
       assistant_id: string;
@@ -1934,6 +1940,11 @@ type SamplingCallData = {
   reasoning_tokens?: number;
   cached_input_tokens?: number;
   duration_ms?: number;
+};
+
+type SdkIdentity = {
+  name: string;
+  version: string;
 };
 
 type SendOptions = {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -382,7 +382,6 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
 declare class AssistantCloud {
-  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -393,18 +392,17 @@ declare class AssistantCloud {
   readonly events: AssistantCloudEvents;
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
   constructor(config: AssistantCloudConfig);
-  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
-  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
+  readonly sdkHeader: () => string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
-  registerSdk(sdk: SdkIdentity): void;
-  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -85,6 +85,7 @@ type AssistantClientAccessor<K extends ClientNames> = ClientSchemas[K]["methods"
 };
 
 declare class AssistantCloud {
+  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -96,13 +97,17 @@ declare class AssistantCloud {
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
   constructor(config: AssistantCloudConfig);
+  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
+  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
+  registerSdk(sdk: SdkIdentity): void;
+  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }
@@ -264,6 +269,7 @@ declare class AssistantCloudRuns {
     api: string;
     headers: () => Promise<{
       Accept: string;
+      "Aui-Sdk": string;
     }>;
     body: {
       assistant_id: string;
@@ -3095,6 +3101,11 @@ type ScopeStates = {
   [K in ClientNames]: ClientSchemas[K]["methods"] extends {
     getState: () => infer S;
   } ? S : never;
+};
+
+type SdkIdentity = {
+  name: string;
+  version: string;
 };
 
 type SendOptions = {

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -85,7 +85,6 @@ type AssistantClientAccessor<K extends ClientNames> = ClientSchemas[K]["methods"
 };
 
 declare class AssistantCloud {
-  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -96,18 +95,17 @@ declare class AssistantCloud {
   readonly events: AssistantCloudEvents;
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
   constructor(config: AssistantCloudConfig);
-  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
-  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
+  readonly sdkHeader: () => string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
-  registerSdk(sdk: SdkIdentity): void;
-  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -23,6 +23,7 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
 declare class AssistantCloud {
+  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -34,13 +35,17 @@ declare class AssistantCloud {
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
   constructor(config: AssistantCloudConfig);
+  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
+  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
+  registerSdk(sdk: SdkIdentity): void;
+  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }
@@ -202,6 +207,7 @@ declare class AssistantCloudRuns {
     api: string;
     headers: () => Promise<{
       Accept: string;
+      "Aui-Sdk": string;
     }>;
     body: {
       assistant_id: string;
@@ -1643,6 +1649,11 @@ type SamplingCallData = {
   reasoning_tokens?: number;
   cached_input_tokens?: number;
   duration_ms?: number;
+};
+
+type SdkIdentity = {
+  name: string;
+  version: string;
 };
 
 type SendOptions = {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -23,7 +23,6 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
 declare class AssistantCloud {
-  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -34,18 +33,17 @@ declare class AssistantCloud {
   readonly events: AssistantCloudEvents;
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
   constructor(config: AssistantCloudConfig);
-  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
-  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
+  readonly sdkHeader: () => string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
-  registerSdk(sdk: SdkIdentity): void;
-  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -25,6 +25,7 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
 declare class AssistantCloud {
+  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -36,13 +37,17 @@ declare class AssistantCloud {
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
   constructor(config: AssistantCloudConfig);
+  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
+  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
+  registerSdk(sdk: SdkIdentity): void;
+  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }
@@ -204,6 +209,7 @@ declare class AssistantCloudRuns {
     api: string;
     headers: () => Promise<{
       Accept: string;
+      "Aui-Sdk": string;
     }>;
     body: {
       assistant_id: string;
@@ -1811,6 +1817,11 @@ type SamplingCallData = {
   reasoning_tokens?: number;
   cached_input_tokens?: number;
   duration_ms?: number;
+};
+
+type SdkIdentity = {
+  name: string;
+  version: string;
 };
 
 type SendOptions = {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -25,7 +25,6 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
 declare class AssistantCloud {
-  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -36,18 +35,17 @@ declare class AssistantCloud {
   readonly events: AssistantCloudEvents;
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
   constructor(config: AssistantCloudConfig);
-  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
-  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
+  readonly sdkHeader: () => string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
-  registerSdk(sdk: SdkIdentity): void;
-  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -83,6 +83,7 @@ type AssistantClientAccessor<K extends ClientNames> = ClientSchemas[K]["methods"
 };
 
 declare class AssistantCloud {
+  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -94,13 +95,17 @@ declare class AssistantCloud {
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
   constructor(config: AssistantCloudConfig);
+  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
+  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
+  registerSdk(sdk: SdkIdentity): void;
+  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }
@@ -262,6 +267,7 @@ declare class AssistantCloudRuns {
     api: string;
     headers: () => Promise<{
       Accept: string;
+      "Aui-Sdk": string;
     }>;
     body: {
       assistant_id: string;
@@ -2761,6 +2767,11 @@ type ScopeStates = {
   [K in ClientNames]: ClientSchemas[K]["methods"] extends {
     getState: () => infer S;
   } ? S : never;
+};
+
+type SdkIdentity = {
+  name: string;
+  version: string;
 };
 
 type SendOptions = {

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -83,7 +83,6 @@ type AssistantClientAccessor<K extends ClientNames> = ClientSchemas[K]["methods"
 };
 
 declare class AssistantCloud {
-  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -94,18 +93,17 @@ declare class AssistantCloud {
   readonly events: AssistantCloudEvents;
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
   constructor(config: AssistantCloudConfig);
-  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
-  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
+  readonly sdkHeader: () => string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
-  registerSdk(sdk: SdkIdentity): void;
-  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -246,6 +246,7 @@ type AssistantClientAccessor<K extends ClientNames> = ClientSchemas[K]["methods"
 };
 
 declare class AssistantCloud {
+  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -257,13 +258,17 @@ declare class AssistantCloud {
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
   constructor(config: AssistantCloudConfig);
+  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
+  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
+  registerSdk(sdk: SdkIdentity): void;
+  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }
@@ -425,6 +430,7 @@ declare class AssistantCloudRuns {
     api: string;
     headers: () => Promise<{
       Accept: string;
+      "Aui-Sdk": string;
     }>;
     body: {
       assistant_id: string;
@@ -1407,6 +1413,7 @@ type CloudThreadListAdapter = {
 
 type CloudThreadListAdapterOptions = {
   cloud?: AssistantCloud | undefined;
+  sdk?: SdkIdentity | undefined;
   create?: (() => Promise<ThreadData$1>) | undefined;
   delete?: ((threadId: string) => Promise<void>) | undefined;
 };
@@ -3996,6 +4003,11 @@ type ScopeStates = {
   [K in ClientNames]: ClientSchemas[K]["methods"] extends {
     getState: () => infer S;
   } ? S : never;
+};
+
+type SdkIdentity = {
+  name: string;
+  version: string;
 };
 
 type SelectItemOverride = (item: Unstable_TriggerItem) => boolean;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -246,7 +246,6 @@ type AssistantClientAccessor<K extends ClientNames> = ClientSchemas[K]["methods"
 };
 
 declare class AssistantCloud {
-  #private;
   readonly threads: AssistantCloudThreads;
   readonly projects: AssistantCloudProjects;
   readonly auth: {
@@ -257,18 +256,17 @@ declare class AssistantCloud {
   readonly events: AssistantCloudEvents;
   readonly scores: AssistantCloudScores;
   readonly telemetry: AssistantCloudTelemetryConfig;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
   constructor(config: AssistantCloudConfig);
-  registerSdk(sdk: SdkIdentity): void;
 }
 
 declare class AssistantCloudAPI {
-  #private;
   _auth: AssistantCloudAuthStrategy;
   _baseUrl: string;
+  readonly registerSdk: (sdk: SdkIdentity) => void;
+  readonly sdkHeader: () => string;
   constructor(config: AssistantCloudConfig);
   initializeAuth(): Promise<boolean>;
-  registerSdk(sdk: SdkIdentity): void;
-  sdkHeader(): string;
   makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
   makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
 }

--- a/packages/ai-sdk/src/runtime/AISDKThreads.cloud.test.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.cloud.test.ts
@@ -54,23 +54,28 @@ const mocks = vi.hoisted(() => {
       return { history };
     },
   };
-  return { adapter };
+  return {
+    adapter,
+    useCloudThreadListAdapter: vi.fn(() => adapter),
+  };
 });
 
 vi.mock("@assistant-ui/core/react", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@assistant-ui/core/react")>()),
-  useCloudThreadListAdapter: () => mocks.adapter,
+  useCloudThreadListAdapter: mocks.useCloudThreadListAdapter,
 }));
 
 import { AISDKThreads } from "./AISDKThreads";
 import { createCancellableTransport } from "./__tests__/controlled-transport";
+import { AI_SDK_SDK } from "./sdkIdentity";
 
 describe("AISDKThreads cloud", () => {
   it("reloads history when switching a keyed cloud thread", async () => {
+    const cloud = {} as AssistantCloud;
     const handle = createAssistantClient(
       AuiConfig({
         threads: AISDKThreads({
-          cloud: {} as AssistantCloud,
+          cloud,
           threadId: "t1",
         }),
       }),
@@ -83,6 +88,10 @@ describe("AISDKThreads cloud", () => {
     });
     await vi.waitFor(() => {
       expect(load).toHaveBeenCalled();
+    });
+    expect(mocks.useCloudThreadListAdapter).toHaveBeenCalledWith({
+      cloud,
+      sdk: AI_SDK_SDK,
     });
     const afterFirst = load.mock.calls.length;
     flushTapSync(() => aui.threads.switchToThread("t2"));

--- a/packages/ai-sdk/src/runtime/AISDKThreads.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.ts
@@ -26,6 +26,7 @@ import {
 } from "./useChatThread";
 import { MessageRepository } from "@assistant-ui/core/internal";
 import { useResourceCleanup } from "./useResourceCleanup";
+import { AI_SDK_SDK } from "./sdkIdentity";
 
 export type AISDKThreadsOptions<UI_MESSAGE extends UIMessage = UIMessage> =
   Omit<ChatThreadOptions<UI_MESSAGE>, "id" | "transport" | "messages"> & {
@@ -179,7 +180,7 @@ const useAISDKThreads = <UI_MESSAGE extends UIMessage = UIMessage>(
     }
   });
 
-  const cloudAdapter = useCloudThreadListAdapter({ cloud });
+  const cloudAdapter = useCloudThreadListAdapter({ cloud, sdk: AI_SDK_SDK });
   const thread = (id: string) => {
     const element = AISDKChatThread({
       threadId: id,

--- a/packages/ai-sdk/src/runtime/sdkIdentity.ts
+++ b/packages/ai-sdk/src/runtime/sdkIdentity.ts
@@ -1,0 +1,9 @@
+import type { SdkIdentity } from "assistant-cloud";
+
+export const AI_SDK_SDK: SdkIdentity = {
+  name: "@assistant-ui/ai-sdk",
+  version:
+    typeof __AUI_PACKAGE_VERSION__ === "string"
+      ? __AUI_PACKAGE_VERSION__
+      : "0.0.0",
+};

--- a/packages/ai-sdk/src/runtime/useChatRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.ts
@@ -9,6 +9,7 @@ import {
 } from "@assistant-ui/core/react";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import { useChatThread, type ChatThreadOptions } from "./useChatThread";
+import { AI_SDK_SDK } from "./sdkIdentity";
 
 export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
   ChatThreadOptions<UI_MESSAGE> & {
@@ -38,7 +39,7 @@ export const useChatRuntime = <UI_MESSAGE extends UIMessage = UIMessage>({
   onThreadIdChange,
   ...options
 }: UseChatRuntimeOptions<UI_MESSAGE> = {}): AssistantRuntime => {
-  const cloudAdapter = useCloudThreadListAdapter({ cloud });
+  const cloudAdapter = useCloudThreadListAdapter({ cloud, sdk: AI_SDK_SDK });
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
       return useChatThreadRuntime(options);

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.switch.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.switch.test.ts
@@ -43,6 +43,7 @@ describe("useCloudChat thread switching", () => {
 
   it("resets visible chat messages immediately when switching to new chat (threadId -> null)", () => {
     const mockCloud = {
+      registerSdk: vi.fn(),
       threads: {
         create: vi.fn(),
         list: vi.fn(),
@@ -78,8 +79,8 @@ describe("useCloudChat thread switching", () => {
     const stopAll = vi
       .spyOn(ChatRegistry.prototype, "stopAll")
       .mockResolvedValue(undefined);
-    const cloudA = { threads: {} };
-    const cloudB = { threads: {} };
+    const cloudA = { registerSdk: vi.fn(), threads: {} };
+    const cloudB = { registerSdk: vi.fn(), threads: {} };
     const threadsA = createThreads(cloudA, null);
     const threadsB = createThreads(cloudB, null);
     const pending = new Promise<never>(() => {});
@@ -111,6 +112,7 @@ describe("useCloudChat thread switching", () => {
 
   it("keeps committed options active when an options update suspends", async () => {
     const cloud = {
+      registerSdk: vi.fn(),
       threads: {
         create: vi.fn().mockResolvedValue({ thread_id: "thread-1" }),
       },
@@ -184,6 +186,7 @@ describe("useCloudChat thread switching", () => {
 
   it("applies a committed transport before any effect in the same commit", async () => {
     const cloud = {
+      registerSdk: vi.fn(),
       threads: {
         create: vi.fn().mockResolvedValue({ thread_id: "thread-1" }),
       },
@@ -248,6 +251,7 @@ describe("useCloudChat thread switching", () => {
       });
 
     const mockCloud = {
+      registerSdk: vi.fn(),
       threads: {
         create: vi.fn(),
         list: vi.fn(),

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.test.ts
@@ -8,6 +8,7 @@ const { mockUseChat, mockCloud, mockResolvedRemoteId } = vi.hoisted(() => {
   const resolvedRemoteId = vi.fn();
 
   const cloud = {
+    registerSdk: vi.fn(),
     threads: {
       create: mockThreadsCreate,
       list: vi.fn().mockResolvedValue({ threads: [] }),
@@ -98,6 +99,7 @@ vi.mock("ai", () => ({
   ),
 }));
 
+import { CLOUD_AI_SDK_SDK } from "../sdkIdentity";
 import { useCloudChat } from "./useCloudChat";
 
 const createThreads = (cloud: typeof mockCloud, threadId: string | null) => ({
@@ -158,6 +160,12 @@ describe("useCloudChat", () => {
 
     const chatB = mockUseChat.mock.calls.at(-1)?.[0].chat;
     expect(chatB).not.toBe(chatA);
+  });
+
+  it("registers the cloud AI SDK on an explicit cloud", () => {
+    renderHook(() => useCloudChat({ cloud: mockCloud as never }));
+
+    expect(mockCloud.registerSdk).toHaveBeenCalledWith(CLOUD_AI_SDK_SDK);
   });
 
   it("sends feedback for the persisted cloud message in the active thread", async () => {

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.ts
@@ -13,6 +13,7 @@ import { useChatRegistry } from "./useChatRegistry";
 import { useCloudChatCore } from "./useCloudChatCore";
 import type { ChatRegistry } from "./ChatRegistry";
 import type { CloudChatCore } from "../core/CloudChatCore";
+import { CLOUD_AI_SDK_SDK } from "../sdkIdentity";
 
 const autoCloudBaseUrl =
   typeof process !== "undefined"
@@ -107,9 +108,8 @@ function useResolvedCloud(
   explicitCloud: AssistantCloud | undefined,
 ): AssistantCloud {
   return useMemo(() => {
-    if (externalThreads) return externalThreads.cloud;
-    if (explicitCloud) return explicitCloud;
-    if (!autoCloud) {
+    const cloud = externalThreads?.cloud ?? explicitCloud ?? autoCloud;
+    if (!cloud) {
       throw new Error(
         "useCloudChat: No cloud configured. Either:\n" +
           "1. Set NEXT_PUBLIC_ASSISTANT_BASE_URL environment variable, or\n" +
@@ -117,7 +117,8 @@ function useResolvedCloud(
           "3. Pass threads from useThreads: useCloudChat({ threads })",
       );
     }
-    return autoCloud;
+    cloud.registerSdk(CLOUD_AI_SDK_SDK);
+    return cloud;
   }, [externalThreads, explicitCloud]);
 }
 

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.ts
@@ -117,7 +117,7 @@ function useResolvedCloud(
           "3. Pass threads from useThreads: useCloudChat({ threads })",
       );
     }
-    cloud.registerSdk(CLOUD_AI_SDK_SDK);
+    cloud.registerSdk?.(CLOUD_AI_SDK_SDK);
     return cloud;
   }, [externalThreads, explicitCloud]);
 }

--- a/packages/cloud-ai-sdk/src/sdkIdentity.ts
+++ b/packages/cloud-ai-sdk/src/sdkIdentity.ts
@@ -1,0 +1,9 @@
+import type { SdkIdentity } from "assistant-cloud";
+
+export const CLOUD_AI_SDK_SDK: SdkIdentity = {
+  name: "@assistant-ui/cloud-ai-sdk",
+  version:
+    typeof __AUI_PACKAGE_VERSION__ === "string"
+      ? __AUI_PACKAGE_VERSION__
+      : "0.0.0",
+};

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -35,6 +35,8 @@ export function Provider({ children }: { children: React.ReactNode }) {
 
 The pieces every client integration needs live in the package, so a runtime binding only maps its own events onto them.
 
+Every request carries `Aui-Sdk` with the client's own version and the identities integrations pass to `registerSdk`, so the cloud can tell which packages talk to a project.
+
 - `CloudRunReporter` sends run reports: nothing while telemetry is off, the cloud's environment, release and tags on every report, the `beforeReport` hook applied last, and a failed send that never surfaces. A report given a key is sent once per key, so the key has to name one run; without a key every call reports.
 - `CloudEngagementReporter` derives engagement events (`message_sent`, `run_stopped`, `error_shown`, `suggestions_shown` and the rest) from what a chat integration observes and keeps the per thread state they need, such as a run's start for the stop duration. An id resolver turns the integration's own thread and message ids into the ids the cloud stores.
 - `assistant-cloud/ai-sdk` holds the AI SDK specifics: `aiSDKV6FormatAdapter`, the stored form of a `UIMessage`, and `extractAISDKRunTelemetry`, which reads the run report fields out of one run's assistant messages. The entry types its messages with `ai` and needs no runtime from it.

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -35,7 +35,7 @@ export function Provider({ children }: { children: React.ReactNode }) {
 
 The pieces every client integration needs live in the package, so a runtime binding only maps its own events onto them.
 
-Every request carries `Aui-Sdk` with the client's own version and the identities integrations pass to `registerSdk`, so the cloud can tell which packages talk to a project.
+Every API request carries `Aui-Sdk` with the client's own version and the identities integrations pass to `registerSdk` (the anonymous token bootstrap requests do not), so the cloud can tell which packages talk to a project.
 
 - `CloudRunReporter` sends run reports: nothing while telemetry is off, the cloud's environment, release and tags on every report, the `beforeReport` hook applied last, and a failed send that never surfaces. A report given a key is sent once per key, so the key has to name one run; without a key every call reports.
 - `CloudEngagementReporter` derives engagement events (`message_sent`, `run_stopped`, `error_shown`, `suggestions_shown` and the rest) from what a chat integration observes and keeps the per thread state they need, such as a run's start for the stop duration. An id resolver turns the integration's own thread and message ids into the ids the cloud stores.

--- a/packages/cloud/src/AssistantCloud.ts
+++ b/packages/cloud/src/AssistantCloud.ts
@@ -21,11 +21,11 @@ export class AssistantCloud {
   public readonly events;
   public readonly scores;
   public readonly telemetry: AssistantCloudTelemetryConfig;
-  private readonly api: AssistantCloudAPI;
+  public readonly registerSdk: (sdk: SdkIdentity) => void;
 
   constructor(config: AssistantCloudConfig) {
     const api = new AssistantCloudAPI(config);
-    this.api = api;
+    this.registerSdk = api.registerSdk;
     const t = config.telemetry;
     this.telemetry =
       t === false
@@ -49,10 +49,5 @@ export class AssistantCloud {
       () => this.telemetry.enabled !== false && this.telemetry.events !== false,
     );
     this.scores = new AssistantCloudScores(api);
-  }
-
-  /** Registers an integration identity for request headers. */
-  public registerSdk(sdk: SdkIdentity): void {
-    this.api.registerSdk(sdk);
   }
 }

--- a/packages/cloud/src/AssistantCloud.ts
+++ b/packages/cloud/src/AssistantCloud.ts
@@ -1,6 +1,7 @@
 import {
   AssistantCloudAPI,
   type AssistantCloudConfig,
+  type SdkIdentity,
   type AssistantCloudTelemetryConfig,
 } from "./AssistantCloudAPI";
 import { AssistantCloudAuthTokens } from "./AssistantCloudAuthTokens";
@@ -20,9 +21,11 @@ export class AssistantCloud {
   public readonly events;
   public readonly scores;
   public readonly telemetry: AssistantCloudTelemetryConfig;
+  private readonly api: AssistantCloudAPI;
 
   constructor(config: AssistantCloudConfig) {
     const api = new AssistantCloudAPI(config);
+    this.api = api;
     const t = config.telemetry;
     this.telemetry =
       t === false
@@ -46,5 +49,10 @@ export class AssistantCloud {
       () => this.telemetry.enabled !== false && this.telemetry.events !== false,
     );
     this.scores = new AssistantCloudScores(api);
+  }
+
+  /** Registers an integration identity for request headers. */
+  public registerSdk(sdk: SdkIdentity): void {
+    this.api.registerSdk(sdk);
   }
 }

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -95,12 +95,31 @@ type MakeRequestOptions = {
   keepalive?: boolean | undefined;
 };
 
+const HEADER_TOKEN = /^[\x21-\x7e]+$/;
+
 export class AssistantCloudAPI {
   public _auth: AssistantCloudAuthStrategy;
   public _baseUrl;
-  private readonly sdks = new Map<string, SdkIdentity>();
+  public readonly registerSdk: (sdk: SdkIdentity) => void;
+  public readonly sdkHeader: () => string;
 
   constructor(config: AssistantCloudConfig) {
+    const sdks = new Map<string, SdkIdentity>();
+    this.registerSdk = (sdk) => {
+      const name = sdk.name.trim();
+      const version = sdk.version.trim();
+      if (!HEADER_TOKEN.test(name) || !HEADER_TOKEN.test(version)) return;
+      sdks.set(`${name}/${version}`, { name, version });
+    };
+    this.sdkHeader = () =>
+      [
+        `assistant-cloud/${ASSISTANT_CLOUD_VERSION}`,
+        ...Array.from(
+          sdks.values(),
+          ({ name, version }) => `${name}/${version}`,
+        ),
+      ].join(" ");
+
     if ("authToken" in config) {
       this._baseUrl = normalizeBaseUrl(config.baseUrl);
       this._auth = new AssistantCloudJWTAuthStrategy(config.authToken);
@@ -125,25 +144,6 @@ export class AssistantCloudAPI {
 
   public async initializeAuth() {
     return !!(await this._auth.getAuthHeaders());
-  }
-
-  /** Registers an integration identity for request headers. */
-  public registerSdk(sdk: SdkIdentity): void {
-    const name = sdk.name.trim();
-    const version = sdk.version.trim();
-    if (!name || !version) return;
-
-    this.sdks.set(`${name}/${version}`, { name, version });
-  }
-
-  public sdkHeader(): string {
-    return [
-      `assistant-cloud/${ASSISTANT_CLOUD_VERSION}`,
-      ...Array.from(
-        this.sdks.values(),
-        ({ name, version }) => `${name}/${version}`,
-      ),
-    ].join(" ");
   }
 
   public async makeRawRequest(

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -6,6 +6,12 @@ import {
   normalizeBaseUrl,
 } from "./AssistantCloudAuthStrategy";
 import type { AssistantCloudRunReport } from "./AssistantCloudRuns";
+import { ASSISTANT_CLOUD_VERSION } from "./version";
+
+export type SdkIdentity = {
+  name: string;
+  version: string;
+};
 
 export type AssistantCloudTelemetryConfig = {
   /**
@@ -92,6 +98,7 @@ type MakeRequestOptions = {
 export class AssistantCloudAPI {
   public _auth: AssistantCloudAuthStrategy;
   public _baseUrl;
+  private readonly sdks = new Map<string, SdkIdentity>();
 
   constructor(config: AssistantCloudConfig) {
     if ("authToken" in config) {
@@ -120,6 +127,25 @@ export class AssistantCloudAPI {
     return !!(await this._auth.getAuthHeaders());
   }
 
+  /** Registers an integration identity for request headers. */
+  public registerSdk(sdk: SdkIdentity): void {
+    const name = sdk.name.trim();
+    const version = sdk.version.trim();
+    if (!name || !version) return;
+
+    this.sdks.set(`${name}/${version}`, { name, version });
+  }
+
+  public sdkHeader(): string {
+    return [
+      `assistant-cloud/${ASSISTANT_CLOUD_VERSION}`,
+      ...Array.from(
+        this.sdks.values(),
+        ({ name, version }) => `${name}/${version}`,
+      ),
+    ].join(" ");
+  }
+
   public async makeRawRequest(
     endpoint: string,
     options: MakeRequestOptions = {},
@@ -131,6 +157,7 @@ export class AssistantCloudAPI {
       ...authHeaders,
       ...options.headers,
       "Content-Type": "application/json",
+      "Aui-Sdk": this.sdkHeader(),
     };
 
     const queryParams = new URLSearchParams();

--- a/packages/cloud/src/AssistantCloudRuns.ts
+++ b/packages/cloud/src/AssistantCloudRuns.ts
@@ -68,6 +68,7 @@ export class AssistantCloudRuns {
         return {
           ...headers,
           Accept: "text/plain",
+          "Aui-Sdk": this.cloud.sdkHeader(),
         };
       },
       body: {

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -3,7 +3,10 @@ export type {
   AssistantCloudThreadMessageFeedbackBody,
   AssistantCloudThreadMessageFeedbackResponse,
 } from "./AssistantCloudThreadMessages";
-export type { AssistantCloudTelemetryConfig } from "./AssistantCloudAPI";
+export type {
+  AssistantCloudTelemetryConfig,
+  SdkIdentity,
+} from "./AssistantCloudAPI";
 export {
   AssistantCloudEvents,
   type AssistantCloudEvent,

--- a/packages/cloud/src/tests/AssistantCloud.test.ts
+++ b/packages/cloud/src/tests/AssistantCloud.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AssistantCloud } from "../AssistantCloud";
 import type { AssistantCloudTelemetryConfig } from "../AssistantCloudAPI";
 
@@ -13,6 +13,10 @@ const createCloud = (
   });
 
 describe("AssistantCloud telemetry config", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("defaults to enabled", () => {
     expect(createCloud().telemetry.enabled).toBe(true);
     expect(createCloud(true).telemetry.enabled).toBe(true);
@@ -56,6 +60,34 @@ describe("AssistantCloud telemetry config", () => {
       release: "web-2026.09.08",
       environment: "production",
       tags: ["region:sg", "tier:paid"],
+    });
+  });
+
+  it("forwards registered SDK identities to requests and stream options", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      text: vi.fn().mockResolvedValue(JSON.stringify({ threads: [] })),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const cloud = createCloud();
+    cloud.registerSdk({ name: "@assistant-ui/core", version: "0.3.18" });
+
+    await cloud.threads.list();
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(init.headers).toMatchObject({
+      "Aui-Sdk": expect.stringMatching(
+        /^assistant-cloud\/.* @assistant-ui\/core\/0\.3\.18$/,
+      ),
+    });
+    await expect(
+      cloud.runs.__internal_getAssistantOptions("assistant-id").headers(),
+    ).resolves.toMatchObject({
+      "Aui-Sdk": expect.stringMatching(
+        /^assistant-cloud\/.* @assistant-ui\/core\/0\.3\.18$/,
+      ),
     });
   });
 });

--- a/packages/cloud/src/tests/AssistantCloudAPI.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAPI.test.ts
@@ -54,6 +54,23 @@ describe("AssistantCloudAPI", () => {
     expect(init.body).toBe(JSON.stringify({ hello: "world" }));
   });
 
+  it("ignores identities that cannot travel in a header", () => {
+    const api = new AssistantCloudAPI({
+      apiKey: "test-key",
+      userId: "u-1",
+      workspaceId: "w-1",
+    });
+    api.registerSdk({ name: "bad name", version: "1.0.0" });
+    api.registerSdk({ name: "@scope/pkg", version: "1.0.0 ok" });
+    api.registerSdk({ name: "@scope/pkg\ttab", version: "1.0.0" });
+    api.registerSdk({ name: "@scope/ok", version: " 1.0.0 " });
+
+    expect(api.sdkHeader().split(" ")).toEqual([
+      expect.stringMatching(/^assistant-cloud\//),
+      "@scope/ok/1.0.0",
+    ]);
+  });
+
   it("sends each registered SDK identity once in registration order", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/cloud/src/tests/AssistantCloudAPI.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAPI.test.ts
@@ -45,12 +45,46 @@ describe("AssistantCloudAPI", () => {
       Authorization: "Bearer test-key",
       "Aui-User-Id": "u-1",
       "Aui-Workspace-Id": "w-1",
+      "Aui-Sdk": expect.stringMatching(/^assistant-cloud\//),
       "Content-Type": "application/json",
       "X-Test": "1",
     });
 
     expect(init.method).toBe("POST");
     expect(init.body).toBe(JSON.stringify({ hello: "world" }));
+  });
+
+  it("sends each registered SDK identity once in registration order", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: vi.fn().mockResolvedValue({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new AssistantCloudAPI({
+      apiKey: "test-key",
+      userId: "u-1",
+      workspaceId: "w-1",
+    });
+
+    api.registerSdk({ name: " @assistant-ui/core ", version: " 0.3.18 " });
+    api.registerSdk({ name: "@assistant-ui/core", version: "0.3.18" });
+    api.registerSdk({ name: "@assistant-ui/ai-sdk", version: "0.0.5" });
+    api.registerSdk({ name: " ", version: "0.0.5" });
+    api.registerSdk({ name: "@assistant-ui/cloud-ai-sdk", version: " " });
+
+    await api.makeRawRequest("/threads", {
+      headers: { "Aui-Sdk": "overridden" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(init.headers).toMatchObject({ "Aui-Sdk": api.sdkHeader() });
+    expect(api.sdkHeader().split(" ")).toEqual([
+      expect.stringMatching(/^assistant-cloud\//),
+      "@assistant-ui/core/0.3.18",
+      "@assistant-ui/ai-sdk/0.0.5",
+    ]);
   });
 
   it("uses custom baseUrl when provided with apiKey config", async () => {

--- a/packages/cloud/src/version.ts
+++ b/packages/cloud/src/version.ts
@@ -1,0 +1,4 @@
+export const ASSISTANT_CLOUD_VERSION: string =
+  typeof __AUI_PACKAGE_VERSION__ === "string"
+    ? __AUI_PACKAGE_VERSION__
+    : "0.0.0";

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import type { AssistantCloud } from "assistant-cloud";
 import { createCloudThreadListAdapter } from "./createCloudThreadListAdapter";
+import { CORE_SDK } from "./sdkIdentity";
 
 vi.mock("@assistant-ui/store", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@assistant-ui/store")>()),
@@ -30,6 +31,7 @@ const makeCloud = () =>
       get: vi.fn(),
     },
     runs: { stream: vi.fn(async () => new ReadableStream()) },
+    registerSdk: vi.fn(),
   }) as unknown as AssistantCloud;
 
 describe("createCloudThreadListAdapter", () => {
@@ -81,6 +83,25 @@ describe("createCloudThreadListAdapter", () => {
 
     expect(adapter.unstable_useAdapters).toBeTypeOf("function");
     expect(adapter.unstable_Provider).toBeUndefined();
+  });
+
+  it("registers core and the calling integration identities", () => {
+    const cloud = makeCloud();
+    const sdk = { name: "@assistant-ui/ai-sdk", version: "0.0.5" };
+
+    createCloudThreadListAdapter({ cloud, sdk });
+
+    expect(cloud.registerSdk).toHaveBeenNthCalledWith(1, CORE_SDK);
+    expect(cloud.registerSdk).toHaveBeenNthCalledWith(2, sdk);
+  });
+
+  it("registers only core without a calling integration identity", () => {
+    const cloud = makeCloud();
+
+    createCloudThreadListAdapter({ cloud });
+
+    expect(cloud.registerSdk).toHaveBeenCalledOnce();
+    expect(cloud.registerSdk).toHaveBeenCalledWith(CORE_SDK);
   });
 
   it("constructs stable history and attachment adapters when the hook runs", () => {

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -1,7 +1,7 @@
 declare const process: { env: Record<string, string | undefined> };
 
 import { type RefObject, useMemo, useState } from "react";
-import { AssistantCloud } from "assistant-cloud";
+import { AssistantCloud, type SdkIdentity } from "assistant-cloud";
 import type {
   RemoteThreadListAdapter,
   RuntimeAdapters,
@@ -10,6 +10,7 @@ import { InMemoryThreadListAdapter } from "../../../runtimes/remote-thread-list/
 import { useAssistantCloudThreadHistoryAdapter } from "./AssistantCloudThreadHistoryAdapter";
 import { CloudFileAttachmentAdapter } from "./CloudFileAttachmentAdapter";
 import { isRecord } from "../../../utils/json/is-json";
+import { CORE_SDK } from "./sdkIdentity";
 
 type ThreadData = {
   externalId: string | undefined;
@@ -17,6 +18,7 @@ type ThreadData = {
 
 export type CloudThreadListAdapterOptions = {
   cloud?: AssistantCloud | undefined;
+  sdk?: SdkIdentity | undefined;
 
   create?: (() => Promise<ThreadData>) | undefined;
   delete?: ((threadId: string) => Promise<void>) | undefined;
@@ -115,6 +117,10 @@ export const createCloudThreadListAdapter = (
     };
     return inMemory;
   }
+
+  cloud.registerSdk?.(CORE_SDK);
+  const sdk = getOptions().sdk;
+  if (sdk) cloud.registerSdk?.(sdk);
 
   return {
     list: async ({ after } = {}) => {

--- a/packages/core/src/react/runtimes/cloud/sdkIdentity.ts
+++ b/packages/core/src/react/runtimes/cloud/sdkIdentity.ts
@@ -1,0 +1,9 @@
+import type { SdkIdentity } from "assistant-cloud";
+
+export const CORE_SDK: SdkIdentity = {
+  name: "@assistant-ui/core",
+  version:
+    typeof __AUI_PACKAGE_VERSION__ === "string"
+      ? __AUI_PACKAGE_VERSION__
+      : "0.0.0",
+};

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
@@ -36,9 +36,11 @@ describe("useCloudThreadListAdapter", () => {
     const cloudDeleteA = vi.fn(async () => {});
     const cloudDeleteB = vi.fn(async () => {});
     const cloudA = {
+      registerSdk: vi.fn(),
       threads: { delete: cloudDeleteA },
     } as unknown as AssistantCloud;
     const cloudB = {
+      registerSdk: vi.fn(),
       threads: { delete: cloudDeleteB },
     } as unknown as AssistantCloud;
     const committed: { current: RemoteThreadListAdapter | null } = {
@@ -117,7 +119,10 @@ describe("useCloudThreadListAdapter", () => {
       .fn()
       .mockResolvedValueOnce({ threads: activeThreads })
       .mockResolvedValueOnce({ threads: archivedThreads });
-    const cloud = { threads: { list } } as unknown as AssistantCloud;
+    const cloud = {
+      registerSdk: vi.fn(),
+      threads: { list },
+    } as unknown as AssistantCloud;
     const { result } = renderHook(() => useCloudThreadListAdapter({ cloud }));
 
     const page = await result.current.list();
@@ -149,7 +154,10 @@ describe("useCloudThreadListAdapter", () => {
       .mockResolvedValueOnce({ threads: firstPage })
       .mockResolvedValueOnce({ threads: [] })
       .mockResolvedValueOnce({ threads: secondPage });
-    const cloud = { threads: { list } } as unknown as AssistantCloud;
+    const cloud = {
+      registerSdk: vi.fn(),
+      threads: { list },
+    } as unknown as AssistantCloud;
     const { result } = renderHook(() => useCloudThreadListAdapter({ cloud }));
 
     const first = await result.current.list();
@@ -186,7 +194,10 @@ describe("useCloudThreadListAdapter", () => {
       .mockResolvedValueOnce({ threads: archivedPage1 })
       .mockResolvedValueOnce({ threads: activePage2 })
       .mockResolvedValueOnce({ threads: archivedPage2 });
-    const cloud = { threads: { list } } as unknown as AssistantCloud;
+    const cloud = {
+      registerSdk: vi.fn(),
+      threads: { list },
+    } as unknown as AssistantCloud;
     const { result } = renderHook(() => useCloudThreadListAdapter({ cloud }));
 
     const page1 = await result.current.list();
@@ -213,7 +224,10 @@ describe("useCloudThreadListAdapter", () => {
       .fn()
       .mockResolvedValueOnce({ threads: activeThreads })
       .mockResolvedValueOnce({ threads: [] });
-    const cloud = { threads: { list } } as unknown as AssistantCloud;
+    const cloud = {
+      registerSdk: vi.fn(),
+      threads: { list },
+    } as unknown as AssistantCloud;
     const { result } = renderHook(() => useCloudThreadListAdapter({ cloud }));
 
     const page = await result.current.list({ after: "thread-20" });

--- a/packages/react-google-adk/src/sdkIdentity.ts
+++ b/packages/react-google-adk/src/sdkIdentity.ts
@@ -1,0 +1,9 @@
+import type { SdkIdentity } from "assistant-cloud";
+
+export const ADK_SDK: SdkIdentity = {
+  name: "@assistant-ui/react-google-adk",
+  version:
+    typeof __AUI_PACKAGE_VERSION__ === "string"
+      ? __AUI_PACKAGE_VERSION__
+      : "0.0.0",
+};

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -57,6 +57,7 @@ import {
   toAdkToolConfirmationReply,
 } from "./adkToolApproval";
 import { adkExtras } from "./adkExtras";
+import { ADK_SDK } from "./sdkIdentity";
 
 export type UseAdkRuntimeOptions = ExternalStoreSharedOptions & {
   stream: AdkStreamCallback;
@@ -504,6 +505,7 @@ export const useAdkRuntime = ({
 }: UseAdkRuntimeOptions) => {
   const aui = useAui();
   const cloudAdapter = useCloudThreadListAdapter({
+    sdk: ADK_SDK,
     cloud,
     create: createCloudThreadListAdapterCreateFallback(
       create,

--- a/packages/react-langchain/src/sdkIdentity.ts
+++ b/packages/react-langchain/src/sdkIdentity.ts
@@ -1,0 +1,9 @@
+import type { SdkIdentity } from "assistant-cloud";
+
+export const LANGCHAIN_SDK: SdkIdentity = {
+  name: "@assistant-ui/react-langchain",
+  version:
+    typeof __AUI_PACKAGE_VERSION__ === "string"
+      ? __AUI_PACKAGE_VERSION__
+      : "0.0.0",
+};

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -47,6 +47,7 @@ import { foldUIUpdates, mergeUIMessages } from "./uiMessages";
 import { langChainExtras } from "./runtimeExtras";
 import { resolveForkCheckpoint } from "./resolveForkCheckpoint";
 import { useLangChainStreamingTiming } from "./streamingTiming";
+import { LANGCHAIN_SDK } from "./sdkIdentity";
 
 const UI_CUSTOM_CHANNELS: readonly Channel[] = ["custom"];
 
@@ -631,6 +632,7 @@ export const useStreamRuntime = (rawOptions: UseStreamRuntimeOptions) => {
 
   const aui = useAui();
   const cloudAdapter = useCloudThreadListAdapter({
+    sdk: LANGCHAIN_SDK,
     cloud,
     create: createCloudThreadListAdapterCreateFallback(
       create,

--- a/packages/react-langgraph/src/sdkIdentity.ts
+++ b/packages/react-langgraph/src/sdkIdentity.ts
@@ -1,0 +1,9 @@
+import type { SdkIdentity } from "assistant-cloud";
+
+export const LANGGRAPH_SDK: SdkIdentity = {
+  name: "@assistant-ui/react-langgraph",
+  version:
+    typeof __AUI_PACKAGE_VERSION__ === "string"
+      ? __AUI_PACKAGE_VERSION__
+      : "0.0.0",
+};

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -61,6 +61,7 @@ import {
   hasToolResult,
   truncateLangChainMessages,
 } from "./messageHelpers";
+import { LANGGRAPH_SDK } from "./sdkIdentity";
 
 const EMPTY_QUEUE_ITEMS: readonly QueueItemState[] = Object.freeze([]);
 const subscribeNoop = () => () => {};
@@ -884,6 +885,7 @@ export const useLangGraphRuntime = ({
 }: UseLangGraphRuntimeOptions) => {
   const aui = useAui();
   const cloudAdapter = useCloudThreadListAdapter({
+    sdk: LANGGRAPH_SDK,
     cloud,
     create: createCloudThreadListAdapterCreateFallback(
       create,

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -86,6 +86,7 @@ if (cjsEntries.length > 0) {
     entry: cjsEntries.map(({ key }) =>
       key === "." ? "src/index.ts" : `src/${key.slice(2)}.ts`,
     ),
+    define: { __AUI_PACKAGE_VERSION__: JSON.stringify(pkg.version) },
     format: "cjs",
     platform: "node",
     dts: isDev ? false : { sourcemap: true },
@@ -105,6 +106,7 @@ if (cjsEntries.length > 0) {
       "!src/**/__tests__/**",
       "!src/**/*.test.{ts,tsx}",
     ],
+    define: { __AUI_PACKAGE_VERSION__: JSON.stringify(pkg.version) },
     ...(remapReactToShim
       ? {
           outputOptions: (options) => ({

--- a/packages/x-buildutils/ts/base.json
+++ b/packages/x-buildutils/ts/base.json
@@ -13,7 +13,7 @@
       "${configDir}/../../../node_modules/@assistant-ui/x-buildutils/types",
       "${configDir}/types"
     ],
-    "types": ["browser-process"],
+    "types": ["browser-process", "aui-build"],
     "moduleResolution": "bundler",
     "verbatimModuleSyntax": true,
     "erasableSyntaxOnly": true,

--- a/packages/x-buildutils/types/aui-build/index.d.ts
+++ b/packages/x-buildutils/types/aui-build/index.d.ts
@@ -1,0 +1,1 @@
+declare const __AUI_PACKAGE_VERSION__: string | undefined;


### PR DESCRIPTION
## Problem

the cloud cannot tell which SDK packages and versions talk to a project. no request carries a package identity, the `release` telemetry field is the customer's own app release, and package versions are not available at runtime anywhere in the monorepo, so questions like "does any paid project still use `@assistant-ui/cloud-ai-sdk`" can only be answered from npm downloads and code search.

## Root cause

`assistant-cloud` never identified itself or the integration that drives it on the wire, and `aui-build` never exposed the version of the package it builds.

## Change

`aui-build` defines `__AUI_PACKAGE_VERSION__` from the built package's version in both tsdown builds and ships the ambient declaration through the shared tsconfig base; packages read it through a `typeof` guard with a `"0.0.0"` fallback, so vitest and unbundled runs keep working. `assistant-cloud` sends `Aui-Sdk` on every request through `makeRawRequest` and on the `headers` callback of `__internal_getAssistantOptions`: the client's own token first (`assistant-cloud/0.2.0`), then every identity registered through the new `AssistantCloud.registerSdk({ name, version })` (an insertion ordered set keyed by name and version, trimmed, empties ignored). the two anonymous token bootstrap fetches are unchanged. `@assistant-ui/core` registers itself in `createCloudThreadListAdapter` and forwards the new `CloudThreadListAdapterOptions.sdk` from the calling integration, through optional calls so an older `assistant-cloud` peer yields no token instead of throwing; `@assistant-ui/ai-sdk` passes its identity from `useChatRuntime` and `AISDKThreads`; `@assistant-ui/cloud-ai-sdk` registers in `useResolvedCloud`. the server side that records the header lives in assistant-cloud (`sdk_clients`, listed on Settings › Telemetry).

## Verification

- `pnpm test` in packages/cloud: 217 pass under ai 7 and under ai 6, peer v6 type check passes; new cases cover the header on a request and on the stream options, registration order and dedupe, ignored empty identities, and the facade forwarding
- `pnpm test src/react/runtimes/cloud` in packages/core: 45 pass, including registration of core and of the given sdk, and core only without one
- `pnpm test` in packages/ai-sdk: 275 pass; `pnpm test` in packages/cloud-ai-sdk: 111 pass under both majors with the resolved cloud registration asserted
- built dist confirms the define: `packages/cloud/dist/version.js` holds `"0.2.0"`, core's identity holds `"0.3.18"`
- oxlint and oxfmt clean, `check-changeset-semver` and `check-workspace-ranges` clean, `pnpm size:update` unchanged, `pnpm api-surface` regenerated (the `sdk` option and the new members appear in every snapshot that re-exports core types)
- not exercised: a request against a deployed cloud; the header is additive and the API's `cors()` reflects requested headers, so a server without the change ignores it

## Public surface

- `assistant-cloud`: new type `SdkIdentity`, new method `AssistantCloud.registerSdk`, new `AssistantCloudAPI.registerSdk` and `sdkHeader`, the `Aui-Sdk` request header; README sentence under Building an integration
- `@assistant-ui/core`: `CloudThreadListAdapterOptions.sdk?: SdkIdentity`
- `@assistant-ui/ai-sdk`, `@assistant-ui/cloud-ai-sdk`: no export change
- `@assistant-ui/x-buildutils`: `__AUI_PACKAGE_VERSION__` define and its ambient declaration (private package); AGENTS.md build paragraph documents the guard
- changesets: `assistant-cloud` patch; `@assistant-ui/core`, `@assistant-ui/ai-sdk`, `@assistant-ui/cloud-ai-sdk` patch


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.wJ005FFYWaNwNG3JZQkNabr_uNbv3GHsP2VLuYXRiz7yeyc-eV9SC-l4yHk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->