### PR TITLE
fix(react-hook-form): submit the actual form owner

### DIFF
--- a/.changeset/form-control-ownership.md
+++ b/.changeset/form-control-ownership.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-hook-form": patch
+---
+
+fix: submit the actual form owner of registered controls, including controls with an explicit form attribute.

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import {
   act,
+  cleanup,
   fireEvent,
   render,
   renderHook,
@@ -9,7 +10,7 @@ import {
 import type { ModelContext } from "@assistant-ui/core";
 import type { FormEvent, ReactNode } from "react";
 import type { Resolver, ResolverResult } from "react-hook-form";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   const register = vi.fn();
@@ -33,6 +34,8 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
 import { useAssistantForm } from "./useAssistantForm";
 
 let provider: { getModelContext: () => ModelContext };
+
+afterEach(cleanup);
 
 beforeEach(() => {
   mocks.register.mockReset();
@@ -97,6 +100,115 @@ describe("useAssistantForm", () => {
       const form = useAssistantForm<{ name: string }>();
       return <input {...form.register("name")} />;
     });
+  });
+
+  describe.each(["input", "textarea", "select", "radio"])(
+    "%s form ownership",
+    (control) => {
+      it.each([false, true])(
+        "submits the explicit owner with an ancestor form: %s",
+        async (nested) => {
+          const submitted = vi.fn((event: FormEvent<HTMLFormElement>) =>
+            event.preventDefault(),
+          );
+          const wrongSubmitted = vi.fn((event: FormEvent<HTMLFormElement>) =>
+            event.preventDefault(),
+          );
+          const Fields = () => {
+            const form = useAssistantForm<{ name: string }>();
+            if (control === "textarea")
+              return <textarea form="owner" {...form.register("name")} />;
+            if (control === "select")
+              return (
+                <select form="owner" {...form.register("name")}>
+                  <option value="a">A</option>
+                </select>
+              );
+            if (control === "radio")
+              return (
+                <>
+                  <input
+                    type="radio"
+                    value="a"
+                    form="owner"
+                    {...form.register("name")}
+                  />
+                  <input
+                    type="radio"
+                    value="b"
+                    form="owner"
+                    {...form.register("name")}
+                  />
+                </>
+              );
+            return <input form="owner" {...form.register("name")} />;
+          };
+          render(
+            <>
+              {nested ? (
+                <form onSubmit={wrongSubmitted}>
+                  <Fields />
+                </form>
+              ) : (
+                <Fields />
+              )}
+              <form id="owner" onSubmit={submitted} />
+            </>,
+          );
+
+          await expect(executeSubmitForm()).resolves.toEqual({ success: true });
+          expect(submitted).toHaveBeenCalledOnce();
+          expect(wrongSubmitted).not.toHaveBeenCalled();
+        },
+      );
+    },
+  );
+
+  it("does not fall back to an ancestor when the explicit owner does not exist", async () => {
+    const submitted = vi.fn((event: FormEvent<HTMLFormElement>) =>
+      event.preventDefault(),
+    );
+    const Fields = () => {
+      const form = useAssistantForm<{ name: string }>();
+      return <input form="missing-owner" {...form.register("name")} />;
+    };
+    render(
+      <form onSubmit={submitted}>
+        <Fields />
+      </form>,
+    );
+
+    await expect(executeSubmitForm()).resolves.toEqual({
+      success: false,
+      message: "Unable retrieve the form element. This is a coding error.",
+    });
+    expect(submitted).not.toHaveBeenCalled();
+  });
+
+  it("keeps the ancestor fallback for custom refs without a form owner property", async () => {
+    await expectRegisteredFieldsToSubmit(() => {
+      const form = useAssistantForm<{ name: string }>();
+      return <div ref={form.register("name").ref} />;
+    });
+  });
+
+  it("validates external controls before submitting their owner", async () => {
+    const submitted = vi.fn((event: FormEvent<HTMLFormElement>) =>
+      event.preventDefault(),
+    );
+    const Fields = () => {
+      const form = useAssistantForm<{ name: string }>();
+      return <input required form="owner" {...form.register("name")} />;
+    };
+    render(
+      <>
+        <Fields />
+        <form id="owner" onSubmit={submitted} />
+      </>,
+    );
+
+    await expectSubmitBlocked();
+    expect(submitted).not.toHaveBeenCalled();
   });
 
   it("submits forms registered with nested inputs", async () => {

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -209,7 +209,14 @@ export const useAssistantForm = <
                   : field._f.ref;
 
                 if (fieldReference instanceof HTMLElement) {
-                  formElement = fieldReference.closest("form");
+                  if ("form" in fieldReference) {
+                    formElement =
+                      fieldReference.form instanceof HTMLFormElement
+                        ? fieldReference.form
+                        : null;
+                  } else {
+                    formElement = fieldReference.closest("form");
+                  }
                   if (formElement) break;
                 }
               }


### PR DESCRIPTION
Fixes #7249

## Problem

The `submit_form` tool can submit the wrong form, or fail to find an existing form, when a registered control uses an explicit HTML `form` attribute.

For example, an input with `form="checkout"` should submit the connected form with `id="checkout"`, even when the input is outside that form or nested inside another form. Before this fix, the first case returns a coding error and the second submits the ancestor instead.

Reproduced against source commit `c41d93a84231a54256e0e1fe6f64951603a039d7`, where `@assistant-ui/react-hook-form` declares version `0.12.32`. The [issue includes a complete runnable reproduction](https://github.com/assistant-ui/assistant-ui/issues/7249).

## Root cause

The tool uses `closest("form")`, which finds a DOM ancestor rather than the control's form owner. HTML allows an explicit owner to override that ancestor.

## Change

Use the native `.form` owner for registered elements that expose it. Keep the ancestor fallback for custom refs without a form-owner property.

A real null owner stays null, so an invalid explicit owner does not silently submit an unrelated ancestor. Validation, native submission, grouped-field handling, and submission settlement keep their existing behavior. This does not change the first-resolvable-field policy when a hook contains fields from multiple forms.

## Verification

The expanded suite fails in 10 cases with the original lookup and passes all 25 tests with this fix. Coverage includes input, textarea, select, grouped radio controls, external owners, overridden ancestors, invalid owner IDs, custom refs, and native validation.

From `packages/react-hook-form`:

```sh
./node_modules/.bin/vitest run src/useAssistantForm.test.tsx
./node_modules/.bin/aui-build
```

From the repository root:

```sh
./node_modules/.bin/oxlint packages/react-hook-form/src/useAssistantForm.ts packages/react-hook-form/src/useAssistantForm.test.tsx
./node_modules/.bin/oxfmt --check packages/react-hook-form/src/useAssistantForm.ts packages/react-hook-form/src/useAssistantForm.test.tsx
node scripts/check-changesets.mjs
git diff --check origin/main...HEAD
```

All commands passed after rebasing onto `b23c50501`. The package entry remains within its recorded size budget.

Local verification used the existing Node 23.11.0 and Vitest 4.1.11 installation. The repository declares Node >=24 and Vitest 5, so GitHub CI still needs to validate that environment. This is source verification, not a test of a published npm artifact.

## Public surface

Patch changeset for `@assistant-ui/react-hook-form`. No new exports, signature changes, documentation claims, API-reference output, or templates.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.r3N9beC4e9gHehgjv8yH9Ed2JyDEFEO6Srog4uORFH3BKFAH-Gm4W-LKgBA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->