### PR TITLE
fix(assistant-stream): tool-call args stream honors the strict flag

### DIFF
--- a/.changeset/stream-tool-call-args-strict.md
+++ b/.changeset/stream-tool-call-args-strict.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: the tool-call `argsText` controller honors the `strict` flag passed to `createAssistantStreamController`

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -267,7 +267,9 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
     const toolName = opt.toolName;
     const toolCallId = opt.toolCallId ?? generateId();
 
-    const [stream, controller] = createToolCallStreamController();
+    const [stream, controller] = createToolCallStreamController({
+      strict: this._state.strict,
+    });
     this._addPart(
       {
         type: "tool-call",

--- a/packages/assistant-stream/src/core/modules/tool-call.test.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAssistantStreamController } from "./assistant-stream";
 import { createToolCallStreamController } from "./tool-call";
 import { ToolResponse } from "../tool/ToolResponse";
@@ -22,6 +22,41 @@ const collectChunks = async (
   );
   return chunks;
 };
+
+describe("ToolCallStreamController argsText strict flag", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws when appending args after close by default", () => {
+    const [stream, controller] = createToolCallStreamController();
+    void stream;
+    controller.argsText.close();
+    expect(() => controller.argsText.append("late")).toThrow(TypeError);
+  });
+
+  it("drops args appended after close with strict: false", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const [stream, controller] = createToolCallStreamController({
+      strict: false,
+    });
+    void stream;
+    controller.argsText.close();
+    expect(() => controller.argsText.append("late")).not.toThrow();
+    expect(error).toHaveBeenCalledOnce();
+  });
+
+  it("inherits strict: false from the assistant stream controller", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const [stream, controller] = createAssistantStreamController({
+      strict: false,
+    });
+    void stream;
+    const toolCall = controller.addToolCallPart("lookup");
+    toolCall.argsText.close();
+    expect(() => toolCall.argsText.append("late")).not.toThrow();
+  });
+});
 
 describe("ToolCallStreamController", () => {
   it("delivers a backend response before an args parse failure", async () => {

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -21,6 +21,10 @@ export type ToolCallStreamController = {
   close(): void;
 };
 
+type ToolCallStreamOptions = {
+  strict?: boolean | undefined;
+};
+
 class ToolCallStreamControllerImpl implements ToolCallStreamController {
   private _isClosed = false;
 
@@ -29,13 +33,17 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
 
   constructor(
     _controller: ReadableStreamDefaultController<AssistantStreamChunk>,
+    options: ToolCallStreamOptions = {},
   ) {
     this._controller = _controller;
-    const stream = createTextStream({
-      start: (c) => {
-        this._argsTextController = c;
+    const stream = createTextStream(
+      {
+        start: (c) => {
+          this._argsTextController = c;
+        },
       },
-    });
+      options,
+    );
 
     let hasArgsText = false;
     this._mergeTask = stream.pipeTo(
@@ -119,16 +127,19 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
 
 export const createToolCallStream = (
   readable: UnderlyingReadable<ToolCallStreamController>,
+  options: ToolCallStreamOptions = {},
 ): AssistantStream => {
   return createControllerStream(
     readable,
-    (controller) => new ToolCallStreamControllerImpl(controller),
+    (controller) => new ToolCallStreamControllerImpl(controller, options),
   );
 };
 
-export const createToolCallStreamController = () => {
+export const createToolCallStreamController = (
+  options: ToolCallStreamOptions = {},
+) => {
   return createControllerStreamPair<
     AssistantStreamChunk,
     ToolCallStreamController
-  >((controller) => new ToolCallStreamControllerImpl(controller));
+  >((controller) => new ToolCallStreamControllerImpl(controller, options));
 };


### PR DESCRIPTION
## Problem

`createAssistantStreamController({ strict: false })` promises that late writes are dropped and logged instead of thrown. That holds for text parts but not for tool-call args:

```ts
const [stream, controller] = createAssistantStreamController({ strict: false });
const tool = controller.addToolCallPart("lookup");
tool.argsText.close();
tool.argsText.append("late"); // throws TypeError [ERR_INVALID_STATE]
```

The same sequence on `controller.addTextPart()` drops with one `console.error`. A producer that opted into lenient mode still crashes on the tool-call path.

## Root cause

`tool-call.ts` builds the inner args stream with `createTextStream({ start })` and no options, and `createToolCallStreamController()` takes none, so the args `TextStreamController` is always constructed with the default `strict: true`. The outer `strict` never reaches it, while `addTextPart` and `addReasoningPart` in `assistant-stream.ts` already forward `this._state.strict` to `createTextStreamController`.

## Change

Add a `ToolCallStreamOptions = { strict?: boolean }` type and thread it through `createToolCallStream(readable, options)`, `createToolCallStreamController(options)`, and the controller constructor into `createTextStream(readable, options)`. `addToolCallPart` passes `{ strict: this._state.strict }`, matching the text and reasoning part sites.

- Both factories are module-internal; the barrel exports only the `ToolCallStreamController` type, so the optional trailing argument reshapes nothing public.
- Default behavior is unchanged: with no options the args controller stays strict and the wire output (including the `{}` default when no args text was appended) is untouched.
- Append after a consumer cancel in strict mode is a separate concern handled in the sibling text controller PR; the tests here are close-based and do not depend on it.

## Verification

```
pnpm -C packages/assistant-stream vitest run src/core/modules/tool-call.test.ts   # 7 passed
pnpm -C packages/assistant-stream vitest run                                     # 37 files, 551 passed, 22 skipped, exit 0
pnpm exec tsc -p packages/assistant-stream/tsconfig.json --noEmit                # exit 0
pnpm exec oxlint / oxfmt --check <changed files>                                # exit 0
pnpm changesets:check                                                            # exit 0
pnpm size:check                                                                  # assistant-stream entries ok, main entry -15 B
```

The two `strict: false` tests (`drops args appended after close`, `inherits strict: false from the assistant stream controller`) fail on main with `ERR_INVALID_STATE` and pass with the change. The default-mode test passes before and after, pinning that the strict default is preserved.

## Public surface

- `assistant-stream`: patch changeset. No exports added, removed, or reshaped.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._LG89_u8NpRAMjTK3lekcOACJOy5tDN6GmqaZz_ExMmdJbmB9SuvQkK9oKQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->