### PR TITLE
fix(cli): write Zed settings to the macOS user config

### DIFF
--- a/.changeset/zed-macos-user-settings.md
+++ b/.changeset/zed-macos-user-settings.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix(cli): install the Zed MCP server in the macOS user settings file.

--- a/apps/docs/content/docs/(before-you-start)/llm.mdx
+++ b/apps/docs/content/docs/(before-you-start)/llm.mdx
@@ -144,7 +144,7 @@ Enable MCP in Settings → search "MCP" → enable "Chat > MCP". Use GitHub Copi
   </Tab>
   <Tab>
 Zed launches MCP servers as local commands, so use the stdio package. Add to your Zed settings file:
-- macOS: `~/.zed/settings.json`
+- macOS: `~/.config/zed/settings.json`
 - Linux: `~/.config/zed/settings.json`
 - Windows: `%APPDATA%\Zed\settings.json`
 

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -75,9 +75,6 @@ const MCP_CONFIGS: Record<
       if (process.platform === "win32") {
         return path.join(process.env.APPDATA || "", "Zed", "settings.json");
       }
-      if (process.platform === "darwin") {
-        return path.join(os.homedir(), ".zed", "settings.json");
-      }
       return path.join(os.homedir(), ".config", "zed", "settings.json");
     },
     config: {

--- a/packages/cli/test/commands/mcp.test.ts
+++ b/packages/cli/test/commands/mcp.test.ts
@@ -161,7 +161,7 @@ describe("mcp command", () => {
 
     await mcp.parseAsync(["node", "mcp", "--zed"], { from: "node" });
 
-    const configPath = path.join(tempDir, ".zed", "settings.json");
+    const configPath = path.join(tempDir, ".config", "zed", "settings.json");
     const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
 
     expect(config).toEqual({
@@ -175,6 +175,51 @@ describe("mcp command", () => {
       },
     });
   });
+
+  it("preserves existing Zed user settings on macOS without creating a project config", async () => {
+    setPlatform("darwin");
+    const configPath = path.join(tempDir, ".config", "zed", "settings.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const settings = {
+      theme: "One Dark",
+      context_servers: { custom: { command: "my-server" } },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(settings));
+
+    await mcp.parseAsync(["node", "mcp", "--zed"], { from: "node" });
+
+    const updated = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    expect(updated.theme).toBe(settings.theme);
+    expect(updated.context_servers.custom).toEqual(
+      settings.context_servers.custom,
+    );
+    expect(updated.context_servers["assistant-ui"]).toBeDefined();
+    expect(fs.existsSync(path.join(tempDir, ".zed", "settings.json"))).toBe(
+      false,
+    );
+  });
+
+  it.each(["linux", "win32"] as const)(
+    "keeps the Zed user settings location on %s",
+    async (platform) => {
+      setPlatform(platform);
+      vi.stubEnv("APPDATA", path.join(tempDir, "AppData"));
+      try {
+        await mcp.parseAsync(["node", "mcp", "--zed"], { from: "node" });
+        const configPath =
+          platform === "win32"
+            ? path.join(tempDir, "AppData", "Zed", "settings.json")
+            : path.join(tempDir, ".config", "zed", "settings.json");
+        expect(
+          JSON.parse(fs.readFileSync(configPath, "utf-8")).context_servers[
+            "assistant-ui"
+          ],
+        ).toBeDefined();
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    },
+  );
 
   it("keeps the stdio npx config for claude-desktop", async () => {
     setPlatform("darwin");


### PR DESCRIPTION
Fixes #7250

## Problem

On macOS, `assistant-ui mcp --zed` writes the MCP server into `~/.zed/settings.json`. That is not Zed's default user settings file, so the command reports success without configuring the editor.

Minimal reproduction: run the command on macOS and inspect the written path. The expected default is `~/.config/zed/settings.json`. The [issue includes an isolated executable test](https://github.com/assistant-ui/assistant-ui/issues/7250) that does not touch real user settings.

Reproduced against source commit `c41d93a84231a54256e0e1fe6f64951603a039d7`, where the `assistant-ui` CLI declares version `0.0.115`.

## Root cause

A Darwin-only branch selects the project-style `.zed` directory under the home directory. Zed's [macOS user config implementation](https://github.com/zed-industries/zed/blob/9d272b036335401f339d024ea94968fd51016c40/crates/paths/src/paths.rs#L121-L140) defaults to `~/.config/zed`, and [settings_file()](https://github.com/zed-industries/zed/blob/9d272b036335401f339d024ea94968fd51016c40/crates/paths/src/paths.rs#L277-L281) adds `settings.json`.

The existing documentation repeated the incorrect macOS path.

## Change

Remove the incorrect Darwin branch and use the existing `.config/zed/settings.json` fallback. Correct the matching macOS path in the MCP setup guide.

Linux and Windows behavior stays unchanged. Existing user settings and other servers are preserved. This does not delete or migrate old files, add custom config-directory handling, or change Zed's configuration parser.

## Verification

Two path regressions fail without the correction. With the fix, all 11 focused MCP tests and all 342 CLI tests pass. Coverage includes macOS settings preservation, not creating the incorrect path, and Linux/Windows paths.

From `packages/cli`:

```sh
./node_modules/.bin/vitest run test/commands/mcp.test.ts
node --input-type=module -e 'import { startVitest } from "vitest/node"; const context = await startVitest("test", [], { run: true, watch: false }, { test: { clearMocks: true } }); await context.close();'
./node_modules/.bin/aui-build
```

From the repository root:

```sh
./node_modules/.bin/oxlint packages/cli/src/commands/mcp.ts packages/cli/test/commands/mcp.test.ts
./node_modules/.bin/oxfmt --check packages/cli/src/commands/mcp.ts packages/cli/test/commands/mcp.test.ts
node scripts/check-changesets.mjs
git diff --check origin/main...HEAD
```

All checks passed, with the full suite and build repeated after rebasing onto `b23c50501`.

Local verification used Node 23.11.0 and Vitest 4.1.11 from the existing workspace installation. The full-suite command enables mock clearing to match the declared Vitest 5 default without changing repository configuration. GitHub CI still needs to verify the declared Node >=24/Vitest 5 environment. No published npm artifact was tested.

## Public surface

Patch changeset for the `assistant-ui` CLI. One existing macOS path corrected in the MCP setup guide. No new exports, command flags, API-reference output, or template changes.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nNT6mAELCq8QiUefKeJFFDzFjOfb9gqfvDOxNTBA-P5UVT4hWB4uooSbl5Y?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->