### PR TITLE
fix(react-native): scroll existing threads to the bottom

### DIFF
--- a/.changeset/calm-native-threads-scroll.md
+++ b/.changeset/calm-native-threads-scroll.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-native": patch
+---
+
+fix: scroll existing threads to their measured bottom offset

--- a/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
@@ -392,9 +392,10 @@ describe("ThreadMessages", () => {
 
       await emit("thread.runStart");
 
-      expect(h.scrollToOffset).toHaveBeenCalledWith(
-        expect.objectContaining({ animated: true }),
-      );
+      expect(h.scrollToOffset).toHaveBeenCalledWith({
+        animated: true,
+        offset: 0,
+      });
     });
 
     it("scrolls when content grows while already at the bottom", async () => {
@@ -465,6 +466,47 @@ describe("ThreadMessages", () => {
       expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
     });
 
+    it("waits for the first layout before consuming a measured initialize scroll", async () => {
+      h.state.thread.messages = [{ id: "1", role: "user" }];
+      await mountFlatList({ components: messageComponents });
+      const props = getFlatListProps();
+
+      await act(async () => {
+        props.onContentSizeChange?.(0, 140);
+      });
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        props.onLayout?.({
+          nativeEvent: { layout: { height: 100 } },
+        });
+      });
+
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
+      expect(h.scrollToOffset).toHaveBeenLastCalledWith({
+        animated: false,
+        offset: 40,
+      });
+    });
+
+    it("uses horizontal measurements for horizontal lists", async () => {
+      h.state.thread.messages = [{ id: "1", role: "user" }];
+      await mountFlatList({ components: messageComponents, horizontal: true });
+      const props = getFlatListProps();
+
+      await act(async () => {
+        props.onLayout?.({
+          nativeEvent: { layout: { width: 100 } },
+        });
+        props.onContentSizeChange?.(140, 0);
+      });
+
+      expect(h.scrollToOffset).toHaveBeenLastCalledWith({
+        animated: false,
+        offset: 40,
+      });
+    });
+
     it("lands the thread-switch scroll on the next content-size event", async () => {
       h.state.thread.messages = [{ id: "1", role: "user" }];
       await mountFlatList({ components: messageComponents });
@@ -477,8 +519,19 @@ describe("ThreadMessages", () => {
       await act(async () => {
         props.onContentSizeChange?.(0, 80);
       });
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        props.onLayout?.({
+          nativeEvent: { layout: { height: 100 } },
+        });
+      });
 
       expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
+      expect(h.scrollToOffset).toHaveBeenLastCalledWith({
+        animated: false,
+        offset: 0,
+      });
     });
 
     it("keeps following through consecutive growth events without scroll echoes", async () => {
@@ -581,9 +634,10 @@ describe("ThreadMessages", () => {
       });
 
       expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
-      expect(h.scrollToOffset).toHaveBeenLastCalledWith(
-        expect.objectContaining({ animated: true }),
-      );
+      expect(h.scrollToOffset).toHaveBeenLastCalledWith({
+        animated: true,
+        offset: 260,
+      });
     });
 
     it("scrolls to the bottom when switching threads", async () => {
@@ -593,9 +647,10 @@ describe("ThreadMessages", () => {
 
       await emit("threads.selectionChanged");
 
-      expect(h.scrollToOffset).toHaveBeenCalledWith(
-        expect.objectContaining({ animated: false }),
-      );
+      expect(h.scrollToOffset).toHaveBeenCalledWith({
+        animated: false,
+        offset: 0,
+      });
     });
 
     it("does not rearm initialize scroll when thread-switch scroll is disabled", async () => {
@@ -691,9 +746,10 @@ describe("ThreadMessages", () => {
         props.onContentSizeChange?.(0, 340);
       });
 
-      expect(h.scrollToOffset).toHaveBeenCalledWith(
-        expect.objectContaining({ animated: false }),
-      );
+      expect(h.scrollToOffset).toHaveBeenCalledWith({
+        animated: false,
+        offset: 280,
+      });
     });
 
     it("commands a bottom scroll when the viewport shrinks while pinned", async () => {
@@ -705,9 +761,10 @@ describe("ThreadMessages", () => {
         });
       });
 
-      expect(h.scrollToOffset).toHaveBeenCalledWith(
-        expect.objectContaining({ animated: false }),
-      );
+      expect(h.scrollToOffset).toHaveBeenCalledWith({
+        animated: false,
+        offset: 240,
+      });
     });
 
     it("preserves a pending animated scroll on a pinned viewport change", async () => {
@@ -722,9 +779,10 @@ describe("ThreadMessages", () => {
       });
 
       expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
-      expect(h.scrollToOffset).toHaveBeenCalledWith(
-        expect.objectContaining({ animated: true }),
-      );
+      expect(h.scrollToOffset).toHaveBeenCalledWith({
+        animated: true,
+        offset: 240,
+      });
     });
 
     it("ignores a layout event with an unchanged viewport height", async () => {
@@ -834,9 +892,10 @@ describe("ThreadMessages", () => {
         props.onContentSizeChange?.(0, 360);
       });
 
-      expect(h.scrollToOffset).toHaveBeenCalledWith(
-        expect.objectContaining({ animated: false }),
-      );
+      expect(h.scrollToOffset).toHaveBeenCalledWith({
+        animated: false,
+        offset: 260,
+      });
     });
 
     it("unpins and cancels a pending scroll on an upward gesture echo", async () => {
@@ -867,9 +926,10 @@ describe("ThreadMessages", () => {
       await act(async () => {
         props.onContentSizeChange?.(0, 340);
       });
-      expect(h.scrollToOffset).toHaveBeenCalledWith(
-        expect.objectContaining({ animated: false }),
-      );
+      expect(h.scrollToOffset).toHaveBeenCalledWith({
+        animated: false,
+        offset: 240,
+      });
 
       await act(async () => {
         props.onScroll?.({

--- a/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
@@ -489,6 +489,30 @@ describe("ThreadMessages", () => {
       });
     });
 
+    it("keeps the initialize scroll pending through a zero content measurement", async () => {
+      h.state.thread.messages = [{ id: "1", role: "user" }];
+      await mountFlatList({ components: messageComponents });
+      const props = getFlatListProps();
+
+      await act(async () => {
+        props.onLayout?.({
+          nativeEvent: { layout: { height: 100 } },
+        });
+        props.onContentSizeChange?.(0, 0);
+      });
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        props.onContentSizeChange?.(0, 300);
+      });
+
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
+      expect(h.scrollToOffset).toHaveBeenLastCalledWith({
+        animated: false,
+        offset: 200,
+      });
+    });
+
     it("uses horizontal measurements for horizontal lists", async () => {
       h.state.thread.messages = [{ id: "1", role: "user" }];
       await mountFlatList({ components: messageComponents, horizontal: true });
@@ -684,7 +708,7 @@ describe("ThreadMessages", () => {
         });
         props.onScroll?.({
           nativeEvent: {
-            contentOffset: { y: 200 },
+            contentOffset: { y: 120 },
             contentSize: { height: 300, width: 0 },
             layoutMeasurement: { height: 100, width: 0 },
           },
@@ -824,12 +848,13 @@ describe("ThreadMessages", () => {
         props.onLayout?.({
           nativeEvent: { layout: { height: 60 } },
         });
+        props.onContentSizeChange?.(0, 360);
       });
 
-      expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
-      expect(h.scrollToOffset).toHaveBeenCalledWith({
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
+      expect(h.scrollToOffset).toHaveBeenLastCalledWith({
         animated: true,
-        offset: 240,
+        offset: 300,
       });
     });
 

--- a/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
@@ -517,7 +517,7 @@ describe("ThreadMessages", () => {
       expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
 
       await act(async () => {
-        props.onContentSizeChange?.(0, 80);
+        props.onContentSizeChange?.(0, 300);
       });
       expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
 
@@ -530,7 +530,7 @@ describe("ThreadMessages", () => {
       expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
       expect(h.scrollToOffset).toHaveBeenLastCalledWith({
         animated: false,
-        offset: 0,
+        offset: 200,
       });
     });
 
@@ -558,12 +558,12 @@ describe("ThreadMessages", () => {
         props.onLayout?.({
           nativeEvent: { layout: { height: 80 } },
         });
-        props.onContentSizeChange?.(0, 60);
+        props.onContentSizeChange?.(0, 260);
       });
 
       expect(h.scrollToOffset).toHaveBeenLastCalledWith({
         animated: false,
-        offset: 0,
+        offset: 180,
       });
     });
 
@@ -673,16 +673,31 @@ describe("ThreadMessages", () => {
       });
     });
 
-    it("scrolls to the bottom when switching threads", async () => {
+    it("uses the measured bottom when a thread switch does not resize content", async () => {
       h.state.thread.messages = [{ id: "1", role: "user" }];
       await mountFlatList({ components: messageComponents });
+      const props = getFlatListProps();
+
+      await act(async () => {
+        props.onLayout?.({
+          nativeEvent: { layout: { height: 100 } },
+        });
+        props.onScroll?.({
+          nativeEvent: {
+            contentOffset: { y: 200 },
+            contentSize: { height: 300, width: 0 },
+            layoutMeasurement: { height: 100, width: 0 },
+          },
+        });
+      });
       h.scrollToOffset.mockClear();
 
       await emit("threads.selectionChanged");
 
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
       expect(h.scrollToOffset).toHaveBeenCalledWith({
         animated: false,
-        offset: 0,
+        offset: 200,
       });
     });
 

--- a/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
@@ -9,7 +9,6 @@ type Msg = { id: string; role: string };
 
 const h = vi.hoisted(() => ({
   state: {
-    threads: { mainThreadId: "thread-a" },
     thread: { messages: [] as Msg[] },
     message: { role: "user" as string, composer: { isEditing: false } },
   },
@@ -116,7 +115,6 @@ describe("ThreadMessages", () => {
   let root: Root;
 
   beforeEach(() => {
-    h.state.threads.mainThreadId = "thread-a";
     h.state.thread.messages = [];
     h.state.message.role = "user";
     h.state.message.composer.isEditing = false;
@@ -590,41 +588,6 @@ describe("ThreadMessages", () => {
       expect(h.scrollToOffset).toHaveBeenLastCalledWith({
         animated: false,
         offset: 180,
-      });
-    });
-
-    it("ignores content measurements queued by the previous thread", async () => {
-      h.state.thread.messages = [{ id: "1", role: "user" }];
-      await mountFlatList({ components: messageComponents });
-      const previousThreadProps = getFlatListProps();
-
-      await act(async () => {
-        previousThreadProps.onLayout?.({
-          nativeEvent: { layout: { height: 100 } },
-        });
-        previousThreadProps.onContentSizeChange?.(0, 300);
-      });
-      h.scrollToOffset.mockClear();
-
-      h.state.threads.mainThreadId = "thread-b";
-      h.state.thread.messages = [{ id: "2", role: "assistant" }];
-      await mountFlatList({ components: messageComponents });
-      const currentThreadProps = getFlatListProps();
-      await emit("threads.selectionChanged");
-
-      await act(async () => {
-        previousThreadProps.onContentSizeChange?.(0, 700);
-      });
-      expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
-
-      await act(async () => {
-        currentThreadProps.onContentSizeChange?.(0, 500);
-      });
-
-      expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
-      expect(h.scrollToOffset).toHaveBeenLastCalledWith({
-        animated: false,
-        offset: 400,
       });
     });
 

--- a/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
@@ -9,6 +9,7 @@ type Msg = { id: string; role: string };
 
 const h = vi.hoisted(() => ({
   state: {
+    threads: { mainThreadId: "thread-a" },
     thread: { messages: [] as Msg[] },
     message: { role: "user" as string, composer: { isEditing: false } },
   },
@@ -115,6 +116,7 @@ describe("ThreadMessages", () => {
   let root: Root;
 
   beforeEach(() => {
+    h.state.threads.mainThreadId = "thread-a";
     h.state.thread.messages = [];
     h.state.message.role = "user";
     h.state.message.composer.isEditing = false;
@@ -588,6 +590,41 @@ describe("ThreadMessages", () => {
       expect(h.scrollToOffset).toHaveBeenLastCalledWith({
         animated: false,
         offset: 180,
+      });
+    });
+
+    it("ignores content measurements queued by the previous thread", async () => {
+      h.state.thread.messages = [{ id: "1", role: "user" }];
+      await mountFlatList({ components: messageComponents });
+      const previousThreadProps = getFlatListProps();
+
+      await act(async () => {
+        previousThreadProps.onLayout?.({
+          nativeEvent: { layout: { height: 100 } },
+        });
+        previousThreadProps.onContentSizeChange?.(0, 300);
+      });
+      h.scrollToOffset.mockClear();
+
+      h.state.threads.mainThreadId = "thread-b";
+      h.state.thread.messages = [{ id: "2", role: "assistant" }];
+      await mountFlatList({ components: messageComponents });
+      const currentThreadProps = getFlatListProps();
+      await emit("threads.selectionChanged");
+
+      await act(async () => {
+        previousThreadProps.onContentSizeChange?.(0, 700);
+      });
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        currentThreadProps.onContentSizeChange?.(0, 500);
+      });
+
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
+      expect(h.scrollToOffset).toHaveBeenLastCalledWith({
+        animated: false,
+        offset: 400,
       });
     });
 

--- a/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
@@ -15,7 +15,7 @@ const h = vi.hoisted(() => ({
   itemState: { role: "user" } as { role: string },
   events: {} as Record<string, Set<() => void>>,
   flatListProps: null as Record<string, unknown> | null,
-  scrollToEnd: vi.fn(),
+  scrollToOffset: vi.fn(),
 }));
 
 vi.mock("react-native", async (importOriginal) => {
@@ -29,7 +29,7 @@ vi.mock("react-native", async (importOriginal) => {
     h.flatListProps = props;
 
     React.useImperativeHandle(ref, () => ({
-      scrollToEnd: h.scrollToEnd,
+      scrollToOffset: h.scrollToOffset,
     }));
 
     const data = (props.data as unknown[]) ?? [];
@@ -121,7 +121,7 @@ describe("ThreadMessages", () => {
     h.itemState = { role: "user" };
     h.events = {};
     h.flatListProps = null;
-    h.scrollToEnd.mockReset();
+    h.scrollToOffset.mockReset();
 
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -370,7 +370,7 @@ describe("ThreadMessages", () => {
     await emit("thread.runStart");
     await emit("threads.selectionChanged");
 
-    expect(h.scrollToEnd).not.toHaveBeenCalled();
+    expect(h.scrollToOffset).not.toHaveBeenCalled();
   });
 
   describe("MessagesFlatList auto-scroll", () => {
@@ -379,24 +379,29 @@ describe("ThreadMessages", () => {
 
       await mountFlatList({ components: messageComponents });
 
-      expect(h.scrollToEnd).toHaveBeenCalledWith({ animated: false });
+      expect(h.scrollToOffset).toHaveBeenCalledWith({
+        animated: false,
+        offset: 0,
+      });
     });
 
     it("scrolls to the bottom when a run starts", async () => {
       h.state.thread.messages = [{ id: "1", role: "user" }];
       await mountFlatList({ components: messageComponents });
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
 
       await emit("thread.runStart");
 
-      expect(h.scrollToEnd).toHaveBeenCalledWith({ animated: true });
+      expect(h.scrollToOffset).toHaveBeenCalledWith(
+        expect.objectContaining({ animated: true }),
+      );
     });
 
     it("scrolls when content grows while already at the bottom", async () => {
       h.state.thread.messages = [{ id: "1", role: "user" }];
       await mountFlatList({ components: messageComponents });
       const props = getFlatListProps();
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
 
       await act(async () => {
         props.onLayout?.({
@@ -412,7 +417,10 @@ describe("ThreadMessages", () => {
         props.onContentSizeChange?.(0, 140);
       });
 
-      expect(h.scrollToEnd).toHaveBeenCalledWith({ animated: false });
+      expect(h.scrollToOffset).toHaveBeenCalledWith({
+        animated: false,
+        offset: 40,
+      });
     });
 
     it("does not treat the first content-size event as automatic content growth", async () => {
@@ -427,7 +435,7 @@ describe("ThreadMessages", () => {
         props.onContentSizeChange?.(0, 140);
       });
 
-      expect(h.scrollToEnd).not.toHaveBeenCalled();
+      expect(h.scrollToOffset).not.toHaveBeenCalled();
     });
 
     it("lands the initialize scroll on the first content-size event", async () => {
@@ -435,35 +443,42 @@ describe("ThreadMessages", () => {
       await mountFlatList({ components: messageComponents });
       const props = getFlatListProps();
 
-      expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        props.onLayout?.({
+          nativeEvent: { layout: { height: 100 } },
+        });
+        props.onContentSizeChange?.(0, 140);
+      });
+
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
+      expect(h.scrollToOffset).toHaveBeenLastCalledWith({
+        animated: false,
+        offset: 40,
+      });
 
       await act(async () => {
         props.onContentSizeChange?.(0, 140);
       });
 
-      expect(h.scrollToEnd).toHaveBeenCalledTimes(2);
-
-      await act(async () => {
-        props.onContentSizeChange?.(0, 140);
-      });
-
-      expect(h.scrollToEnd).toHaveBeenCalledTimes(2);
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
     });
 
     it("lands the thread-switch scroll on the next content-size event", async () => {
       h.state.thread.messages = [{ id: "1", role: "user" }];
       await mountFlatList({ components: messageComponents });
       const props = getFlatListProps();
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
 
       await emit("threads.selectionChanged");
-      expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
 
       await act(async () => {
         props.onContentSizeChange?.(0, 80);
       });
 
-      expect(h.scrollToEnd).toHaveBeenCalledTimes(2);
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
     });
 
     it("keeps following through consecutive growth events without scroll echoes", async () => {
@@ -483,7 +498,7 @@ describe("ThreadMessages", () => {
           },
         });
       });
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
 
       await act(async () => {
         props.onContentSizeChange?.(0, 140);
@@ -492,14 +507,14 @@ describe("ThreadMessages", () => {
         props.onContentSizeChange?.(0, 180);
       });
 
-      expect(h.scrollToEnd).toHaveBeenCalledTimes(2);
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
     });
 
     it("does not scroll when content grows after the user scrolled away", async () => {
       h.state.thread.messages = [{ id: "1", role: "user" }];
       await mountFlatList({ components: messageComponents });
       const props = getFlatListProps();
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
 
       await act(async () => {
         props.onLayout?.({
@@ -522,7 +537,7 @@ describe("ThreadMessages", () => {
         props.onContentSizeChange?.(0, 340);
       });
 
-      expect(h.scrollToEnd).not.toHaveBeenCalled();
+      expect(h.scrollToOffset).not.toHaveBeenCalled();
     });
 
     it("lands the run-start scroll once the appended message resizes content", async () => {
@@ -549,10 +564,10 @@ describe("ThreadMessages", () => {
           },
         });
       });
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
 
       await emit("thread.runStart");
-      expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
 
       await act(async () => {
         props.onScroll?.({
@@ -565,18 +580,22 @@ describe("ThreadMessages", () => {
         props.onContentSizeChange?.(0, 360);
       });
 
-      expect(h.scrollToEnd).toHaveBeenCalledTimes(2);
-      expect(h.scrollToEnd).toHaveBeenLastCalledWith({ animated: true });
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(2);
+      expect(h.scrollToOffset).toHaveBeenLastCalledWith(
+        expect.objectContaining({ animated: true }),
+      );
     });
 
     it("scrolls to the bottom when switching threads", async () => {
       h.state.thread.messages = [{ id: "1", role: "user" }];
       await mountFlatList({ components: messageComponents });
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
 
       await emit("threads.selectionChanged");
 
-      expect(h.scrollToEnd).toHaveBeenCalledWith({ animated: false });
+      expect(h.scrollToOffset).toHaveBeenCalledWith(
+        expect.objectContaining({ animated: false }),
+      );
     });
 
     it("does not rearm initialize scroll when thread-switch scroll is disabled", async () => {
@@ -585,7 +604,7 @@ describe("ThreadMessages", () => {
         components: messageComponents,
         scrollToBottomOnThreadSwitch: false,
       });
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
 
       await emit("threads.selectionChanged");
 
@@ -598,7 +617,7 @@ describe("ThreadMessages", () => {
         scrollToBottomOnThreadSwitch: false,
       });
 
-      expect(h.scrollToEnd).not.toHaveBeenCalled();
+      expect(h.scrollToOffset).not.toHaveBeenCalled();
     });
 
     it("honors opt-outs for automatic content growth and run-start scrolls", async () => {
@@ -610,7 +629,7 @@ describe("ThreadMessages", () => {
         scrollToBottomOnRunStart: false,
       });
       const props = getFlatListProps();
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
 
       await act(async () => {
         props.onLayout?.({
@@ -627,7 +646,7 @@ describe("ThreadMessages", () => {
       });
       await emit("thread.runStart");
 
-      expect(h.scrollToEnd).not.toHaveBeenCalled();
+      expect(h.scrollToOffset).not.toHaveBeenCalled();
     });
 
     it("sets a useful default scroll throttle", async () => {
@@ -655,7 +674,7 @@ describe("ThreadMessages", () => {
         });
         props.onContentSizeChange?.(0, 300);
       });
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
       return props;
     };
 
@@ -667,12 +686,14 @@ describe("ThreadMessages", () => {
           nativeEvent: { layout: { height: 60 } },
         });
       });
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
       await act(async () => {
         props.onContentSizeChange?.(0, 340);
       });
 
-      expect(h.scrollToEnd).toHaveBeenCalledWith({ animated: false });
+      expect(h.scrollToOffset).toHaveBeenCalledWith(
+        expect.objectContaining({ animated: false }),
+      );
     });
 
     it("commands a bottom scroll when the viewport shrinks while pinned", async () => {
@@ -684,22 +705,26 @@ describe("ThreadMessages", () => {
         });
       });
 
-      expect(h.scrollToEnd).toHaveBeenCalledWith({ animated: false });
+      expect(h.scrollToOffset).toHaveBeenCalledWith(
+        expect.objectContaining({ animated: false }),
+      );
     });
 
     it("preserves a pending animated scroll on a pinned viewport change", async () => {
       const props = await mountPinned();
 
       await emit("thread.runStart");
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
       await act(async () => {
         props.onLayout?.({
           nativeEvent: { layout: { height: 60 } },
         });
       });
 
-      expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
-      expect(h.scrollToEnd).toHaveBeenCalledWith({ animated: true });
+      expect(h.scrollToOffset).toHaveBeenCalledTimes(1);
+      expect(h.scrollToOffset).toHaveBeenCalledWith(
+        expect.objectContaining({ animated: true }),
+      );
     });
 
     it("ignores a layout event with an unchanged viewport height", async () => {
@@ -711,13 +736,13 @@ describe("ThreadMessages", () => {
         });
       });
 
-      expect(h.scrollToEnd).not.toHaveBeenCalled();
+      expect(h.scrollToOffset).not.toHaveBeenCalled();
     });
 
     it("does not command a scroll on the first layout measurement", async () => {
       await mountFlatList({ components: messageComponents });
       getFlatListProps();
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
 
       await act(async () => {
         getFlatListProps().onLayout?.({
@@ -725,7 +750,7 @@ describe("ThreadMessages", () => {
         });
       });
 
-      expect(h.scrollToEnd).not.toHaveBeenCalled();
+      expect(h.scrollToOffset).not.toHaveBeenCalled();
     });
 
     it("does not command a scroll on viewport change when autoScroll is off", async () => {
@@ -744,7 +769,7 @@ describe("ThreadMessages", () => {
         });
         props.onContentSizeChange?.(0, 300);
       });
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
 
       await act(async () => {
         props.onLayout?.({
@@ -752,7 +777,7 @@ describe("ThreadMessages", () => {
         });
       });
 
-      expect(h.scrollToEnd).not.toHaveBeenCalled();
+      expect(h.scrollToOffset).not.toHaveBeenCalled();
     });
 
     it("stays unpinned when the viewport shrinks after scrolling away", async () => {
@@ -776,7 +801,7 @@ describe("ThreadMessages", () => {
         props.onContentSizeChange?.(0, 340);
       });
 
-      expect(h.scrollToEnd).not.toHaveBeenCalled();
+      expect(h.scrollToOffset).not.toHaveBeenCalled();
     });
 
     it("keeps the pin through a downward scroll echo after a commanded scroll", async () => {
@@ -795,7 +820,7 @@ describe("ThreadMessages", () => {
       await act(async () => {
         props.onContentSizeChange?.(0, 320);
       });
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
       await act(async () => {
         props.onScroll?.({
           nativeEvent: {
@@ -809,14 +834,16 @@ describe("ThreadMessages", () => {
         props.onContentSizeChange?.(0, 360);
       });
 
-      expect(h.scrollToEnd).toHaveBeenCalledWith({ animated: false });
+      expect(h.scrollToOffset).toHaveBeenCalledWith(
+        expect.objectContaining({ animated: false }),
+      );
     });
 
     it("unpins and cancels a pending scroll on an upward gesture echo", async () => {
       const props = await mountPinned();
 
       await emit("thread.runStart");
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
       await act(async () => {
         props.onScroll?.({
           nativeEvent: {
@@ -830,17 +857,19 @@ describe("ThreadMessages", () => {
         props.onContentSizeChange?.(0, 360);
       });
 
-      expect(h.scrollToEnd).not.toHaveBeenCalled();
+      expect(h.scrollToOffset).not.toHaveBeenCalled();
     });
 
     it("scrolls on content growth while pinned and stays put while unpinned", async () => {
       const props = await mountPinned();
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
 
       await act(async () => {
         props.onContentSizeChange?.(0, 340);
       });
-      expect(h.scrollToEnd).toHaveBeenCalledWith({ animated: false });
+      expect(h.scrollToOffset).toHaveBeenCalledWith(
+        expect.objectContaining({ animated: false }),
+      );
 
       await act(async () => {
         props.onScroll?.({
@@ -851,12 +880,12 @@ describe("ThreadMessages", () => {
           },
         });
       });
-      h.scrollToEnd.mockClear();
+      h.scrollToOffset.mockClear();
       await act(async () => {
         props.onContentSizeChange?.(0, 380);
       });
 
-      expect(h.scrollToEnd).not.toHaveBeenCalled();
+      expect(h.scrollToOffset).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
@@ -534,6 +534,39 @@ describe("ThreadMessages", () => {
       });
     });
 
+    it("does not consume a thread-switch scroll with the previous thread metrics", async () => {
+      h.state.thread.messages = [{ id: "1", role: "user" }];
+      await mountFlatList({ components: messageComponents });
+      const props = getFlatListProps();
+
+      await act(async () => {
+        props.onLayout?.({
+          nativeEvent: { layout: { height: 100 } },
+        });
+        props.onScroll?.({
+          nativeEvent: {
+            contentOffset: { y: 200 },
+            contentSize: { height: 300, width: 0 },
+            layoutMeasurement: { height: 100, width: 0 },
+          },
+        });
+      });
+      h.scrollToOffset.mockClear();
+
+      await emit("threads.selectionChanged");
+      await act(async () => {
+        props.onLayout?.({
+          nativeEvent: { layout: { height: 80 } },
+        });
+        props.onContentSizeChange?.(0, 60);
+      });
+
+      expect(h.scrollToOffset).toHaveBeenLastCalledWith({
+        animated: false,
+        offset: 0,
+      });
+    });
+
     it("keeps following through consecutive growth events without scroll echoes", async () => {
       h.state.thread.messages = [{ id: "1", role: "user" }];
       await mountFlatList({ components: messageComponents });

--- a/packages/react-native/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.tsx
@@ -206,6 +206,7 @@ const useComposedFlatListRef = (
 const useThreadMessagesFlatListAutoScroll = ({
   flatListRef,
   hasMessages,
+  horizontal = false,
   autoScroll = true,
   scrollToBottomOnRunStart = true,
   scrollToBottomOnInitialize = true,
@@ -213,6 +214,7 @@ const useThreadMessagesFlatListAutoScroll = ({
 }: {
   flatListRef: RefObject<FlatList<ThreadMessage> | null>;
   hasMessages: boolean;
+  horizontal?: boolean | null | undefined;
   autoScroll?: boolean | undefined;
   scrollToBottomOnRunStart?: boolean | undefined;
   scrollToBottomOnInitialize?: boolean | undefined;
@@ -224,7 +226,7 @@ const useThreadMessagesFlatListAutoScroll = ({
     scrollY: 0,
   });
   const isAtBottomRef = useRef(true);
-  const lastScrollEventYRef = useRef(0);
+  const lastScrollEventOffsetRef = useRef(0);
   const initializeScrollRequestedRef = useRef(false);
   const pendingScrollToBottomRef = useRef<false | { animated: boolean }>(false);
 
@@ -253,9 +255,21 @@ const useThreadMessagesFlatListAutoScroll = ({
     (event: LayoutChangeEvent) => {
       const wasAtBottom = isAtBottomRef.current;
       const previousViewportHeight = metricsRef.current.viewportHeight;
-      const viewportHeight = event.nativeEvent.layout.height;
+      const viewportHeight = horizontal
+        ? event.nativeEvent.layout.width
+        : event.nativeEvent.layout.height;
       metricsRef.current.viewportHeight = viewportHeight;
       updateIsAtBottom();
+      const pending = pendingScrollToBottomRef.current;
+      if (
+        pending &&
+        metricsRef.current.contentHeight > 0 &&
+        viewportHeight > 0
+      ) {
+        pendingScrollToBottomRef.current = false;
+        scrollToBottom(pending.animated);
+        return;
+      }
       if (!wasAtBottom) return;
       // Layout changes are never user gestures, so they must not unpin. Past
       // the first measurement, a viewport change while pinned re-commands the
@@ -266,29 +280,31 @@ const useThreadMessagesFlatListAutoScroll = ({
         previousViewportHeight !== 0 &&
         viewportHeight !== previousViewportHeight
       ) {
-        const pending = pendingScrollToBottomRef.current;
         scrollToBottom(pending ? pending.animated : false);
       } else {
         isAtBottomRef.current = true;
       }
     },
-    [autoScroll, scrollToBottom, updateIsAtBottom],
+    [autoScroll, horizontal, scrollToBottom, updateIsAtBottom],
   );
 
   const handleScroll = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
       const { contentOffset, contentSize, layoutMeasurement } =
         event.nativeEvent;
-      const previousEventY = lastScrollEventYRef.current;
+      const scrollOffset = horizontal ? contentOffset.x : contentOffset.y;
+      const previousEventOffset = lastScrollEventOffsetRef.current;
       const wasPinnedToBottom = isAtBottomRef.current;
-      lastScrollEventYRef.current = contentOffset.y;
+      lastScrollEventOffsetRef.current = scrollOffset;
       metricsRef.current = {
-        contentHeight: contentSize.height,
-        viewportHeight: layoutMeasurement.height,
-        scrollY: contentOffset.y,
+        contentHeight: horizontal ? contentSize.width : contentSize.height,
+        viewportHeight: horizontal
+          ? layoutMeasurement.width
+          : layoutMeasurement.height,
+        scrollY: scrollOffset,
       };
       updateIsAtBottom();
-      const upwardMove = contentOffset.y < previousEventY;
+      const upwardMove = scrollOffset < previousEventOffset;
       // Only a deliberate upward move unpins or cancels a pending scroll.
       // Gestures are detected echo-to-echo because a commanded scroll
       // optimistically moves the tracked position ahead of its ascending
@@ -300,21 +316,22 @@ const useThreadMessagesFlatListAutoScroll = ({
         pendingScrollToBottomRef.current = false;
       }
     },
-    [updateIsAtBottom],
+    [horizontal, updateIsAtBottom],
   );
 
   const handleContentSizeChange = useCallback(
-    (_width: number, height: number) => {
+    (width: number, height: number) => {
       const metrics = metricsRef.current;
+      const contentHeight = horizontal ? width : height;
       const previousContentHeight = metrics.contentHeight;
       const wasAtBottom = isAtBottomRef.current;
-      metrics.contentHeight = height;
+      metrics.contentHeight = contentHeight;
       updateIsAtBottom();
 
       // Initialize and thread-switch requests are repeated after the list has
       // measured so the explicit bottom offset uses real content metrics.
       const pendingScroll = pendingScrollToBottomRef.current;
-      if (pendingScroll) {
+      if (pendingScroll && metrics.viewportHeight > 0) {
         pendingScrollToBottomRef.current = false;
         scrollToBottom(pendingScroll.animated);
         return;
@@ -323,11 +340,11 @@ const useThreadMessagesFlatListAutoScroll = ({
       if (!autoScroll) return;
       if (!wasAtBottom) return;
       if (previousContentHeight === 0) return;
-      if (height <= previousContentHeight) return;
+      if (contentHeight <= previousContentHeight) return;
 
       scrollToBottom(false);
     },
-    [autoScroll, scrollToBottom, updateIsAtBottom],
+    [autoScroll, horizontal, scrollToBottom, updateIsAtBottom],
   );
 
   useEffect(() => {
@@ -352,7 +369,7 @@ const useThreadMessagesFlatListAutoScroll = ({
   useAuiEvent("threads.selectionChanged", () => {
     if (!scrollToBottomOnThreadSwitch) return;
     initializeScrollRequestedRef.current = false;
-    lastScrollEventYRef.current = 0;
+    lastScrollEventOffsetRef.current = 0;
     pendingScrollToBottomRef.current = { animated: false };
     scrollToBottom(false);
   });
@@ -393,6 +410,7 @@ export const ThreadMessagesFlatList = forwardRef<
     } = useThreadMessagesFlatListAutoScroll({
       flatListRef,
       hasMessages: messages.length > 0,
+      horizontal: flatListProps.horizontal,
       autoScroll,
       scrollToBottomOnInitialize,
       scrollToBottomOnRunStart,

--- a/packages/react-native/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.tsx
@@ -8,6 +8,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
 } from "react";
 import {
@@ -205,6 +206,7 @@ const useComposedFlatListRef = (
 
 const useThreadMessagesFlatListAutoScroll = ({
   flatListRef,
+  threadId,
   hasMessages,
   horizontal = false,
   autoScroll = true,
@@ -213,6 +215,7 @@ const useThreadMessagesFlatListAutoScroll = ({
   scrollToBottomOnThreadSwitch = true,
 }: {
   flatListRef: RefObject<FlatList<ThreadMessage> | null>;
+  threadId: string;
   hasMessages: boolean;
   horizontal?: boolean | null | undefined;
   autoScroll?: boolean | undefined;
@@ -226,6 +229,7 @@ const useThreadMessagesFlatListAutoScroll = ({
     scrollY: 0,
   });
   const isAtBottomRef = useRef(true);
+  const activeThreadIdRef = useRef(threadId);
   const lastScrollEventOffsetRef = useRef(0);
   const initializeScrollRequestedRef = useRef(false);
   const contentSizeVersionRef = useRef(0);
@@ -236,6 +240,10 @@ const useThreadMessagesFlatListAutoScroll = ({
         minimumContentSizeVersion: number;
       }
   >(false);
+
+  useLayoutEffect(() => {
+    activeThreadIdRef.current = threadId;
+  }, [threadId]);
 
   const updateIsAtBottom = useCallback(() => {
     const { contentHeight, scrollY, viewportHeight } = metricsRef.current;
@@ -260,6 +268,8 @@ const useThreadMessagesFlatListAutoScroll = ({
 
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => {
+      if (activeThreadIdRef.current !== threadId) return;
+
       const wasAtBottom = isAtBottomRef.current;
       const previousViewportHeight = metricsRef.current.viewportHeight;
       const viewportHeight = horizontal
@@ -292,11 +302,13 @@ const useThreadMessagesFlatListAutoScroll = ({
         isAtBottomRef.current = true;
       }
     },
-    [autoScroll, horizontal, scrollToBottom, updateIsAtBottom],
+    [autoScroll, horizontal, scrollToBottom, threadId, updateIsAtBottom],
   );
 
   const handleScroll = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (activeThreadIdRef.current !== threadId) return;
+
       const { contentOffset, contentSize, layoutMeasurement } =
         event.nativeEvent;
       const scrollOffset = horizontal ? contentOffset.x : contentOffset.y;
@@ -323,11 +335,13 @@ const useThreadMessagesFlatListAutoScroll = ({
         pendingScrollToBottomRef.current = false;
       }
     },
-    [horizontal, updateIsAtBottom],
+    [horizontal, threadId, updateIsAtBottom],
   );
 
   const handleContentSizeChange = useCallback(
     (width: number, height: number) => {
+      if (activeThreadIdRef.current !== threadId) return;
+
       const metrics = metricsRef.current;
       const contentHeight = horizontal ? width : height;
       const previousContentHeight = metrics.contentHeight;
@@ -357,7 +371,7 @@ const useThreadMessagesFlatListAutoScroll = ({
 
       scrollToBottom(false);
     },
-    [autoScroll, horizontal, scrollToBottom, updateIsAtBottom],
+    [autoScroll, horizontal, scrollToBottom, threadId, updateIsAtBottom],
   );
 
   useEffect(() => {
@@ -424,6 +438,7 @@ export const ThreadMessagesFlatList = forwardRef<
     forwardedRef,
   ) => {
     const messages = useAuiState((s) => s.thread.messages);
+    const threadId = useAuiState((s) => s.threads.mainThreadId);
     const [flatListRef, setFlatListRef] = useComposedFlatListRef(forwardedRef);
     const {
       handleContentSizeChange: handleAutoScrollContentSizeChange,
@@ -431,6 +446,7 @@ export const ThreadMessagesFlatList = forwardRef<
       handleScroll: handleAutoScrollScroll,
     } = useThreadMessagesFlatListAutoScroll({
       flatListRef,
+      threadId,
       hasMessages: messages.length > 0,
       horizontal: flatListProps.horizontal,
       autoScroll,
@@ -487,6 +503,7 @@ export const ThreadMessagesFlatList = forwardRef<
 
     return (
       <FlatList
+        key={threadId}
         ref={setFlatListRef}
         data={messages as unknown as ThreadMessage[]}
         renderItem={renderItem}

--- a/packages/react-native/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.tsx
@@ -8,7 +8,6 @@ import {
   memo,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useRef,
 } from "react";
 import {
@@ -206,7 +205,6 @@ const useComposedFlatListRef = (
 
 const useThreadMessagesFlatListAutoScroll = ({
   flatListRef,
-  threadId,
   hasMessages,
   horizontal = false,
   autoScroll = true,
@@ -215,7 +213,6 @@ const useThreadMessagesFlatListAutoScroll = ({
   scrollToBottomOnThreadSwitch = true,
 }: {
   flatListRef: RefObject<FlatList<ThreadMessage> | null>;
-  threadId: string;
   hasMessages: boolean;
   horizontal?: boolean | null | undefined;
   autoScroll?: boolean | undefined;
@@ -229,7 +226,6 @@ const useThreadMessagesFlatListAutoScroll = ({
     scrollY: 0,
   });
   const isAtBottomRef = useRef(true);
-  const activeThreadIdRef = useRef(threadId);
   const lastScrollEventOffsetRef = useRef(0);
   const initializeScrollRequestedRef = useRef(false);
   const contentSizeVersionRef = useRef(0);
@@ -240,10 +236,6 @@ const useThreadMessagesFlatListAutoScroll = ({
         minimumContentSizeVersion: number;
       }
   >(false);
-
-  useLayoutEffect(() => {
-    activeThreadIdRef.current = threadId;
-  }, [threadId]);
 
   const updateIsAtBottom = useCallback(() => {
     const { contentHeight, scrollY, viewportHeight } = metricsRef.current;
@@ -268,8 +260,6 @@ const useThreadMessagesFlatListAutoScroll = ({
 
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => {
-      if (activeThreadIdRef.current !== threadId) return;
-
       const wasAtBottom = isAtBottomRef.current;
       const previousViewportHeight = metricsRef.current.viewportHeight;
       const viewportHeight = horizontal
@@ -302,13 +292,11 @@ const useThreadMessagesFlatListAutoScroll = ({
         isAtBottomRef.current = true;
       }
     },
-    [autoScroll, horizontal, scrollToBottom, threadId, updateIsAtBottom],
+    [autoScroll, horizontal, scrollToBottom, updateIsAtBottom],
   );
 
   const handleScroll = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      if (activeThreadIdRef.current !== threadId) return;
-
       const { contentOffset, contentSize, layoutMeasurement } =
         event.nativeEvent;
       const scrollOffset = horizontal ? contentOffset.x : contentOffset.y;
@@ -335,13 +323,11 @@ const useThreadMessagesFlatListAutoScroll = ({
         pendingScrollToBottomRef.current = false;
       }
     },
-    [horizontal, threadId, updateIsAtBottom],
+    [horizontal, updateIsAtBottom],
   );
 
   const handleContentSizeChange = useCallback(
     (width: number, height: number) => {
-      if (activeThreadIdRef.current !== threadId) return;
-
       const metrics = metricsRef.current;
       const contentHeight = horizontal ? width : height;
       const previousContentHeight = metrics.contentHeight;
@@ -371,7 +357,7 @@ const useThreadMessagesFlatListAutoScroll = ({
 
       scrollToBottom(false);
     },
-    [autoScroll, horizontal, scrollToBottom, threadId, updateIsAtBottom],
+    [autoScroll, horizontal, scrollToBottom, updateIsAtBottom],
   );
 
   useEffect(() => {
@@ -438,7 +424,6 @@ export const ThreadMessagesFlatList = forwardRef<
     forwardedRef,
   ) => {
     const messages = useAuiState((s) => s.thread.messages);
-    const threadId = useAuiState((s) => s.threads.mainThreadId);
     const [flatListRef, setFlatListRef] = useComposedFlatListRef(forwardedRef);
     const {
       handleContentSizeChange: handleAutoScrollContentSizeChange,
@@ -446,7 +431,6 @@ export const ThreadMessagesFlatList = forwardRef<
       handleScroll: handleAutoScrollScroll,
     } = useThreadMessagesFlatListAutoScroll({
       flatListRef,
-      threadId,
       hasMessages: messages.length > 0,
       horizontal: flatListProps.horizontal,
       autoScroll,

--- a/packages/react-native/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.tsx
@@ -503,7 +503,6 @@ export const ThreadMessagesFlatList = forwardRef<
 
     return (
       <FlatList
-        key={threadId}
         ref={setFlatListRef}
         data={messages as unknown as ThreadMessage[]}
         renderItem={renderItem}

--- a/packages/react-native/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.tsx
@@ -370,6 +370,8 @@ const useThreadMessagesFlatListAutoScroll = ({
     if (!scrollToBottomOnThreadSwitch) return;
     initializeScrollRequestedRef.current = false;
     lastScrollEventOffsetRef.current = 0;
+    metricsRef.current.contentHeight = 0;
+    metricsRef.current.scrollY = 0;
     pendingScrollToBottomRef.current = { animated: false };
     scrollToBottom(false);
   });

--- a/packages/react-native/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.tsx
@@ -228,8 +228,14 @@ const useThreadMessagesFlatListAutoScroll = ({
   const isAtBottomRef = useRef(true);
   const lastScrollEventOffsetRef = useRef(0);
   const initializeScrollRequestedRef = useRef(false);
-  const pendingScrollToBottomRef = useRef<false | { animated: boolean }>(false);
-  const contentMeasuredRef = useRef(false);
+  const contentSizeVersionRef = useRef(0);
+  const pendingScrollToBottomRef = useRef<
+    | false
+    | {
+        animated: boolean;
+        minimumContentSizeVersion: number;
+      }
+  >(false);
 
   const updateIsAtBottom = useCallback(() => {
     const { contentHeight, scrollY, viewportHeight } = metricsRef.current;
@@ -262,7 +268,11 @@ const useThreadMessagesFlatListAutoScroll = ({
       metricsRef.current.viewportHeight = viewportHeight;
       updateIsAtBottom();
       const pending = pendingScrollToBottomRef.current;
-      if (pending && contentMeasuredRef.current && viewportHeight > 0) {
+      if (
+        pending &&
+        contentSizeVersionRef.current >= pending.minimumContentSizeVersion &&
+        viewportHeight > 0
+      ) {
         pendingScrollToBottomRef.current = false;
         scrollToBottom(pending.animated);
         return;
@@ -322,14 +332,19 @@ const useThreadMessagesFlatListAutoScroll = ({
       const contentHeight = horizontal ? width : height;
       const previousContentHeight = metrics.contentHeight;
       const wasAtBottom = isAtBottomRef.current;
-      contentMeasuredRef.current = true;
+      if (contentHeight > 0) contentSizeVersionRef.current += 1;
       metrics.contentHeight = contentHeight;
       updateIsAtBottom();
 
       // Initialize and thread-switch requests are repeated after the list has
       // measured so the explicit bottom offset uses real content metrics.
       const pendingScroll = pendingScrollToBottomRef.current;
-      if (pendingScroll && metrics.viewportHeight > 0) {
+      if (
+        pendingScroll &&
+        contentSizeVersionRef.current >=
+          pendingScroll.minimumContentSizeVersion &&
+        metrics.viewportHeight > 0
+      ) {
         pendingScrollToBottomRef.current = false;
         scrollToBottom(pendingScroll.animated);
         return;
@@ -354,13 +369,19 @@ const useThreadMessagesFlatListAutoScroll = ({
     if (initializeScrollRequestedRef.current) return;
 
     initializeScrollRequestedRef.current = true;
-    pendingScrollToBottomRef.current = { animated: false };
+    pendingScrollToBottomRef.current = {
+      animated: false,
+      minimumContentSizeVersion: Math.max(1, contentSizeVersionRef.current),
+    };
     scrollToBottom(false);
   }, [hasMessages, scrollToBottom, scrollToBottomOnInitialize]);
 
   useAuiEvent("thread.runStart", () => {
     if (!scrollToBottomOnRunStart) return;
-    pendingScrollToBottomRef.current = { animated: true };
+    pendingScrollToBottomRef.current = {
+      animated: true,
+      minimumContentSizeVersion: contentSizeVersionRef.current + 1,
+    };
     scrollToBottom(true);
   });
 
@@ -368,8 +389,10 @@ const useThreadMessagesFlatListAutoScroll = ({
     if (!scrollToBottomOnThreadSwitch) return;
     initializeScrollRequestedRef.current = false;
     lastScrollEventOffsetRef.current = 0;
-    contentMeasuredRef.current = false;
-    pendingScrollToBottomRef.current = { animated: false };
+    pendingScrollToBottomRef.current = {
+      animated: false,
+      minimumContentSizeVersion: contentSizeVersionRef.current + 1,
+    };
     scrollToBottom(false);
   });
 

--- a/packages/react-native/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.tsx
@@ -229,6 +229,7 @@ const useThreadMessagesFlatListAutoScroll = ({
   const lastScrollEventOffsetRef = useRef(0);
   const initializeScrollRequestedRef = useRef(false);
   const pendingScrollToBottomRef = useRef<false | { animated: boolean }>(false);
+  const contentMeasuredRef = useRef(false);
 
   const updateIsAtBottom = useCallback(() => {
     const { contentHeight, scrollY, viewportHeight } = metricsRef.current;
@@ -261,11 +262,7 @@ const useThreadMessagesFlatListAutoScroll = ({
       metricsRef.current.viewportHeight = viewportHeight;
       updateIsAtBottom();
       const pending = pendingScrollToBottomRef.current;
-      if (
-        pending &&
-        metricsRef.current.contentHeight > 0 &&
-        viewportHeight > 0
-      ) {
+      if (pending && contentMeasuredRef.current && viewportHeight > 0) {
         pendingScrollToBottomRef.current = false;
         scrollToBottom(pending.animated);
         return;
@@ -325,6 +322,7 @@ const useThreadMessagesFlatListAutoScroll = ({
       const contentHeight = horizontal ? width : height;
       const previousContentHeight = metrics.contentHeight;
       const wasAtBottom = isAtBottomRef.current;
+      contentMeasuredRef.current = true;
       metrics.contentHeight = contentHeight;
       updateIsAtBottom();
 
@@ -370,8 +368,7 @@ const useThreadMessagesFlatListAutoScroll = ({
     if (!scrollToBottomOnThreadSwitch) return;
     initializeScrollRequestedRef.current = false;
     lastScrollEventOffsetRef.current = 0;
-    metricsRef.current.contentHeight = 0;
-    metricsRef.current.scrollY = 0;
+    contentMeasuredRef.current = false;
     pendingScrollToBottomRef.current = { animated: false };
     scrollToBottom(false);
   });

--- a/packages/react-native/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.tsx
@@ -241,9 +241,10 @@ const useThreadMessagesFlatListAutoScroll = ({
   const scrollToBottom = useCallback(
     (animated: boolean) => {
       const { contentHeight, viewportHeight } = metricsRef.current;
-      metricsRef.current.scrollY = Math.max(0, contentHeight - viewportHeight);
+      const offset = Math.max(0, contentHeight - viewportHeight);
+      metricsRef.current.scrollY = offset;
       isAtBottomRef.current = true;
-      flatListRef.current?.scrollToEnd({ animated });
+      flatListRef.current?.scrollToOffset({ offset, animated });
     },
     [flatListRef],
   );
@@ -310,9 +311,8 @@ const useThreadMessagesFlatListAutoScroll = ({
       metrics.contentHeight = height;
       updateIsAtBottom();
 
-      // FlatList.scrollToEnd is a no-op before the list has measured, so the
-      // initialize and thread-switch scrolls land on the next content-size
-      // event, once real metrics exist.
+      // Initialize and thread-switch requests are repeated after the list has
+      // measured so the explicit bottom offset uses real content metrics.
       const pendingScroll = pendingScrollToBottomRef.current;
       if (pendingScroll) {
         pendingScrollToBottomRef.current = false;


### PR DESCRIPTION
## Problem

Opening an existing React Native thread can leave the message list at the top instead of scrolling to the latest message. The issue is reproducible on `@assistant-ui/react-native` 0.1.39 and 0.1.40 with dynamically sized messages.

Closes #7125.

## Root cause

The auto-scroll hook calculated the exact bottom offset but discarded it and called `FlatList.scrollToEnd()`. During the content-size measurement frame, React Native can treat that call as a no-op when item heights are dynamic. Initialization, viewport layout, and content measurement can also arrive in either order, so consuming a pending request before fresh positive content is measured can retain an incorrect offset.

## Change

Use `scrollToOffset()` with the measured `contentSize - viewportSize` target. Track the active axis so horizontal lists use width and x offsets.

Pending initialization, thread-switch, and run-start requests now carry the content measurement version they require. This keeps retries pending through zero-size or early layout callbacks, preserves run-start animation until message growth arrives, and uses the previous measured bottom immediately when a same-height thread switch produces no new content-size event.

The list remains mounted across thread switches, preserving message component state and forwarded-ref continuity.

## Verification

- `pnpm --filter @assistant-ui/react-native test -- src/primitives/thread/ThreadMessages.test.tsx` (34 files, 262 tests)
- `pnpm --filter @assistant-ui/react-native build`
- `pnpm exec oxlint packages/react-native/src/primitives/thread/ThreadMessages.tsx packages/react-native/src/primitives/thread/ThreadMessages.test.tsx`
- `pnpm exec oxfmt --check packages/react-native/src/primitives/thread/ThreadMessages.tsx packages/react-native/src/primitives/thread/ThreadMessages.test.tsx`
- `pnpm changesets:check`

The regression expectations fail with the previous `scrollToEnd()` implementation because no measured offset is issued, and pass with this change.

## Public surface

`@assistant-ui/react-native` behavior only. No API or type changes. Includes a patch changeset.