### PR TITLE
fix(heat-graph): preserve tooltip behavior with hover handlers

### DIFF
--- a/.changeset/quiet-cells-hover.md
+++ b/.changeset/quiet-cells-hover.md
@@ -1,0 +1,5 @@
+---
+"heat-graph": patch
+---
+
+fix: preserve tooltip behavior when cells define hover handlers

--- a/packages/heat-graph/src/components/Cell.test.tsx
+++ b/packages/heat-graph/src/components/Cell.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { useTooltipState } from "../context";
+import { Cell } from "./Cell";
+import { Grid } from "./Grid";
+import { Root } from "./Root";
+
+const TooltipStateProbe = () => {
+  const state = useTooltipState();
+  return <output>{state?.hoveredCell?.count ?? "none"}</output>;
+};
+
+describe("Cell", () => {
+  it("preserves tooltip behavior when custom hover handlers are provided", () => {
+    const onMouseEnter = vi.fn();
+    const onMouseLeave = vi.fn();
+
+    render(
+      <Root
+        data={[{ date: "2025-01-13", count: 5 }]}
+        start="2025-01-13"
+        end="2025-01-13"
+        weekStart="monday"
+      >
+        <Grid>
+          {() => (
+            <Cell
+              data-testid="cell"
+              onMouseEnter={onMouseEnter}
+              onMouseLeave={onMouseLeave}
+            />
+          )}
+        </Grid>
+        <TooltipStateProbe />
+      </Root>,
+    );
+
+    const cell = screen.getByTestId("cell");
+    fireEvent.mouseEnter(cell);
+
+    expect(onMouseEnter).toHaveBeenCalledOnce();
+    expect(screen.getByRole("status").textContent).toBe("5");
+
+    fireEvent.mouseLeave(cell);
+
+    expect(onMouseLeave).toHaveBeenCalledOnce();
+    expect(screen.getByRole("status").textContent).toBe("none");
+  });
+});

--- a/packages/heat-graph/src/components/Cell.test.tsx
+++ b/packages/heat-graph/src/components/Cell.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { useTooltipState } from "../context";
 import { Cell } from "./Cell";
 import { Grid } from "./Grid";
@@ -45,5 +45,57 @@ describe("Cell", () => {
 
     expect(onMouseLeave).toHaveBeenCalledOnce();
     expect(screen.getByRole("status").textContent).toBe("none");
+  });
+
+  it("keeps the tooltip closed when custom enter handling prevents default", () => {
+    render(
+      <Root
+        data={[{ date: "2025-01-13", count: 5 }]}
+        start="2025-01-13"
+        end="2025-01-13"
+        weekStart="monday"
+      >
+        <Grid>
+          {() => (
+            <Cell
+              data-testid="cell"
+              onMouseEnter={(event) => event.preventDefault()}
+            />
+          )}
+        </Grid>
+        <TooltipStateProbe />
+      </Root>,
+    );
+
+    fireEvent.mouseEnter(screen.getByTestId("cell"));
+
+    expect(screen.getByRole("status").textContent).toBe("none");
+  });
+
+  it("keeps the tooltip open when custom leave handling prevents default", () => {
+    render(
+      <Root
+        data={[{ date: "2025-01-13", count: 5 }]}
+        start="2025-01-13"
+        end="2025-01-13"
+        weekStart="monday"
+      >
+        <Grid>
+          {() => (
+            <Cell
+              data-testid="cell"
+              onMouseLeave={(event) => event.preventDefault()}
+            />
+          )}
+        </Grid>
+        <TooltipStateProbe />
+      </Root>,
+    );
+
+    const cell = screen.getByTestId("cell");
+    fireEvent.mouseEnter(cell);
+    fireEvent.mouseLeave(cell);
+
+    expect(screen.getByRole("status").textContent).toBe("5");
   });
 });

--- a/packages/heat-graph/src/components/Cell.tsx
+++ b/packages/heat-graph/src/components/Cell.tsx
@@ -12,7 +12,10 @@ export type CellProps = ComponentPropsWithoutRef<"div"> & {
 };
 
 export const Cell = forwardRef<HTMLDivElement, CellProps>(
-  ({ colorScale: colorScaleProp, style, ...props }, ref) => {
+  (
+    { colorScale: colorScaleProp, style, onMouseEnter, onMouseLeave, ...props },
+    ref,
+  ) => {
     const cell = useCellContext();
     const { colorScale: colorScaleCtx } = useHeatGraphContext();
     const dispatch = useTooltipDispatch();
@@ -32,12 +35,16 @@ export const Cell = forwardRef<HTMLDivElement, CellProps>(
       <div
         ref={ref}
         style={mergedStyle}
-        onMouseEnter={
-          dispatch
-            ? (e) => dispatch.onCellEnter(cell, e.currentTarget)
-            : undefined
-        }
-        onMouseLeave={dispatch?.onCellLeave}
+        onMouseEnter={(event) => {
+          onMouseEnter?.(event);
+          if (event.defaultPrevented) return;
+          dispatch?.onCellEnter(cell, event.currentTarget);
+        }}
+        onMouseLeave={(event) => {
+          onMouseLeave?.(event);
+          if (event.defaultPrevented) return;
+          dispatch?.onCellLeave();
+        }}
         {...props}
       />
     );


### PR DESCRIPTION
## Problem

Passing `onMouseEnter` or `onMouseLeave` to `HeatGraph.Cell` replaces the component's internal tooltip handlers. A custom enter handler prevents the tooltip from opening, while a custom leave handler can leave it visible after the pointer exits. This affects `heat-graph` 0.0.18.

## Root cause

`Cell` applied its internal hover handlers before spreading consumer props, so React received only the consumer callbacks for matching event names.

## Change

Compose consumer hover callbacks with the internal tooltip dispatch. Consumer callbacks run first and can use `preventDefault()` to suppress the built-in tooltip behavior, matching the event composition convention used by other primitives.

## Verification

- Added a component regression test covering custom enter and leave handlers together with tooltip state.
- Confirmed the regression test fails on the original implementation because the tooltip remains closed.
- `pnpm --filter heat-graph test -- Cell.test.tsx`
- `pnpm exec oxlint packages/heat-graph/src/components/Cell.tsx packages/heat-graph/src/components/Cell.test.tsx`
- `pnpm --filter heat-graph build`
- `pnpm changesets:check`

## Public surface

`heat-graph` behavior changes only. No exports or type signatures change. Includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.UXlcc3mOCwoi8dgqmYbciZSEKC6pUmEJAa4OXS9b0dvK3IXE1OW-X_sdmUQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->