### PR TITLE
fix(assistant-stream): reject malformed data-stream frame values at the parse boundary

### DIFF
--- a/.changeset/datastream-frame-value-guards.md
+++ b/.changeset/datastream-frame-value-guards.md
@@ -2,4 +2,4 @@
 "assistant-stream": patch
 ---
 
-fix: reject malformed data-stream frame values at the parse boundary instead of crashing or coercing
+fix: reject malformed data-stream frame values at the parse boundary instead of crashing or coercing. Frames such as `e:null` or `0:123` that previously passed through now throw in strict mode and are dropped with a log in `strict: false`.

--- a/.changeset/datastream-frame-value-guards.md
+++ b/.changeset/datastream-frame-value-guards.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: reject malformed data-stream frame values at the parse boundary instead of crashing or coercing

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -718,13 +718,11 @@ describe("DataStreamDecoder malformed frame values", () => {
     "k:{}",
     "aui-data:{}",
     'aui-data:{"name":"n"}',
-    'h:{"sourceType":"url","id":"s1"}',
-    'h:{"sourceType":"other","id":"s1","url":"https://x"}',
-    'h:{"sourceType":"document","id":"d1"}',
+    'h:{"id":"s1","url":"https://x"}',
     "d:{}",
     "e:{}",
     "f:{}",
-    'd:{"finishReason":"stop"}',
+    'd:{"finishReason":5}',
   ];
 
   it.each([...crashFrames, ...coercionFrames, ...partShapeFrames])(
@@ -869,14 +867,40 @@ describe("DataStreamDecoder malformed frame values", () => {
       'a:{"toolCallId":"t1","result":null,"isError":null}',
       'h:{"sourceType":"url","id":"s1","url":"https://x","title":null}',
       'e:{"finishReason":"stop","usage":{},"isContinued":null}',
+      'aui-reasoning-part-start:{"unstable_summary":null}',
     ]);
 
     expect(chunks.map((c) => c.type)).toContain("result");
     expect(chunks.map((c) => c.type)).toContain("step-finish");
-    expect(
-      chunks.filter((c) => c.type === "part-start").map((c) => c.part.type),
-    ).toEqual(["tool-call", "source"]);
+    const parts = chunks.filter((c) => c.type === "part-start");
+    expect(parts.map((c) => c.part.type)).toEqual([
+      "tool-call",
+      "source",
+      "reasoning",
+    ]);
+    expect(parts[2]?.part).not.toHaveProperty("unstable_summary");
   });
+
+  it.each([true, false])(
+    "accepts finish frames without usage and sources of any type with strict: %s",
+    async (strict) => {
+      const chunks = await decodeLines(
+        [
+          'h:{"sourceType":"other","id":"s1","url":"https://x"}',
+          'e:{"finishReason":"stop"}',
+          'd:{"finishReason":"stop"}',
+        ],
+        { strict },
+      );
+
+      expect(chunks.map((c) => c.type)).toEqual([
+        "part-start",
+        "part-finish",
+        "step-finish",
+        "message-finish",
+      ]);
+    },
+  );
 
   it.each([true, false])(
     "accepts a document source without a url with strict: %s",

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -715,11 +715,10 @@ describe("DataStreamDecoder malformed frame values", () => {
   ];
   const coercionFrames = ["0:null", "0:123", "g:{}", "3:null"];
   const partShapeFrames = [
-    "h:{}",
+    'h:{"sourceType":5}',
     "k:{}",
     "aui-data:{}",
     'aui-data:{"name":"n"}',
-    'h:{"id":"s1","url":"https://x"}',
     "d:{}",
     "e:{}",
     "f:{}",

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -693,3 +693,103 @@ describe("DataStreamDecoder strict: false", () => {
     expect(error).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("DataStreamDecoder malformed frame values", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const crashFrames = [
+    "b:null",
+    "9:null",
+    "a:null",
+    "h:null",
+    "k:null",
+    "aui-text-delta:null",
+    "aui-reasoning-delta:null",
+    "aui-reasoning-part-start:null",
+    '2:{"a":1}',
+    "8:null",
+    'aui-state:"x"',
+  ];
+  const coercionFrames = ["0:null", "0:123", "g:{}", "3:null"];
+
+  it.each([...crashFrames, ...coercionFrames])(
+    "rejects %s with a descriptive error by default",
+    async (frame) => {
+      const type = frame.slice(0, frame.indexOf(":"));
+      await expect(decodeLines([frame, '0:"ok"'])).rejects.toThrow(
+        `Invalid value for data-stream chunk type "${type}"`,
+      );
+    },
+  );
+
+  it.each([...crashFrames, ...coercionFrames])(
+    "drops %s and keeps decoding with strict: false",
+    async (frame) => {
+      const error = vi.spyOn(console, "error").mockImplementation(() => {});
+      const chunks = await decodeLines([frame, '0:"ok"'], { strict: false });
+
+      const textDeltas = chunks
+        .filter((c) => c.type === "text-delta")
+        .map((c) => c.textDelta);
+      expect(textDeltas).toEqual(["ok"]);
+      expect(
+        chunks.some((c) => c.type === "part-start" && c.part.type !== "text"),
+      ).toBe(false);
+      expect(chunks.some((c) => c.type === "data")).toBe(false);
+      expect(chunks.some((c) => c.type === "annotations")).toBe(false);
+      expect(chunks.some((c) => c.type === "update-state")).toBe(false);
+      expect(chunks.some((c) => c.type === "error")).toBe(false);
+      expect(error).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("rejects an args delta frame without argsTextDelta", async () => {
+    await expect(
+      decodeLines([
+        'b:{"toolCallId":"t1","toolName":"search"}',
+        'c:{"toolCallId":"t1"}',
+      ]),
+    ).rejects.toThrow('Invalid value for data-stream chunk type "c"');
+  });
+
+  it("keeps the tool call open across a dropped args delta with strict: false", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const chunks = await decodeLines(
+      [
+        'b:{"toolCallId":"t1","toolName":"search"}',
+        'c:{"toolCallId":"t1"}',
+        'c:{"toolCallId":"t1","argsTextDelta":"{\\"a\\":1}"}',
+      ],
+      { strict: false },
+    );
+
+    const argsText = chunks
+      .filter((c) => c.type === "text-delta")
+      .map((c) => c.textDelta)
+      .join("");
+    expect(argsText).toBe('{"a":1}');
+    expect(chunks.some((c) => c.type === "tool-call-args-text-finish")).toBe(
+      true,
+    );
+  });
+
+  it("logs each rejected type once with a preview of the value", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    await decodeLines(["b:null", 'b:{"toolCallId":1}', "0:null"], {
+      strict: false,
+    });
+
+    expect(error.mock.calls.map(([message]) => message)).toEqual([
+      'Dropped data-stream chunk with invalid value for type "b": null',
+      'Dropped data-stream chunk with invalid value for type "0": null',
+    ]);
+  });
+
+  it("leaves unknown chunk types to the existing unsupported-type arm", async () => {
+    await expect(decodeLines(["zz:null"])).rejects.toThrow(
+      "unsupported chunk type: zz",
+    );
+  });
+});

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -813,6 +813,15 @@ describe("DataStreamDecoder malformed frame values", () => {
     ).toBe(true);
   });
 
+  it.each([
+    '9:{"toolCallId":"t1","toolName":"search"}',
+    '9:{"toolCallId":"t1","toolName":"search","args":"oops"}',
+  ])("rejects a complete tool call frame %s by default", async (frame) => {
+    await expect(decodeLines([frame])).rejects.toThrow(
+      'Invalid value for data-stream chunk type "9"',
+    );
+  });
+
   it("treats null args on a complete tool call frame as absent", async () => {
     const chunks = await decodeLines([
       '9:{"toolCallId":"t1","toolName":"search","args":null}',

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -713,8 +713,9 @@ describe("DataStreamDecoder malformed frame values", () => {
     'aui-state:"x"',
   ];
   const coercionFrames = ["0:null", "0:123", "g:{}", "3:null"];
+  const partShapeFrames = ["h:{}", "k:{}", "aui-data:{}"];
 
-  it.each([...crashFrames, ...coercionFrames])(
+  it.each([...crashFrames, ...coercionFrames, ...partShapeFrames])(
     "rejects %s with a descriptive error by default",
     async (frame) => {
       const type = frame.slice(0, frame.indexOf(":"));
@@ -724,7 +725,7 @@ describe("DataStreamDecoder malformed frame values", () => {
     },
   );
 
-  it.each([...crashFrames, ...coercionFrames])(
+  it.each([...crashFrames, ...coercionFrames, ...partShapeFrames])(
     "drops %s and keeps decoding with strict: false",
     async (frame) => {
       const error = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -794,8 +795,14 @@ describe("DataStreamDecoder malformed frame values", () => {
   });
 
   it.each([
-    ['d:{"type":"data","finishReason":"stop"}', "message-finish"],
-    ['e:{"type":"data","finishReason":"stop"}', "step-finish"],
+    [
+      'd:{"type":"data","finishReason":"stop","usage":{"inputTokens":1,"outputTokens":1}}',
+      "message-finish",
+    ],
+    [
+      'e:{"type":"data","finishReason":"stop","usage":{"inputTokens":1,"outputTokens":1},"isContinued":false}',
+      "step-finish",
+    ],
     ['f:{"type":"data","messageId":"m1"}', "step-start"],
   ])(
     "keeps the chunk type of %s despite a type key in the value",
@@ -808,7 +815,9 @@ describe("DataStreamDecoder malformed frame values", () => {
   );
 
   it("keeps the addressed path despite a path key in the value", async () => {
-    const chunks = await decodeLines(['d:{"path":[3],"finishReason":"stop"}']);
+    const chunks = await decodeLines([
+      'd:{"path":[3],"finishReason":"stop","usage":{"inputTokens":1,"outputTokens":1}}',
+    ]);
 
     expect(chunks).toEqual([
       expect.objectContaining({ type: "message-finish", path: [] }),

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -813,13 +813,10 @@ describe("DataStreamDecoder malformed frame values", () => {
     ).toBe(true);
   });
 
-  it.each([
-    '9:{"toolCallId":"t1","toolName":"search"}',
-    '9:{"toolCallId":"t1","toolName":"search","args":"oops"}',
-  ])("rejects a complete tool call frame %s by default", async (frame) => {
-    await expect(decodeLines([frame])).rejects.toThrow(
-      'Invalid value for data-stream chunk type "9"',
-    );
+  it("rejects a complete tool call frame whose args are not an object", async () => {
+    await expect(
+      decodeLines(['9:{"toolCallId":"t1","toolName":"search","args":"oops"}']),
+    ).rejects.toThrow('Invalid value for data-stream chunk type "9"');
   });
 
   it("treats null args on a complete tool call frame as absent", async () => {

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -715,7 +715,6 @@ describe("DataStreamDecoder malformed frame values", () => {
   ];
   const coercionFrames = ["0:null", "0:123", "g:{}", "3:null"];
   const partShapeFrames = [
-    'h:{"sourceType":5}',
     "k:{}",
     "aui-data:{}",
     'aui-data:{"name":"n"}',
@@ -816,6 +815,18 @@ describe("DataStreamDecoder malformed frame values", () => {
     await expect(
       decodeLines(['9:{"toolCallId":"t1","toolName":"search","args":"oops"}']),
     ).rejects.toThrow('Invalid value for data-stream chunk type "9"');
+  });
+
+  it("accepts array args on a complete tool call frame as the v4 parser does", async () => {
+    const chunks = await decodeLines([
+      '9:{"toolCallId":"t1","toolName":"search","args":[1]}',
+    ]);
+
+    const argsText = chunks
+      .filter((c) => c.type === "text-delta")
+      .map((c) => c.textDelta)
+      .join("");
+    expect(argsText).toBe("[1]");
   });
 
   it("treats null args on a complete tool call frame as absent", async () => {

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -787,6 +787,51 @@ describe("DataStreamDecoder malformed frame values", () => {
     ]);
   });
 
+  it("rejects a complete tool call frame whose args are not an object", async () => {
+    await expect(
+      decodeLines(['9:{"toolCallId":"t1","toolName":"search","args":"oops"}']),
+    ).rejects.toThrow('Invalid value for data-stream chunk type "9"');
+  });
+
+  it.each([
+    ['d:{"type":"data","finishReason":"stop"}', "message-finish"],
+    ['e:{"type":"data","finishReason":"stop"}', "step-finish"],
+    ['f:{"type":"data","messageId":"m1"}', "step-start"],
+  ])(
+    "keeps the chunk type of %s despite a type key in the value",
+    async (frame, type) => {
+      const chunks = await decodeLines([frame]);
+
+      expect(chunks.map((c) => c.type)).toEqual([type]);
+      expect(chunks.some((c) => c.type === "data")).toBe(false);
+    },
+  );
+
+  it("keeps the addressed path despite a path key in the value", async () => {
+    const chunks = await decodeLines(['d:{"path":[3],"finishReason":"stop"}']);
+
+    expect(chunks).toEqual([
+      expect.objectContaining({ type: "message-finish", path: [] }),
+    ]);
+  });
+
+  it.each([
+    [
+      'h:{"type":"file","sourceType":"url","id":"s1","url":"https://x"}',
+      "source",
+    ],
+    ['k:{"type":"data","data":"aGk=","mimeType":"text/plain"}', "file"],
+    ['aui-data:{"type":"file","name":"n","data":1}', "data"],
+  ])(
+    "keeps the part type of %s despite a type key in the value",
+    async (frame, type) => {
+      const chunks = await decodeLines([frame]);
+
+      const parts = chunks.filter((c) => c.type === "part-start");
+      expect(parts.map((c) => c.part.type)).toEqual([type]);
+    },
+  );
+
   it("leaves unknown chunk types to the existing unsupported-type arm", async () => {
     await expect(decodeLines(["zz:null"])).rejects.toThrow(
       "unsupported chunk type: zz",

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -713,7 +713,12 @@ describe("DataStreamDecoder malformed frame values", () => {
     'aui-state:"x"',
   ];
   const coercionFrames = ["0:null", "0:123", "g:{}", "3:null"];
-  const partShapeFrames = ["h:{}", "k:{}", "aui-data:{}"];
+  const partShapeFrames = [
+    "h:{}",
+    "k:{}",
+    "aui-data:{}",
+    'aui-data:{"name":"n"}',
+  ];
 
   it.each([...crashFrames, ...coercionFrames, ...partShapeFrames])(
     "rejects %s with a descriptive error by default",
@@ -838,6 +843,27 @@ describe("DataStreamDecoder malformed frame values", () => {
 
       const parts = chunks.filter((c) => c.type === "part-start");
       expect(parts.map((c) => c.part.type)).toEqual([type]);
+    },
+  );
+
+  it.each([true, false])(
+    "accepts a document source without a url with strict: %s",
+    async (strict) => {
+      const chunks = await decodeLines(
+        ['h:{"sourceType":"document","id":"d1","title":"Q3 report"}'],
+        { strict },
+      );
+
+      expect(chunks.filter((c) => c.type === "part-start")).toEqual([
+        expect.objectContaining({
+          part: expect.objectContaining({
+            type: "source",
+            sourceType: "document",
+            id: "d1",
+            title: "Q3 report",
+          }),
+        }),
+      ]);
     },
   );
 

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -718,6 +718,13 @@ describe("DataStreamDecoder malformed frame values", () => {
     "k:{}",
     "aui-data:{}",
     'aui-data:{"name":"n"}',
+    'h:{"sourceType":"url","id":"s1"}',
+    'h:{"sourceType":"other","id":"s1","url":"https://x"}',
+    'h:{"sourceType":"document","id":"d1"}',
+    "d:{}",
+    "e:{}",
+    "f:{}",
+    'd:{"finishReason":"stop"}',
   ];
 
   it.each([...crashFrames, ...coercionFrames, ...partShapeFrames])(
@@ -845,6 +852,31 @@ describe("DataStreamDecoder malformed frame values", () => {
       expect(parts.map((c) => c.part.type)).toEqual([type]);
     },
   );
+
+  it("rejects a tool call result frame without a result", async () => {
+    await expect(
+      decodeLines([
+        'b:{"toolCallId":"t1","toolName":"search"}',
+        'a:{"toolCallId":"t1"}',
+      ]),
+    ).rejects.toThrow('Invalid value for data-stream chunk type "a"');
+  });
+
+  it("treats null in an optional field as absent by default", async () => {
+    const chunks = await decodeLines([
+      'b:{"toolCallId":"t1","toolName":"search","parentId":null}',
+      'c:{"toolCallId":"t1","argsTextDelta":"{}","isFinal":null}',
+      'a:{"toolCallId":"t1","result":null,"isError":null}',
+      'h:{"sourceType":"url","id":"s1","url":"https://x","title":null}',
+      'e:{"finishReason":"stop","usage":{},"isContinued":null}',
+    ]);
+
+    expect(chunks.map((c) => c.type)).toContain("result");
+    expect(chunks.map((c) => c.type)).toContain("step-finish");
+    expect(
+      chunks.filter((c) => c.type === "part-start").map((c) => c.part.type),
+    ).toEqual(["tool-call", "source"]);
+  });
 
   it.each([true, false])(
     "accepts a document source without a url with strict: %s",

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -3,6 +3,7 @@ import { DataStreamDecoder, DataStreamEncoder } from "./DataStream";
 import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
 import { createAssistantStreamController } from "../../modules/assistant-stream";
 import { toolResultStream } from "../../tool/toolResultStream";
+import { NO_RESULT } from "../../tool/ToolResponse";
 
 const decodeLines = async (lines: string[], options?: { strict?: boolean }) => {
   const bytes = new ReadableStream<Uint8Array>({
@@ -798,10 +799,38 @@ describe("DataStreamDecoder malformed frame values", () => {
     ]);
   });
 
-  it("rejects a complete tool call frame whose args are not an object", async () => {
-    await expect(
-      decodeLines(['9:{"toolCallId":"t1","toolName":"search","args":"oops"}']),
-    ).rejects.toThrow('Invalid value for data-stream chunk type "9"');
+  it("settles a tool call result frame without a result as NO_RESULT", async () => {
+    const chunks = await decodeLines([
+      'b:{"toolCallId":"t1","toolName":"search"}',
+      'a:{"toolCallId":"t1"}',
+      '0:"ok"',
+    ]);
+
+    const result = chunks.find((c) => c.type === "result");
+    expect(result?.result).toBe(NO_RESULT);
+    expect(
+      chunks.some((c) => c.type === "text-delta" && c.textDelta === "ok"),
+    ).toBe(true);
+  });
+
+  it("treats null args on a complete tool call frame as absent", async () => {
+    const chunks = await decodeLines([
+      '9:{"toolCallId":"t1","toolName":"search","args":null}',
+    ]);
+
+    const argsText = chunks
+      .filter((c) => c.type === "text-delta")
+      .map((c) => c.textDelta)
+      .join("");
+    expect(argsText).toBe("{}");
+  });
+
+  it("defaults isContinued on a step finish frame that omits it", async () => {
+    const chunks = await decodeLines(['e:{"finishReason":"stop"}']);
+
+    expect(chunks).toEqual([
+      expect.objectContaining({ type: "step-finish", isContinued: false }),
+    ]);
   });
 
   it.each([
@@ -850,15 +879,6 @@ describe("DataStreamDecoder malformed frame values", () => {
       expect(parts.map((c) => c.part.type)).toEqual([type]);
     },
   );
-
-  it("rejects a tool call result frame without a result", async () => {
-    await expect(
-      decodeLines([
-        'b:{"toolCallId":"t1","toolName":"search"}',
-        'a:{"toolCallId":"t1"}',
-      ]),
-    ).rejects.toThrow('Invalid value for data-stream chunk type "a"');
-  });
 
   it("treats null in an optional field as absent by default", async () => {
     const chunks = await decodeLines([

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -43,6 +43,7 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
   [DataStreamStreamChunkType.ToolCall]: objectWith({
     toolCallId: isString,
     toolName: isString,
+    args: optional(isObject),
   }),
   [DataStreamStreamChunkType.ToolCallResult]: objectWith({
     toolCallId: isString,
@@ -539,26 +540,26 @@ export class DataStreamDecoder extends PipeableTransformStream<
             case DataStreamStreamChunkType.FinishMessage:
               closeOpenToolCallArgs();
               controller.enqueue({
+                ...value,
                 type: "message-finish",
                 path: [],
-                ...value,
               });
               break;
 
             case DataStreamStreamChunkType.StartStep:
               controller.enqueue({
+                ...value,
                 type: "step-start",
                 path: [],
-                ...value,
               });
               break;
 
             case DataStreamStreamChunkType.FinishStep:
               closeOpenToolCallArgs();
               controller.enqueue({
+                ...value,
                 type: "step-finish",
                 path: [],
-                ...value,
               });
               break;
             case DataStreamStreamChunkType.Data:
@@ -583,8 +584,8 @@ export class DataStreamDecoder extends PipeableTransformStream<
                 ? controller.withParentId(parentId)
                 : controller;
               ctrl.appendSource({
-                type: "source",
                 ...sourceData,
+                type: "source",
               });
               break;
             }
@@ -604,16 +605,16 @@ export class DataStreamDecoder extends PipeableTransformStream<
                 ? controller.withParentId(parentId)
                 : controller;
               ctrl.appendFile({
-                type: "file",
                 ...fileData,
+                type: "file",
               });
               break;
             }
 
             case DataStreamStreamChunkType.AuiDataPart:
               controller.appendData({
-                type: "data",
                 ...value,
+                type: "data",
               });
               break;
 

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -29,7 +29,6 @@ const optional = (check: (value: unknown) => boolean) => (value: unknown) =>
   value === undefined || value === null || check(value);
 const isBoolean = (value: unknown) => typeof value === "boolean";
 const present = (value: unknown) => value !== undefined;
-const isObjectOrNull = (value: unknown) => typeof value === "object";
 const objectWith = (
   fields: Record<string, (value: unknown) => boolean>,
 ): ValueRule => {
@@ -47,7 +46,7 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
   [DataStreamStreamChunkType.ToolCall]: objectWith({
     toolCallId: isString,
     toolName: isString,
-    args: optional(isObjectOrNull),
+    args: optional(isObject),
   }),
   [DataStreamStreamChunkType.ToolCallResult]: objectWith({
     toolCallId: isString,
@@ -77,8 +76,8 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
   }),
   [DataStreamStreamChunkType.ReasoningDelta]: isString,
   [DataStreamStreamChunkType.Source]: objectWith({
-    sourceType: isString,
-    id: isString,
+    sourceType: optional(isString),
+    id: optional(isString),
     url: optional(isString),
     title: optional(isString),
     parentId: optional(isString),

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -18,6 +18,74 @@ type DataStreamOptions = {
   strict?: boolean | undefined;
 };
 
+type ValueRule = (value: unknown) => boolean;
+type ValueFields = Record<string, unknown>;
+
+const isString = (value: unknown) => typeof value === "string";
+const isArray = (value: unknown) => Array.isArray(value);
+const isObject = (value: unknown): value is ValueFields =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+const optional = (check: (value: unknown) => boolean) => (value: unknown) =>
+  value === undefined || check(value);
+const isBoolean = (value: unknown) => typeof value === "boolean";
+const objectWith =
+  (fields: Record<string, (value: unknown) => boolean>): ValueRule =>
+  (value) =>
+    isObject(value) &&
+    Object.entries(fields).every(([key, check]) => check(value[key]));
+const unchecked = () => true;
+
+const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
+  [DataStreamStreamChunkType.TextDelta]: isString,
+  [DataStreamStreamChunkType.Data]: isArray,
+  [DataStreamStreamChunkType.Error]: isString,
+  [DataStreamStreamChunkType.Annotation]: isArray,
+  [DataStreamStreamChunkType.ToolCall]: objectWith({
+    toolCallId: isString,
+    toolName: isString,
+  }),
+  [DataStreamStreamChunkType.ToolCallResult]: objectWith({
+    toolCallId: isString,
+    isError: optional(isBoolean),
+  }),
+  [DataStreamStreamChunkType.StartToolCall]: objectWith({
+    toolCallId: isString,
+    toolName: isString,
+    parentId: optional(isString),
+  }),
+  [DataStreamStreamChunkType.ToolCallArgsTextDelta]: objectWith({
+    toolCallId: isString,
+    argsTextDelta: isString,
+    isFinal: optional(isBoolean),
+  }),
+  [DataStreamStreamChunkType.FinishMessage]: isObject,
+  [DataStreamStreamChunkType.FinishStep]: isObject,
+  [DataStreamStreamChunkType.StartStep]: isObject,
+  [DataStreamStreamChunkType.ReasoningDelta]: isString,
+  [DataStreamStreamChunkType.Source]: objectWith({
+    parentId: optional(isString),
+  }),
+  [DataStreamStreamChunkType.RedactedReasoning]: unchecked,
+  [DataStreamStreamChunkType.ReasoningSignature]: unchecked,
+  [DataStreamStreamChunkType.File]: objectWith({
+    parentId: optional(isString),
+  }),
+  [DataStreamStreamChunkType.AuiUpdateStateOperations]: isArray,
+  [DataStreamStreamChunkType.AuiTextDelta]: objectWith({
+    textDelta: isString,
+    parentId: isString,
+  }),
+  [DataStreamStreamChunkType.AuiReasoningDelta]: objectWith({
+    reasoningDelta: isString,
+    parentId: isString,
+  }),
+  [DataStreamStreamChunkType.AuiDataPart]: isObject,
+  [DataStreamStreamChunkType.AuiReasoningPartStart]: objectWith({
+    unstable_summary: optional(isString),
+    parentId: optional(isString),
+  }),
+};
+
 export class DataStreamEncoder
   extends PipeableTransformStream<AssistantStreamChunk, Uint8Array<ArrayBuffer>>
   implements AssistantStreamEncoder
@@ -302,6 +370,22 @@ export class DataStreamDecoder extends PipeableTransformStream<
         strict,
         transform(chunk, controller) {
           const { type, value } = chunk;
+
+          const rule = Object.prototype.hasOwnProperty.call(VALUE_RULES, type)
+            ? VALUE_RULES[type]
+            : undefined;
+          if (rule && !rule(value)) {
+            const preview = JSON.stringify(value)?.slice(0, 200);
+            if (strict)
+              throw new Error(
+                `Invalid value for data-stream chunk type "${type}": ${preview}`,
+              );
+            logDropped(
+              `value:${type}`,
+              `Dropped data-stream chunk with invalid value for type "${type}": ${preview}`,
+            );
+            return;
+          }
 
           switch (type) {
             case DataStreamStreamChunkType.ReasoningDelta:

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -29,6 +29,7 @@ const optional = (check: (value: unknown) => boolean) => (value: unknown) =>
   value === undefined || value === null || check(value);
 const isBoolean = (value: unknown) => typeof value === "boolean";
 const present = (value: unknown) => value !== undefined;
+const isObjectOrNull = (value: unknown) => typeof value === "object";
 const objectWith = (
   fields: Record<string, (value: unknown) => boolean>,
 ): ValueRule => {
@@ -46,6 +47,7 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
   [DataStreamStreamChunkType.ToolCall]: objectWith({
     toolCallId: isString,
     toolName: isString,
+    args: isObjectOrNull,
   }),
   [DataStreamStreamChunkType.ToolCallResult]: objectWith({
     toolCallId: isString,

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -26,7 +26,7 @@ const isArray = (value: unknown) => Array.isArray(value);
 const isObject = (value: unknown): value is ValueFields =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 const optional = (check: (value: unknown) => boolean) => (value: unknown) =>
-  value === undefined || check(value);
+  value === undefined || value === null || check(value);
 const isBoolean = (value: unknown) => typeof value === "boolean";
 const present = (value: unknown) => value !== undefined;
 const objectWith = (
@@ -50,6 +50,7 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
   }),
   [DataStreamStreamChunkType.ToolCallResult]: objectWith({
     toolCallId: isString,
+    result: present,
     isError: optional(isBoolean),
   }),
   [DataStreamStreamChunkType.StartToolCall]: objectWith({
@@ -62,17 +63,26 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
     argsTextDelta: isString,
     isFinal: optional(isBoolean),
   }),
-  [DataStreamStreamChunkType.FinishMessage]: isObject,
-  [DataStreamStreamChunkType.FinishStep]: isObject,
-  [DataStreamStreamChunkType.StartStep]: isObject,
-  [DataStreamStreamChunkType.ReasoningDelta]: isString,
-  [DataStreamStreamChunkType.Source]: objectWith({
-    sourceType: isString,
-    id: isString,
-    url: optional(isString),
-    title: optional(isString),
-    parentId: optional(isString),
+  [DataStreamStreamChunkType.FinishMessage]: objectWith({
+    finishReason: isString,
+    usage: isObject,
   }),
+  [DataStreamStreamChunkType.FinishStep]: objectWith({
+    finishReason: isString,
+    usage: isObject,
+    isContinued: optional(isBoolean),
+  }),
+  [DataStreamStreamChunkType.StartStep]: objectWith({
+    messageId: isString,
+  }),
+  [DataStreamStreamChunkType.ReasoningDelta]: isString,
+  [DataStreamStreamChunkType.Source]: (value) =>
+    isObject(value) &&
+    isString(value.id) &&
+    optional(isString)(value.parentId) &&
+    (value.sourceType === "url"
+      ? isString(value.url) && optional(isString)(value.title)
+      : value.sourceType === "document" && isString(value.title)),
   [DataStreamStreamChunkType.RedactedReasoning]: unchecked,
   [DataStreamStreamChunkType.ReasoningSignature]: unchecked,
   [DataStreamStreamChunkType.File]: objectWith({

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -47,7 +47,7 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
   [DataStreamStreamChunkType.ToolCall]: objectWith({
     toolCallId: isString,
     toolName: isString,
-    args: isObjectOrNull,
+    args: optional(isObjectOrNull),
   }),
   [DataStreamStreamChunkType.ToolCallResult]: objectWith({
     toolCallId: isString,

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -64,11 +64,17 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
   [DataStreamStreamChunkType.StartStep]: isObject,
   [DataStreamStreamChunkType.ReasoningDelta]: isString,
   [DataStreamStreamChunkType.Source]: objectWith({
+    sourceType: isString,
+    id: isString,
+    url: isString,
+    title: optional(isString),
     parentId: optional(isString),
   }),
   [DataStreamStreamChunkType.RedactedReasoning]: unchecked,
   [DataStreamStreamChunkType.ReasoningSignature]: unchecked,
   [DataStreamStreamChunkType.File]: objectWith({
+    data: isString,
+    mimeType: isString,
     parentId: optional(isString),
   }),
   [DataStreamStreamChunkType.AuiUpdateStateOperations]: isArray,
@@ -80,7 +86,10 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
     reasoningDelta: isString,
     parentId: isString,
   }),
-  [DataStreamStreamChunkType.AuiDataPart]: isObject,
+  [DataStreamStreamChunkType.AuiDataPart]: objectWith({
+    name: isString,
+    parentId: optional(isString),
+  }),
   [DataStreamStreamChunkType.AuiReasoningPartStart]: objectWith({
     unstable_summary: optional(isString),
     parentId: optional(isString),

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -65,24 +65,24 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
   }),
   [DataStreamStreamChunkType.FinishMessage]: objectWith({
     finishReason: isString,
-    usage: isObject,
+    usage: optional(isObject),
   }),
   [DataStreamStreamChunkType.FinishStep]: objectWith({
     finishReason: isString,
-    usage: isObject,
+    usage: optional(isObject),
     isContinued: optional(isBoolean),
   }),
   [DataStreamStreamChunkType.StartStep]: objectWith({
     messageId: isString,
   }),
   [DataStreamStreamChunkType.ReasoningDelta]: isString,
-  [DataStreamStreamChunkType.Source]: (value) =>
-    isObject(value) &&
-    isString(value.id) &&
-    optional(isString)(value.parentId) &&
-    (value.sourceType === "url"
-      ? isString(value.url) && optional(isString)(value.title)
-      : value.sourceType === "document" && isString(value.title)),
+  [DataStreamStreamChunkType.Source]: objectWith({
+    sourceType: isString,
+    id: isString,
+    url: optional(isString),
+    title: optional(isString),
+    parentId: optional(isString),
+  }),
   [DataStreamStreamChunkType.RedactedReasoning]: unchecked,
   [DataStreamStreamChunkType.ReasoningSignature]: unchecked,
   [DataStreamStreamChunkType.File]: objectWith({
@@ -433,10 +433,9 @@ export class DataStreamDecoder extends PipeableTransformStream<
               // Opening through appendReasoning registers the part as the
               // current reasoning append target, so the deltas that follow
               // extend it instead of opening a second part.
+              const unstable_summary = value.unstable_summary ?? undefined;
               target.appendReasoning("", {
-                ...(value.unstable_summary !== undefined
-                  ? { unstable_summary: value.unstable_summary }
-                  : {}),
+                ...(unstable_summary !== undefined ? { unstable_summary } : {}),
               });
               break;
             }

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -46,11 +46,9 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
   [DataStreamStreamChunkType.ToolCall]: objectWith({
     toolCallId: isString,
     toolName: isString,
-    args: optional(isObject),
   }),
   [DataStreamStreamChunkType.ToolCallResult]: objectWith({
     toolCallId: isString,
-    result: present,
     isError: optional(isBoolean),
   }),
   [DataStreamStreamChunkType.StartToolCall]: objectWith({
@@ -533,7 +531,8 @@ export class DataStreamDecoder extends PipeableTransformStream<
             }
 
             case DataStreamStreamChunkType.ToolCall: {
-              const { toolCallId, toolName, args } = value;
+              const { toolCallId, toolName } = value;
+              const args = value.args ?? undefined;
               const toolCallController =
                 toolCallPartRegistry.tryGet(toolCallId);
 
@@ -580,6 +579,7 @@ export class DataStreamDecoder extends PipeableTransformStream<
               closeOpenToolCallArgs();
               controller.enqueue({
                 ...value,
+                isContinued: value.isContinued ?? false,
                 type: "step-finish",
                 path: [],
               });

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -28,11 +28,14 @@ const isObject = (value: unknown): value is ValueFields =>
 const optional = (check: (value: unknown) => boolean) => (value: unknown) =>
   value === undefined || check(value);
 const isBoolean = (value: unknown) => typeof value === "boolean";
-const objectWith =
-  (fields: Record<string, (value: unknown) => boolean>): ValueRule =>
-  (value) =>
-    isObject(value) &&
-    Object.entries(fields).every(([key, check]) => check(value[key]));
+const present = (value: unknown) => value !== undefined;
+const objectWith = (
+  fields: Record<string, (value: unknown) => boolean>,
+): ValueRule => {
+  const entries = Object.entries(fields);
+  return (value) =>
+    isObject(value) && entries.every(([key, check]) => check(value[key]));
+};
 const unchecked = () => true;
 
 const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
@@ -66,7 +69,7 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
   [DataStreamStreamChunkType.Source]: objectWith({
     sourceType: isString,
     id: isString,
-    url: isString,
+    url: optional(isString),
     title: optional(isString),
     parentId: optional(isString),
   }),
@@ -88,6 +91,7 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
   }),
   [DataStreamStreamChunkType.AuiDataPart]: objectWith({
     name: isString,
+    data: present,
     parentId: optional(isString),
   }),
   [DataStreamStreamChunkType.AuiReasoningPartStart]: objectWith({

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -46,7 +46,7 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
   [DataStreamStreamChunkType.ToolCall]: objectWith({
     toolCallId: isString,
     toolName: isString,
-    args: optional(isObject),
+    args: optional((value) => typeof value === "object"),
   }),
   [DataStreamStreamChunkType.ToolCallResult]: objectWith({
     toolCallId: isString,
@@ -75,13 +75,7 @@ const VALUE_RULES: Record<DataStreamStreamChunkType, ValueRule> = {
     messageId: isString,
   }),
   [DataStreamStreamChunkType.ReasoningDelta]: isString,
-  [DataStreamStreamChunkType.Source]: objectWith({
-    sourceType: optional(isString),
-    id: optional(isString),
-    url: optional(isString),
-    title: optional(isString),
-    parentId: optional(isString),
-  }),
+  [DataStreamStreamChunkType.Source]: isObject,
   [DataStreamStreamChunkType.RedactedReasoning]: unchecked,
   [DataStreamStreamChunkType.ReasoningSignature]: unchecked,
   [DataStreamStreamChunkType.File]: objectWith({

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -279,8 +279,8 @@
       "gzip": 16908
     },
     "./resumable": {
-      "min": 16391,
-      "gzip": 5490
+      "min": 17734,
+      "gzip": 5907
     },
     "./resumable/ioredis": {
       "min": 5830,

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -275,8 +275,8 @@
   },
   "assistant-stream": {
     ".": {
-      "min": 58576,
-      "gzip": 16546
+      "min": 59843,
+      "gzip": 16908
     },
     "./resumable": {
       "min": 16391,


### PR DESCRIPTION
## Problem

One data-stream frame whose JSON parses but does not have the shape its type declares aborts the whole response with a raw `TypeError`, in `strict: true` and `strict: false` alike. `b:null` throws `Cannot destructure property 'toolCallId' of 'value' as it is null`, `2:{"a":1}` throws `chunk.data is not iterable` downstream in the accumulator, and scalar frames coerce instead of failing: `0:null` renders as the text `null`, `g:{}` as `[object Object]`. Every frame after the bad one is lost. Resume runs always decode leniently, so a retained stream with one such frame fails on every reconnect. Closes #7245.

## Root cause

`DataStreamChunkDecoder` checks only that the text after the colon parses as JSON, then casts the value to whatever `DataStreamChunk` declares for the type. Every `DataStreamDecoder` arm destructures or forwards the value on that trust. The existing strict and lenient arms cover unknown chunk types, duplicate tool-call starts, and unknown tool-call ids; no arm inspects the value itself.

## Change

A module-private `VALUE_RULES` table keyed by `DataStreamStreamChunkType`, mirroring the transport decoder's `KNOWN_CHUNK_TYPES`, checked once at the top of the decoder transform. A known type whose value fails its rule throws `Invalid value for data-stream chunk type "<type>": <200-char preview>` in strict mode and drops through the existing deduplicated `logDropped` in lenient mode. Unknown types still fall through to the existing unsupported-type arm. Each rule covers the fields the decoder reads, plus every declared field of the source, file, and data part frames since those spread straight into a part, typed as `chunk-types.ts` declares them; the `Record` type forces a rule for any chunk type added later.

- The `message-finish`, `step-start`, `step-finish`, source, file, and data arms now spread the value before the `type` and `path` literals, so a value carrying its own `type` key can no longer forge a different chunk or part type past the object rule.
- A source frame must be an object; `sourceType`, `id`, `url`, `title` and `parentId` are optional strings, matching the v4 `source` parser which checks only for an object, and the decoder reads none of them but `parentId`.
- An optional field accepts JSON `null` as absent, since every arm already treats `null` that way, and a `null` reasoning summary is dropped rather than forwarded.
- A tool call result frame without `result` settles as `NO_RESULT`, the same contract the UIMessageStream decoder already has under test; `args` on a complete tool call frame must be an object or `null` when present, matching the v4 `tool_call` parser, and `null` args are treated as absent. A step finish frame without `isContinued` emits `false`, matching the v4 parser default.
- Parse-boundary only. `DataStreamChunk`, `chunk-types.ts`, and every emitted `AssistantStreamChunk` are unchanged.
- Strict mode throws where the transport decoder drops `invalid-fields` unconditionally. The data-stream decoder's existing arms throw in strict, and a wrong-shaped value is a server bug the fail-fast default exists to surface, so this file's convention wins.
- `e:null`, `f:null`, and `aui-data:null` passed through harmlessly before and are rejected now, since they are off-spec for the same reason.
- `d` and `e` require a string `finishReason`, `f` a string `messageId`; `usage` stays optional because the AI SDK v4 `finish_message` and `finish_step` parsers require only `finishReason` and `streamText` omits `usage` when `sendUsage` is false.
- The TS and Python encoders both omit optional keys rather than emitting `null`, and every AI SDK v4 frame shape passes its rule.

## Verification

```
pnpm -C packages/assistant-stream exec vitest run                 # 614 passed, 22 skipped, exit 0
pnpm -C packages/assistant-stream exec vitest run src/core/serialization/data-stream/   # 99 passed
pnpm -C packages/assistant-stream exec oxlint <changed files>     # exit 0
pnpm -C packages/assistant-stream exec oxfmt --check <changed files>  # exit 0
pnpm changesets:check                                             # exit 0
pnpm size:check                                                   # assistant-stream . 16546 -> 16908 and ./resumable 5490 -> 5907 re-recorded via pnpm size:update; all five assistant-stream rows ok
```

With the guard stashed, 33 of the 34 value-rule tests fail; the unknown-type control is the one that passes without it. With the guard, all pass, along with the forged-type, args, and empty part-frame cases. The non-ok size rows belong to assistant-cloud, cloud-ai-sdk, and react-mcp dists this branch does not rebuild.

## Public surface

`assistant-stream` patch changeset. No export, type, or docs change.
