### PR TITLE
fix(assistant-stream): strict text append drops after the consumer cancels

### DIFF
--- a/.changeset/stream-strict-append-after-cancel.md
+++ b/.changeset/stream-strict-append-after-cancel.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: strict `TextStreamController.append()` drops deltas instead of throwing after the consumer cancels the stream

--- a/packages/assistant-stream/src/core/modules/text.test.ts
+++ b/packages/assistant-stream/src/core/modules/text.test.ts
@@ -26,16 +26,24 @@ describe("TextStreamController", () => {
 });
 
 describe("TextStreamController after consumer cancel", () => {
-  it("drops appends without throwing", async () => {
+  it("drops appends silently", async () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     const [stream, controller] = createTextStreamController();
     await stream.cancel();
     expect(() => controller.append("late")).not.toThrow();
-    expect(() => controller.append("later")).not.toThrow();
-    expect(error).toHaveBeenCalledOnce();
+    expect(error).not.toHaveBeenCalled();
   });
 
-  it("drops appends on a text part after the reader cancels", async () => {
+  it("drops appends silently with strict: false", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const [stream, controller] = createTextStreamController({ strict: false });
+    await stream.cancel();
+    expect(() => controller.append("late")).not.toThrow();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("drops appends on a text part silently after the reader cancels", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
     let part!: TextStreamController;
     const stream = createAssistantStream((controller) => {
       part = controller.addTextPart();
@@ -45,6 +53,7 @@ describe("TextStreamController after consumer cancel", () => {
     await reader.read();
     await reader.cancel("consumer stopped");
     expect(() => part.append("late")).not.toThrow();
+    expect(error).not.toHaveBeenCalled();
   });
 
   it("closes without throwing", async () => {

--- a/packages/assistant-stream/src/core/modules/text.test.ts
+++ b/packages/assistant-stream/src/core/modules/text.test.ts
@@ -11,7 +11,7 @@ describe("TextStreamController", () => {
     const [stream, controller] = createTextStreamController();
     void stream;
     controller.close();
-    expect(() => controller.append("late")).toThrow();
+    expect(() => controller.append("late")).toThrow(TypeError);
   });
 
   it("drops appends after close with strict: false", () => {
@@ -26,6 +26,27 @@ describe("TextStreamController", () => {
 });
 
 describe("TextStreamController after consumer cancel", () => {
+  it("drops appends without throwing", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const [stream, controller] = createTextStreamController();
+    await stream.cancel();
+    expect(() => controller.append("late")).not.toThrow();
+    expect(() => controller.append("later")).not.toThrow();
+    expect(error).toHaveBeenCalledOnce();
+  });
+
+  it("drops appends on a text part after the reader cancels", async () => {
+    let part!: TextStreamController;
+    const stream = createAssistantStream((controller) => {
+      part = controller.addTextPart();
+      part.append("hello");
+    });
+    const reader = stream.getReader();
+    await reader.read();
+    await reader.cancel("consumer stopped");
+    expect(() => part.append("late")).not.toThrow();
+  });
+
   it("closes without throwing", async () => {
     const [stream, controller] = createTextStreamController();
     await stream.cancel();

--- a/packages/assistant-stream/src/core/modules/text.ts
+++ b/packages/assistant-stream/src/core/modules/text.ts
@@ -36,17 +36,22 @@ class TextStreamControllerImpl implements TextStreamController {
       path: [],
       textDelta,
     };
-    if (this._strict && this._isClosed) {
-      throw new TypeError("Cannot append to a closed TextStreamController");
-    }
-    enqueueIfOpen(this._controller, chunk, (error) => {
-      if (!this._warnedDropped) {
-        this._warnedDropped = true;
-        console.error(`Dropped text delta for closed stream: ${String(error)}`);
+    if (this._isClosed) {
+      if (this._strict) {
+        throw new TypeError("Cannot append to a closed TextStreamController");
       }
-    });
+      enqueueIfOpen(this._controller, chunk, this._warnDroppedAfterClose);
+      return this;
+    }
+    enqueueIfOpen(this._controller, chunk);
     return this;
   }
+
+  private _warnDroppedAfterClose = (error: TypeError) => {
+    if (this._warnedDropped) return;
+    this._warnedDropped = true;
+    console.error(`Dropped text delta for closed stream: ${String(error)}`);
+  };
 
   close() {
     if (this._isClosed) return;

--- a/packages/assistant-stream/src/core/modules/text.ts
+++ b/packages/assistant-stream/src/core/modules/text.ts
@@ -36,9 +36,8 @@ class TextStreamControllerImpl implements TextStreamController {
       path: [],
       textDelta,
     };
-    if (this._strict) {
-      this._controller.enqueue(chunk);
-      return this;
+    if (this._strict && this._isClosed) {
+      throw new TypeError("Cannot append to a closed TextStreamController");
     }
     enqueueIfOpen(this._controller, chunk, (error) => {
       if (!this._warnedDropped) {


### PR DESCRIPTION
## Problem

A producer holding a `TextStreamController` in strict mode (the default) that appends after the consumer cancelled the `ReadableStream` gets an uncaught `TypeError [ERR_INVALID_STATE]: Invalid state: Controller is already closed`.

Repro on main:

```ts
const [stream, controller] = createTextStreamController();
await stream.cancel();
controller.append("late"); // throws ERR_INVALID_STATE
```

Same shape through the public controller: `createAssistantStreamController()`, `addTextPart()`, the reader cancels, the part keeps appending. Inside a `createAssistantStream` callback the runner swallows the error once the stream is cancelled, so the crash reaches only holders driving the controller from their own loop.

## Root cause

`text.ts` `append()` strict branch calls `this._controller.enqueue(chunk)` unguarded, while `close()` and the non-strict branch already go through `enqueueIfOpen` from `controller-guards.ts`.

Two states share that branch today. Append after a producer `close()` is a producer bug and strict throws on purpose (pinned by "throws when appending after close"). Append after a consumer cancel is not a producer bug: every other writer on `AssistantStreamController` already no-ops once the merger is cancelled, and `close()` does since #6316. The controller's own `_isClosed` flag already separates the two, so no new state is needed.

## Change

`append()` branches on `_isClosed` first. After a producer `close()`, strict throws a descriptive `TypeError` and non-strict keeps its warn-once `console.error` drop. Otherwise every append routes through `enqueueIfOpen` with no drop callback, so an append after the consumer cancelled is discarded silently. Net effect per state:

| state | strict before | strict after | non-strict before | non-strict after |
| --- | --- | --- | --- | --- |
| append after producer close | throws (runtime ERR_INVALID_STATE) | throws TypeError with a message | drops, warns once | drops, warns once |
| append after consumer cancel | throws | drops silently | drops, warns once | drops silently |

- The strict-after-close throw now carries its own message instead of relying on the platform error text; the pinned test asserts `TypeError` for both.
- Cancel-side drops are silent in both modes, matching the `createAssistantStream` contract ("failures after an explicit close are logged, while failures after consumer cancellation are discarded") and the other writers (`merger.enqueue`, `merger.addStream`, `closeIfOpen`), which already no-op silently once cancelled. Non-strict moves from warn-once to silent for this case.
- The warn-once callback is a field, so the hot path allocates no per-delta closure.
- `tool-call.ts` shares this controller for `argsText`, so its args stream inherits the same behavior; its strict flag plumbing is a separate PR.

## Verification

```
pnpm -C packages/assistant-stream vitest run src/core/modules/text.test.ts   # 8 passed
pnpm -C packages/assistant-stream vitest run                                # 37 files, 551 passed, 22 skipped, exit 0
pnpm exec tsc -p packages/assistant-stream/tsconfig.json --noEmit           # exit 0
pnpm exec oxlint <changed files>                                             # exit 0
pnpm exec oxfmt --check <changed files>                                     # exit 0
pnpm changesets:check                                                       # exit 0
pnpm size:check                                                             # assistant-stream entries ok, main entry +2 B
```

The three cancel tests (`drops appends silently`, `drops appends silently with strict: false`, `drops appends on a text part silently after the reader cancels`) assert no throw and no `console.error`; the strict ones fail on main with `ERR_INVALID_STATE`. The text-part test goes through `addTextPart`, whose part is owned by the caller and stays open after the callback returns.

## Public surface

- `assistant-stream`: patch changeset. No exports added, removed, or reshaped.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.HkSoyErxJLQlJ-t8rWKsjN_7_B6r67GR0E53usClvXpGVDkivvhWXKig2xA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->