### PR TITLE
fix(core): report the observed error and first token time of ai-sdk/v6 runs

### DIFF
--- a/.changeset/cloud-history-observed-run.md
+++ b/.changeset/cloud-history-observed-run.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/ai-sdk": patch
+---
+
+fix: report the error, error code and first token time of a run persisted in the `ai-sdk/v6` format; the runtime hands the cloud history adapter the thread message it persisted, whose status and timing complete a report the stored message cannot carry

--- a/.changeset/cloud-history-observed-run.md
+++ b/.changeset/cloud-history-observed-run.md
@@ -3,4 +3,4 @@
 "@assistant-ui/ai-sdk": patch
 ---
 
-fix: report the error, error code and first token time of a run persisted in the `ai-sdk/v6` format; the runtime hands the cloud history adapter the thread message it persisted, whose status and timing complete a report the stored message cannot carry
+fix: report the error, error code and first token time of a run persisted in the `ai-sdk/v6` format; the runtime hands the cloud history adapter the thread message it persisted, whose status and timing complete a report the stored message cannot carry. the failed message's status error is now the `AssistantError` shape (`{ code, message }`, the code being the AI SDK error's `code` or its name) instead of the message string, and `first_token_ms` reads `firstTokenTime` as the duration the runtime records instead of subtracting the stream start, which also repairs the `aui/v0` path

--- a/.changeset/devtools-first-token-duration.md
+++ b/.changeset/devtools-first-token-duration.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+fix: read the first token time as the duration the runtime records instead of subtracting the stream start, which always clamped it to zero

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -1056,6 +1056,7 @@ type GenericThreadHistoryAdapter<TMessage> = {
       start_ms: number;
       end_ms: number;
     }[];
+    message?: ThreadMessage;
   }): void;
 };
 

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -2190,6 +2190,7 @@ type GenericThreadHistoryAdapter<TMessage> = {
       start_ms: number;
       end_ms: number;
     }[];
+    message?: ThreadMessage;
   }): void;
 };
 

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -802,6 +802,7 @@ type GenericThreadHistoryAdapter<TMessage> = {
       start_ms: number;
       end_ms: number;
     }[];
+    message?: ThreadMessage;
   }): void;
 };
 

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -579,6 +579,7 @@ type GenericThreadHistoryAdapter<TMessage> = {
       start_ms: number;
       end_ms: number;
     }[];
+    message?: ThreadMessage;
   }): void;
 };
 

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1056,6 +1056,7 @@ type GenericThreadHistoryAdapter<TMessage> = {
       start_ms: number;
       end_ms: number;
     }[];
+    message?: ThreadMessage;
   }): void;
 };
 

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -838,6 +838,7 @@ type GenericThreadHistoryAdapter<TMessage> = {
       start_ms: number;
       end_ms: number;
     }[];
+    message?: ThreadMessage;
   }): void;
 };
 

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1335,6 +1335,7 @@ type GenericThreadHistoryAdapter<TMessage> = {
       start_ms: number;
       end_ms: number;
     }[];
+    message?: ThreadMessage;
   }): void;
 };
 

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -1767,6 +1767,7 @@ type GenericThreadHistoryAdapter<TMessage> = {
       start_ms: number;
       end_ms: number;
     }[];
+    message?: ThreadMessage;
   }): void;
 };
 

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -964,6 +964,7 @@ type GenericThreadHistoryAdapter<TMessage> = {
       start_ms: number;
       end_ms: number;
     }[];
+    message?: ThreadMessage;
   }): void;
 };
 

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -983,6 +983,7 @@ type GenericThreadHistoryAdapter<TMessage> = {
       start_ms: number;
       end_ms: number;
     }[];
+    message?: ThreadMessage;
   }): void;
 };
 

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -1626,6 +1626,7 @@ type GenericThreadHistoryAdapter<TMessage> = {
       start_ms: number;
       end_ms: number;
     }[];
+    message?: ThreadMessage;
   }): void;
 };
 

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2483,6 +2483,7 @@ type GenericThreadHistoryAdapter<TMessage> = {
       start_ms: number;
       end_ms: number;
     }[];
+    message?: ThreadMessage;
   }): void;
 };
 

--- a/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
@@ -374,6 +374,7 @@ The `useChatRuntime` hook captures full run telemetry including timing data. Thi
 
 **Automatically captured:**
 - `status`: `"completed"`, `"incomplete"` or `"error"`
+- `outcome_type`: `"aborted"` for a run the user cancelled; `"length"` and `"content_filter"` need the route configuration below
 - `message_id`: the persisted assistant message the run produced
 - `duration_ms`: total run duration
 - `steps`: per-step timing, usage, and tool calls; the per-step `finish_reason` is reported by `useCloudChat` only, because the assistant-ui step metadata carries no finish reason
@@ -387,7 +388,7 @@ No message content is sent apart from `output_text`, which is the assistant outp
 **Requires route configuration:**
 - `model_id`: the model used
 - `provider`: the provider that served the model (`model.provider` below); server spans carry it as well
-- `outcome_type` (`"length"`, `"content_filter"`): read from `finishReason` in the message metadata (`finishReason: part.finishReason` below); `"aborted"` and `"disconnected"` are reported by `useCloudChat` only
+- `outcome_type` (`"length"`, `"content_filter"`): read from `finishReason` in the message metadata (`finishReason: part.finishReason` below); `"disconnected"` is reported by `useCloudChat` only
 - `input_tokens` / `output_tokens`: token usage statistics
 
 **Reported by the runtime itself:** the `"error"` status with `error` and `error_code`, and `first_token_ms`. The runtime hands the history adapter the thread message it persisted, and that message's error and first token time complete the report, so neither needs route configuration.

--- a/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
@@ -387,10 +387,10 @@ No message content is sent apart from `output_text`, which is the assistant outp
 **Requires route configuration:**
 - `model_id`: the model used
 - `provider`: the provider that served the model (`model.provider` below); server spans carry it as well
-- `outcome_type` (`"length"`, `"content_filter"`) and the `"error"` status: read from `finishReason` in the message metadata (`finishReason: part.finishReason` below); `"aborted"` and `"disconnected"` are reported by `useCloudChat` only
+- `outcome_type` (`"length"`, `"content_filter"`): read from `finishReason` in the message metadata (`finishReason: part.finishReason` below); `"aborted"` and `"disconnected"` are reported by `useCloudChat` only
 - `input_tokens` / `output_tokens`: token usage statistics
 
-**Not reported by `useChatRuntime` yet:** `first_token_ms` ([#7112](https://github.com/assistant-ui/assistant-ui/issues/7112)) and `error` with `error_code` ([#7116](https://github.com/assistant-ui/assistant-ui/issues/7116)); the AI SDK message the runtime persists carries neither the timing nor the error. `useCloudChat` reports all three.
+**Reported by the runtime itself:** the `"error"` status with `error` and `error_code`, and `first_token_ms`. The runtime hands the history adapter the thread message it persisted, and that message's error and first token time complete the report, so neither needs route configuration.
 
 To capture model and usage data, add the `messageMetadata` callback to your AI SDK route:
 

--- a/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
@@ -373,7 +373,7 @@ export function Chat() {
 The `useChatRuntime` hook captures full run telemetry including timing data. This integrates with the assistant-ui runtime to provide:
 
 **Automatically captured:**
-- `status`: `"completed"` or `"incomplete"`
+- `status`: `"completed"`, `"incomplete"` or `"error"`
 - `message_id`: the persisted assistant message the run produced
 - `duration_ms`: total run duration
 - `steps`: per-step timing, usage, and tool calls; the per-step `finish_reason` is reported by `useCloudChat` only, because the assistant-ui step metadata carries no finish reason

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -1505,11 +1505,25 @@ describe("useAISDKRuntime", () => {
     ).toMatchObject({
       type: "incomplete",
       reason: "error",
-      error: {
-        message: "rate limited",
-        name: "AI_APICallError",
-        code: "rate_limited",
-      },
+      error: { code: "rate_limited", message: "rate limited" },
+    });
+  });
+
+  it("uses the error name as the code when the error carries none", () => {
+    const chat = createChatHelpers([
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      { id: "a1", role: "assistant", parts: [{ type: "text", text: "" }] },
+    ]);
+    chat.error = Object.assign(new Error("upstream failed"), {
+      name: "AI_APICallError",
+    });
+
+    const { result } = renderHook(() => useAISDKRuntime(chat));
+
+    expect(
+      result.current.thread.getState().messages.at(-1)?.status,
+    ).toMatchObject({
+      error: { code: "AI_APICallError", message: "upstream failed" },
     });
   });
 });

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -1487,4 +1487,29 @@ describe("useAISDKRuntime", () => {
       error: chat.error,
     });
   });
+
+  it("keeps the error name and code on the failed message status", () => {
+    const chat = createChatHelpers([
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      { id: "a1", role: "assistant", parts: [{ type: "text", text: "" }] },
+    ]);
+    chat.error = Object.assign(new Error("rate limited"), {
+      name: "AI_APICallError",
+      code: "rate_limited",
+    });
+
+    const { result } = renderHook(() => useAISDKRuntime(chat));
+
+    expect(
+      result.current.thread.getState().messages.at(-1)?.status,
+    ).toMatchObject({
+      type: "incomplete",
+      reason: "error",
+      error: {
+        message: "rate limited",
+        name: "AI_APICallError",
+        code: "rate_limited",
+      },
+    });
+  });
 });

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -47,6 +47,7 @@ import {
   MessageRepository,
 } from "@assistant-ui/core/internal";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
+import type { AssistantError } from "@assistant-ui/core";
 import { sliceMessagesUntil } from "../utils/sliceMessagesUntil";
 import { toCreateMessage } from "../converters/toCreateMessage";
 import { vercelAttachmentAdapter } from "../adapters/vercelAttachmentAdapter";
@@ -219,12 +220,16 @@ const useGeneratedSuggestions = (
 
 const NO_CANCELLED_MESSAGE_IDS: ReadonlySet<string> = new Set();
 
-const describeChatError = (error: Error): ReadonlyJSONObject => {
+const toChatError = (error: Error): AssistantError => {
   const code = (error as { code?: unknown }).code;
   return {
+    code:
+      typeof code === "string"
+        ? code
+        : error.name !== "Error"
+          ? error.name
+          : "unknown",
     message: error.message,
-    ...(error.name !== "Error" ? { name: error.name } : undefined),
-    ...(typeof code === "string" ? { code } : undefined),
   };
 };
 
@@ -325,7 +330,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         mcpAppMetadataCache: mcpAppMetadataCacheRef.current,
         ...(optimisticMessageId && { optimisticMessageId }),
         ...(chatHelpers.error && {
-          error: describeChatError(chatHelpers.error),
+          error: toChatError(chatHelpers.error),
         }),
         ...(cancelledMessageIds.size > 0 && { cancelledMessageIds }),
       }),

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -219,6 +219,15 @@ const useGeneratedSuggestions = (
 
 const NO_CANCELLED_MESSAGE_IDS: ReadonlySet<string> = new Set();
 
+const describeChatError = (error: Error): ReadonlyJSONObject => {
+  const code = (error as { code?: unknown }).code;
+  return {
+    message: error.message,
+    ...(error.name !== "Error" ? { name: error.name } : undefined),
+    ...(typeof code === "string" ? { code } : undefined),
+  };
+};
+
 export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   chatHelpers: ReturnType<typeof useChat<UI_MESSAGE>>,
   adapter: AISDKRuntimeAdapter<UI_MESSAGE> = {},
@@ -315,7 +324,9 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         toolLastInputCache: toolLastInputCacheRef.current,
         mcpAppMetadataCache: mcpAppMetadataCacheRef.current,
         ...(optimisticMessageId && { optimisticMessageId }),
-        ...(chatHelpers.error && { error: chatHelpers.error.message }),
+        ...(chatHelpers.error && {
+          error: describeChatError(chatHelpers.error),
+        }),
         ...(cancelledMessageIds.size > 0 && { cancelledMessageIds }),
       }),
       [

--- a/packages/ai-sdk/src/runtime/useExternalHistory.test.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.test.ts
@@ -780,6 +780,12 @@ describe("useExternalHistory persistence", () => {
       ],
       expect.any(Object),
     );
+    expect(reportTelemetry.mock.calls[0]![1]).toMatchObject({
+      message: expect.objectContaining({
+        id: "assistant-a",
+        status: { type: "complete", reason: "stop" },
+      }),
+    });
   });
 
   it("restores deferred telemetry for reloaded paused messages", async () => {

--- a/packages/ai-sdk/src/runtime/useExternalHistory.test.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.test.ts
@@ -788,6 +788,29 @@ describe("useExternalHistory persistence", () => {
     });
   });
 
+  it("reports a run that failed before any assistant message", async () => {
+    const { append, reportTelemetry, runCycle, flush } =
+      createPersistenceHarness(true);
+    const failed = createAssistantMessage(
+      {
+        type: "incomplete",
+        reason: "error",
+        error: { code: "AI_APICallError", message: "upstream failed" },
+      },
+      [],
+    );
+
+    await runCycle([failed]);
+    await flush();
+
+    expect(append).not.toHaveBeenCalled();
+    expect(reportTelemetry).toHaveBeenCalledTimes(1);
+    expect(reportTelemetry).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({ message: failed }),
+    );
+  });
+
   it("restores deferred telemetry for reloaded paused messages", async () => {
     const { append, update, reportTelemetry, load, runCycle, flush } =
       createPersistenceHarness(true, {

--- a/packages/ai-sdk/src/runtime/useExternalHistory.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.ts
@@ -371,7 +371,10 @@ export const useExternalHistory = <TMessage>(
 
             if (deferredTelemetryIds.current.has(message.id) && isTerminal) {
               deferredTelemetryIds.current.delete(message.id);
-              adapter.reportTelemetry?.(batchItems, telemetryOptions);
+              adapter.reportTelemetry?.(batchItems, {
+                ...telemetryOptions,
+                message,
+              });
             }
           }
         })

--- a/packages/core/src/adapters/thread-history.ts
+++ b/packages/core/src/adapters/thread-history.ts
@@ -7,6 +7,7 @@ import type {
   ExportedMessageRepositoryItem,
 } from "../runtime/utils/message-repository";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
+import type { ThreadMessage } from "../types";
 
 export interface MessageStorageEntry<TPayload> {
   id: string;
@@ -52,6 +53,8 @@ export type GenericThreadHistoryAdapter<TMessage> = {
     options?: {
       durationMs?: number;
       stepTimestamps?: { start_ms: number; end_ms: number }[];
+      /** The thread message the items were persisted from; its status and timing complete a report the stored format cannot carry. */
+      message?: ThreadMessage;
     },
   ): void;
 };

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -804,6 +804,66 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
   });
 
+  it("reads the error and timing of an ai-sdk/v6 run from the thread message", () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const cloud = makeCloud();
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter({ current: cloud }),
+    );
+    const formatted = result.current.withFormat({
+      format: "ai-sdk/v6",
+      encode: ({ message }) => message,
+      decode: ({ parent_id, content }) => ({
+        parentId: parent_id,
+        message: content as { id: string },
+      }),
+      getId: (message: { id: string }) => message.id,
+    });
+    const base = makeAssistantMessage("assistant-1");
+    const message: ThreadAssistantMessage = {
+      ...base,
+      status: {
+        type: "incomplete",
+        reason: "error",
+        error: Object.assign(new Error("model unavailable"), {
+          code: "model_unavailable",
+        }),
+      },
+      metadata: {
+        ...base.metadata,
+        timing: {
+          streamStartTime: 100,
+          firstTokenTime: 340,
+          totalChunks: 3,
+          toolCallCount: 0,
+        },
+      },
+    };
+
+    formatted.reportTelemetry(
+      [
+        {
+          parentId: null,
+          message: {
+            id: "message-1",
+            role: "assistant",
+            parts: [{ type: "text", text: "partial" }],
+          },
+        },
+      ],
+      { message },
+    );
+
+    expect(cloud.runs.report).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "error",
+        error: "model unavailable",
+        error_code: "model_unavailable",
+        first_token_ms: 240,
+      }),
+    );
+  });
+
   it("reports the model ID carried by aui/v0 step metadata", () => {
     mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -864,6 +864,43 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
   });
 
+  it("reports a run that failed before any assistant message was stored", () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const cloud = makeCloud();
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter({ current: cloud }),
+    );
+    const formatted = result.current.withFormat({
+      format: "ai-sdk/v6",
+      encode: ({ message }) => message,
+      decode: ({ parent_id, content }) => ({
+        parentId: parent_id,
+        message: content as { id: string },
+      }),
+      getId: (message: { id: string }) => message.id,
+    });
+    const message: ThreadAssistantMessage = {
+      ...makeAssistantMessage("assistant-1"),
+      content: [],
+      status: {
+        type: "incomplete",
+        reason: "error",
+        error: { code: "AI_APICallError", message: "upstream failed" },
+      },
+    };
+
+    formatted.reportTelemetry([], { message, durationMs: 120 });
+
+    expect(cloud.runs.report).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "error",
+        error: "upstream failed",
+        error_code: "AI_APICallError",
+        duration_ms: 120,
+      }),
+    );
+  });
+
   it("reports the model ID carried by aui/v0 step metadata", () => {
     mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -512,7 +512,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
         },
         timing: {
           streamStartTime: 100,
-          firstTokenTime: 155.6,
+          firstTokenTime: 55.6,
           totalChunks: 1,
           toolCallCount: 0,
         },
@@ -833,7 +833,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
         ...base.metadata,
         timing: {
           streamStartTime: 100,
-          firstTokenTime: 340,
+          firstTokenTime: 240,
           totalChunks: 3,
           toolCallCount: 0,
         },

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -7,6 +7,7 @@ import type {
   MessageFormatRepository,
 } from "../../../adapters/thread-history";
 import type { ExportedMessageRepositoryItem } from "../../../runtime/utils/message-repository";
+import type { ThreadMessage } from "../../../types";
 import {
   type AssistantCloud,
   type AssistantCloudEvent,
@@ -227,6 +228,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
         options?: {
           durationMs?: number;
           stepTimestamps?: StepTimestamp[];
+          message?: ThreadMessage;
         },
       ) {
         const encodedRunMessages = items.map((item) =>
@@ -237,7 +239,12 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
           encodedRunMessages,
           options,
           resolvePinned(),
-          extractLastRunMessageInfo(items, formatAdapter),
+          mergeRunMessageInfo(
+            extractLastRunMessageInfo(items, formatAdapter),
+            options?.message
+              ? extractRunMessageInfo(options.message, "aui/v0")
+              : undefined,
+          ),
         );
       },
       async load(): Promise<MessageFormatRepository<TMessage>> {
@@ -441,6 +448,15 @@ function extractLastRunMessageInfo<
     if (info) return info;
   }
   return undefined;
+}
+
+function mergeRunMessageInfo(
+  stored: RunMessageInfo | undefined,
+  observed: RunMessageInfo | undefined,
+): RunMessageInfo | undefined {
+  if (!observed) return stored;
+  const { localMessageId: _observedId, ...outcome } = observed;
+  return { ...stored, ...outcome };
 }
 
 function extractRunMessageInfo(

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -335,7 +335,11 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     const remoteId = item.getState().remoteId;
     if (!remoteId) return;
 
-    const extracted = extractRunTelemetry(format, runMessages);
+    const extracted =
+      extractRunTelemetry(format, runMessages) ??
+      (messageInfo?.status !== undefined
+        ? { status: "incomplete" as const }
+        : undefined);
     if (!extracted) return;
 
     this._sendReport(

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -470,14 +470,10 @@ function extractRunMessageInfo(
   const metadata = isRecord(message.metadata) ? message.metadata : undefined;
   const custom = isRecord(metadata?.custom) ? metadata.custom : undefined;
   const timing = isRecord(metadata?.timing) ? metadata.timing : undefined;
-  const streamStartTime = timing?.streamStartTime;
   const firstTokenTime = timing?.firstTokenTime;
   const firstTokenMs =
-    typeof streamStartTime === "number" &&
-    Number.isFinite(streamStartTime) &&
-    typeof firstTokenTime === "number" &&
-    Number.isFinite(firstTokenTime)
-      ? Math.round(firstTokenTime - streamStartTime)
+    typeof firstTokenTime === "number" && Number.isFinite(firstTokenTime)
+      ? Math.round(firstTokenTime)
       : undefined;
   const finishReason =
     status?.type === "incomplete"

--- a/packages/react-devtools/src/views/message/MessageMetrics.tsx
+++ b/packages/react-devtools/src/views/message/MessageMetrics.tsx
@@ -16,9 +16,8 @@ const inlineStats = (message: MessagePreview): string[] => {
 
   if (timing && !canRenderBar(timing)) {
     const ttft =
-      timing.firstTokenTime !== undefined &&
-      timing.streamStartTime !== undefined
-        ? Math.max(0, timing.firstTokenTime - timing.streamStartTime)
+      timing.firstTokenTime !== undefined
+        ? Math.max(0, timing.firstTokenTime)
         : undefined;
     if (ttft !== undefined) stats.push(`TTFT ${formatMs(ttft)}`);
     if (timing.totalStreamTime !== undefined) {

--- a/packages/react-devtools/src/views/message/TtftBar.test.tsx
+++ b/packages/react-devtools/src/views/message/TtftBar.test.tsx
@@ -1,0 +1,20 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { TtftBar } from "./TtftBar";
+
+describe("TtftBar", () => {
+  it("reads the first token time as a duration from the stream start", () => {
+    const html = renderToStaticMarkup(
+      <TtftBar
+        timing={{
+          streamStartTime: 1_700_000_000_000,
+          firstTokenTime: 150,
+          totalStreamTime: 900,
+        }}
+      />,
+    );
+
+    expect(html).toContain("TTFT 150ms");
+    expect(html).toContain("750ms stream");
+  });
+});

--- a/packages/react-devtools/src/views/message/TtftBar.tsx
+++ b/packages/react-devtools/src/views/message/TtftBar.tsx
@@ -4,7 +4,7 @@ import type { MessageTimingPreview } from "./types";
 /**
  * Splits a model turn into the time-to-first-token segment (dim) and the
  * streaming segment (solid). The only width-bearing timing form: both numbers
- * are measured, not derived. Renders nothing unless all three timestamps exist.
+ * are measured, not derived. Renders nothing unless all three timing values exist.
  */
 export const TtftBar = ({ timing }: { timing: MessageTimingPreview }) => {
   const { streamStartTime, firstTokenTime, totalStreamTime } = timing;
@@ -16,7 +16,7 @@ export const TtftBar = ({ timing }: { timing: MessageTimingPreview }) => {
     return null;
   }
 
-  const ttft = Math.max(0, firstTokenTime - streamStartTime);
+  const ttft = Math.max(0, firstTokenTime);
   const total = Math.max(totalStreamTime, ttft);
   const stream = Math.max(0, total - ttft);
   const ttftPercent = total > 0 ? (ttft / total) * 100 : 0;

--- a/packages/react-devtools/src/views/thread/Transcript.tsx
+++ b/packages/react-devtools/src/views/thread/Transcript.tsx
@@ -169,12 +169,7 @@ const metricSeries = (messages: readonly MessagePreview[]): MetricSeries[] =>
     },
     {
       label: "TTFT",
-      values: collect(messages, (message) =>
-        message.timing?.firstTokenTime !== undefined &&
-        message.timing?.streamStartTime !== undefined
-          ? message.timing.firstTokenTime - message.timing.streamStartTime
-          : undefined,
-      ),
+      values: collect(messages, (message) => message.timing?.firstTokenTime),
       format: (value: number) => `${Math.round(value)}ms`,
     },
     {


### PR DESCRIPTION
## Problem

on the assistant-ui runtime with `useChatRuntime`, a failed run reaches the cloud with `status: "error"` only when the route writes `finishReason` into the message metadata, and never with the error message or code; `first_token_ms` is never reported either. `useCloudChat` reports all three.

closes #7116, closes #7112.

## Root cause

`useExternalHistory` in `@assistant-ui/ai-sdk` reports run telemetry from the AI SDK `UIMessage`s it persists in the `ai-sdk/v6` format, and a `UIMessage` has no status, no error and no timing. the runtime does have them: the aui `ThreadMessage` it built from the chat carries `status: { type: "incomplete", reason: "error", error }` and `metadata.timing`, but the cloud history adapter never saw that message on the formatted path, so `extractRunMessageInfo` only ever read the stored metadata.

## Change

`GenericThreadHistoryAdapter.reportTelemetry` accepts `message`, the thread message the items were persisted from, next to `durationMs` and `stepTimestamps`. `useExternalHistory` passes it with every report. the cloud adapter's formatted `reportTelemetry` reads the observed status, outcome, error, error code and first token time from that message with the same extractor the `aui/v0` path uses and merges them over what the stored format provides, keeping the stored inner message id for the remote id lookup. the runtime also stops flattening the chat error to its message: the failed message's status now carries the `AssistantError` shape (`{ code, message }`, the code being the AI SDK error's `code` or its name), which the error primitive already reads through the message field, so `error_code` is filled. `first_token_ms` was never sent on either format: both producers of `MessageTiming` record `firstTokenTime` relative to the stream start, and the extractor subtracted the absolute `streamStartTime` from it, went negative and dropped it; it now reads the duration as is, which repairs the `aui/v0` path as well, and the three devtools views that made the same subtraction and rendered zero. a request that fails before the stream starts leaves no assistant message to persist, so the report path now falls through with an incomplete status whenever the thread message carries one, and the observed error reaches the cloud for that case too; a cancelled run reports `outcome_type: "aborted"` the same way. the docs page for the assistant-ui runtime on the cloud drops the "not reported yet" note and says the runtime reports these itself.

## Verification

- `pnpm test src/react/runtimes/cloud` in packages/core: 47 pass, including new cases where an `ai-sdk/v6` run reported with an errored thread message carries `status: "error"`, `error`, `error_code` and `first_token_ms`, and where a run with no stored assistant message still reports its error
- `pnpm test` in packages/ai-sdk: 278 pass, with the external history test asserting the thread message rides along with the telemetry call and runtime tests asserting the failed message status carries the error code, or its name when it has none
- `pnpm test` in packages/react-devtools: 126 pass, including a bar rendered from a nonzero stream start
- oxlint and oxfmt clean, `check-changeset-semver` clean, `pnpm size:update` unchanged, `pnpm api-surface` regenerated (the one optional field appears in every snapshot that re-exports the adapter type)
- not exercised: a live run against a deployed cloud; the wire payload is unchanged and the report builder already carried these fields

## Public surface

- `@assistant-ui/core`: `GenericThreadHistoryAdapter.reportTelemetry` options gain `message?: ThreadMessage`; no other export change
- `@assistant-ui/ai-sdk`: the failed message's `status.error` is an `AssistantError` object instead of a string (the error primitive reads both)
- `@assistant-ui/react-devtools`: no export change
- changesets: `@assistant-ui/core` patch, `@assistant-ui/ai-sdk` patch, `@assistant-ui/react-devtools` patch
