### PR TITLE
fix(cli): preserve commented VS Code and Zed MCP settings

### DIFF
--- a/.changeset/vscode-mcp-jsonc.md
+++ b/.changeset/vscode-mcp-jsonc.md
@@ -2,4 +2,4 @@
 "assistant-ui": patch
 ---
 
-fix(cli): accept VS Code MCP configuration comments and trailing commas while preserving unrelated settings.
+fix(cli): accept comments and trailing commas in VS Code and Zed MCP configuration while preserving unrelated settings.

--- a/.changeset/vscode-mcp-jsonc.md
+++ b/.changeset/vscode-mcp-jsonc.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix(cli): accept VS Code MCP configuration comments and trailing commas while preserving unrelated settings.

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -4,8 +4,11 @@ import path from "node:path";
 import os from "node:os";
 import {
   applyEdits,
+  format,
   modify,
   parse as parseJsonc,
+  parseTree,
+  type Node,
   type ParseError,
 } from "jsonc-parser";
 import { logger } from "../lib/utils/logger";
@@ -156,6 +159,61 @@ class McpConfigParseError extends Error {
 const getTargetFlag = (target: Exclude<MCPTarget, "claude-code">) =>
   `--${target}`;
 
+const lastPropertyValue = (node: Node, key: string) =>
+  node.children?.findLast((property) => property.children?.[0]?.value === key)
+    ?.children?.[1];
+
+function updateVscodeConfig(content: string, server: object): string {
+  const formattingOptions = {
+    insertSpaces: true,
+    tabSize: 2,
+    eol: content.includes("\r\n") ? "\r\n" : "\n",
+    keepLines: false,
+  };
+  const root = parseTree(content);
+  // JSONC parsing uses the last duplicate key, but modify() targets the first.
+  const servers = root && lastPropertyValue(root, "servers");
+  if (!servers) {
+    return applyEdits(
+      content,
+      modify(
+        content,
+        ["servers"],
+        { "assistant-ui": server },
+        { formattingOptions },
+      ),
+    );
+  }
+
+  const existing =
+    servers.type === "object"
+      ? lastPropertyValue(servers, "assistant-ui")
+      : servers;
+  const edit = existing
+    ? {
+        offset: existing.offset,
+        length: existing.length,
+        content: JSON.stringify(
+          servers.type === "object" ? server : { "assistant-ui": server },
+        ),
+      }
+    : modify(
+        content.slice(servers.offset, servers.offset + servers.length),
+        ["assistant-ui"],
+        server,
+        {},
+      ).map((edit) => ({ ...edit, offset: edit.offset + servers.offset }))[0]!;
+  const updated = applyEdits(content, [edit]);
+  return applyEdits(
+    updated,
+    format(
+      updated,
+      { offset: edit.offset, length: edit.content.length },
+      formattingOptions,
+    ),
+  );
+}
+
 async function installForTarget(target: MCPTarget): Promise<void> {
   if (target === "claude-code") {
     logger.info("Installing MCP server for Claude Code...");
@@ -264,21 +322,7 @@ async function installForTarget(target: MCPTarget): Promise<void> {
 
   const updatedContent =
     target === "vscode"
-      ? applyEdits(
-          content,
-          modify(
-            content,
-            ["servers", "assistant-ui"],
-            newConfig.servers["assistant-ui"],
-            {
-              formattingOptions: {
-                insertSpaces: true,
-                tabSize: 2,
-                eol: content.includes("\r\n") ? "\r\n" : "\n",
-              },
-            },
-          ),
-        )
+      ? updateVscodeConfig(content, newConfig.servers["assistant-ui"])
       : `${JSON.stringify(newConfig, null, 2)}\n`;
   fs.writeFileSync(configPath, updatedContent);
 

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -32,6 +32,7 @@ const MCP_CONFIGS: Record<
     getPath: () => string;
     config: object;
     replaceServerKey?: string;
+    jsoncServerKey?: string;
     postInstall?: string;
   }
 > = {
@@ -75,11 +76,13 @@ const MCP_CONFIGS: Record<
       },
     },
     replaceServerKey: "servers",
+    jsoncServerKey: "servers",
     postInstall:
       "Enable MCP in Settings → search 'MCP' → enable 'Chat > MCP'. Use Copilot Chat in Agent mode.",
   },
   zed: {
     name: "Zed",
+    jsoncServerKey: "context_servers",
     getPath: () => {
       if (process.platform === "win32") {
         return path.join(process.env.APPDATA || "", "Zed", "settings.json");
@@ -163,7 +166,11 @@ const lastPropertyValue = (node: Node, key: string) =>
   node.children?.findLast((property) => property.children?.[0]?.value === key)
     ?.children?.[1];
 
-function updateVscodeConfig(content: string, server: object): string {
+function updateJsoncConfig(
+  content: string,
+  serverKey: string,
+  server: object,
+): string {
   const formattingOptions = {
     insertSpaces: true,
     tabSize: 2,
@@ -172,13 +179,13 @@ function updateVscodeConfig(content: string, server: object): string {
   };
   const root = parseTree(content);
   // JSONC parsing uses the last duplicate key, but modify() targets the first.
-  const servers = root && lastPropertyValue(root, "servers");
+  const servers = root && lastPropertyValue(root, serverKey);
   if (!servers) {
     return applyEdits(
       content,
       modify(
         content,
-        ["servers"],
+        [serverKey],
         { "assistant-ui": server },
         { formattingOptions },
       ),
@@ -280,7 +287,7 @@ async function installForTarget(target: MCPTarget): Promise<void> {
   if (fs.existsSync(configPath)) {
     content = fs.readFileSync(configPath, "utf-8");
     try {
-      if (target === "vscode") {
+      if (targetConfig.jsoncServerKey) {
         const errors: ParseError[] = [];
         existingConfig = parseJsonc(content, errors, {
           allowTrailingComma: true,
@@ -320,10 +327,13 @@ async function installForTarget(target: MCPTarget): Promise<void> {
     };
   }
 
-  const updatedContent =
-    target === "vscode"
-      ? updateVscodeConfig(content, newConfig.servers["assistant-ui"])
-      : `${JSON.stringify(newConfig, null, 2)}\n`;
+  const updatedContent = targetConfig.jsoncServerKey
+    ? updateJsoncConfig(
+        content,
+        targetConfig.jsoncServerKey,
+        newConfig[targetConfig.jsoncServerKey]["assistant-ui"],
+      )
+    : `${JSON.stringify(newConfig, null, 2)}\n`;
   fs.writeFileSync(configPath, updatedContent);
 
   logger.break();

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -2,6 +2,12 @@ import { Command } from "commander";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import {
+  applyEdits,
+  modify,
+  parse as parseJsonc,
+  type ParseError,
+} from "jsonc-parser";
 import { logger } from "../lib/utils/logger";
 import { runSpawn, SpawnExitError, SpawnSignalError } from "../lib/run-spawn";
 import * as p from "@clack/prompts";
@@ -212,10 +218,28 @@ async function installForTarget(target: MCPTarget): Promise<void> {
   }
 
   let existingConfig: any = {};
+  let content = "{}\n";
   if (fs.existsSync(configPath)) {
-    const content = fs.readFileSync(configPath, "utf-8");
+    content = fs.readFileSync(configPath, "utf-8");
     try {
-      existingConfig = JSON.parse(content);
+      if (target === "vscode") {
+        const errors: ParseError[] = [];
+        existingConfig = parseJsonc(content, errors, {
+          allowTrailingComma: true,
+          allowEmptyContent: true,
+        });
+        if (existingConfig === undefined) existingConfig = {};
+        if (
+          errors.length > 0 ||
+          existingConfig === null ||
+          typeof existingConfig !== "object" ||
+          Array.isArray(existingConfig)
+        ) {
+          throw new SyntaxError("Invalid MCP configuration");
+        }
+      } else {
+        existingConfig = JSON.parse(content);
+      }
     } catch {
       const flag = getTargetFlag(target);
       logger.error(`Could not parse ${targetConfig.name} MCP config.`);
@@ -238,7 +262,25 @@ async function installForTarget(target: MCPTarget): Promise<void> {
     };
   }
 
-  fs.writeFileSync(configPath, `${JSON.stringify(newConfig, null, 2)}\n`);
+  const updatedContent =
+    target === "vscode"
+      ? applyEdits(
+          content,
+          modify(
+            content,
+            ["servers", "assistant-ui"],
+            newConfig.servers["assistant-ui"],
+            {
+              formattingOptions: {
+                insertSpaces: true,
+                tabSize: 2,
+                eol: content.includes("\r\n") ? "\r\n" : "\n",
+              },
+            },
+          ),
+        )
+      : `${JSON.stringify(newConfig, null, 2)}\n`;
+  fs.writeFileSync(configPath, updatedContent);
 
   logger.break();
   logger.success(`MCP server installed for ${targetConfig.name}!`);

--- a/packages/cli/test/commands/mcp.test.ts
+++ b/packages/cli/test/commands/mcp.test.ts
@@ -339,6 +339,109 @@ describe("mcp command", () => {
     });
   });
 
+  it.each(["\n", "\r\n"])(
+    "preserves commented Zed settings with %j line endings",
+    async (eol) => {
+      setPlatform("linux");
+      const configPath = path.join(tempDir, ".config", "zed", "settings.json");
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      const content = [
+        "{",
+        "  // Editor preferences",
+        '  "theme": "One Dark",',
+        '  "languages": { "TypeScript": { "tab_size": 4 } },',
+        '  "context_servers": {',
+        '    "assistant-ui": { "command": { "path": "old", "env": { "CUSTOM": "value" } }, "settings": { "enabled": true } },',
+        "    // Keep this custom server",
+        '    "other": { "command": { "path": "custom", "args": [] } },',
+        "  },",
+        "}",
+        "",
+      ].join(eol);
+      fs.writeFileSync(configPath, content);
+
+      await mcp.parseAsync(["node", "mcp", "--zed"], { from: "node" });
+
+      const updated = fs.readFileSync(configPath, "utf-8");
+      expect(updated).toContain(
+        content.slice(0, content.indexOf('    "assistant-ui"')),
+      );
+      expect(updated).toContain(
+        content.slice(content.indexOf("    // Keep this custom server")),
+      );
+      expect(updated.replaceAll(eol, "")).not.toMatch(/[\r\n]/);
+      expect(parseJsonc(updated, [], { allowTrailingComma: true })).toEqual({
+        theme: "One Dark",
+        languages: { TypeScript: { tab_size: 4 } },
+        context_servers: {
+          "assistant-ui": {
+            command: {
+              path: "npx",
+              args: ["-y", "@assistant-ui/mcp-docs-server"],
+              env: { CUSTOM: "value" },
+            },
+            settings: { enabled: true },
+          },
+          other: { command: { path: "custom", args: [] } },
+        },
+      });
+
+      await mcp.parseAsync(["node", "mcp", "--zed"], { from: "node" });
+      expect(fs.readFileSync(configPath, "utf-8")).toBe(updated);
+    },
+  );
+
+  it.each([
+    '{\n  "languages": { "TypeScript": { "tab_size": 4 } },\n  "theme": "One Dark"\n}\n',
+    '// Editor preferences\n{ "context_servers": null }\n',
+    '// Editor preferences\n{ "context_servers": {}, "context_servers": { "assistant-ui": { "command": { "path": "old" } } } }\n',
+    '// Editor preferences\n{ "context_servers": { "assistant-ui": {}, "assistant-ui": { "command": { "path": "old" } } } }\n',
+  ])(
+    "updates the effective Zed server without a whole-file rewrite in %j",
+    async (content) => {
+      setPlatform("linux");
+      const configPath = path.join(tempDir, ".config", "zed", "settings.json");
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, content);
+
+      await mcp.parseAsync(["node", "mcp", "--zed"], { from: "node" });
+
+      const updated = fs.readFileSync(configPath, "utf-8");
+      expect(
+        parseJsonc(updated).context_servers["assistant-ui"].command,
+      ).toEqual({
+        path: "npx",
+        args: ["-y", "@assistant-ui/mcp-docs-server"],
+      });
+      if (content.includes('"languages"')) {
+        expect(updated).toContain(
+          '"languages": { "TypeScript": { "tab_size": 4 } }',
+        );
+      } else {
+        expect(updated).toContain("// Editor preferences");
+      }
+    },
+  );
+
+  it.each(['{"context_servers": {', "null", "[]"])(
+    "leaves malformed Zed settings %j unchanged with a diagnostic",
+    async (content) => {
+      setPlatform("linux");
+      const configPath = path.join(tempDir, ".config", "zed", "settings.json");
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, content);
+
+      await expect(
+        mcp.parseAsync(["node", "mcp", "--zed"], { from: "node" }),
+      ).rejects.toThrow("process.exit");
+
+      expect(fs.readFileSync(configPath, "utf-8")).toBe(content);
+      expect(consoleErrorSpy.mock.calls.flat().join("\n")).toContain(
+        "Could not parse Zed MCP config.",
+      );
+    },
+  );
+
   it("keeps the stdio npx config for claude-desktop", async () => {
     setPlatform("darwin");
 

--- a/packages/cli/test/commands/mcp.test.ts
+++ b/packages/cli/test/commands/mcp.test.ts
@@ -218,6 +218,46 @@ describe("mcp command", () => {
   });
 
   it.each([
+    '"servers": null',
+    '"servers": { "assistant-ui": { "command": "first" }, "assistant-ui": { "command": "last" } }',
+    '"servers": { "assistant-ui": { "command": "shadowed" } }, "servers": { "other": { "command": "custom" } }',
+    '"servers": { "assistant-ui": { "command": "shadowed" } }, "servers": null',
+    '"servers": {}, "servers": { "assistant-ui": { "command": "last" } }',
+  ])(
+    "updates the effective VS Code server configuration in %s",
+    async (servers) => {
+      const configPath = path.join(tempDir, ".vscode", "mcp.json");
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(
+        configPath,
+        `{\r\n  ${servers},\r\n  // Keep inputs\r\n  "inputs": [ ]\r\n}\r\n`,
+      );
+
+      await mcp.parseAsync(["node", "mcp", "--vscode"], { from: "node" });
+
+      const updated = fs.readFileSync(configPath, "utf-8");
+      const config = parseJsonc(updated);
+      expect(config.servers["assistant-ui"]).toEqual({
+        type: "http",
+        url: HOSTED_MCP_URL,
+      });
+      if (servers.includes('"other"')) {
+        expect(config.servers.other).toEqual({ command: "custom" });
+      }
+      if (servers.includes('"shadowed"')) {
+        expect(updated).toContain(
+          '"servers": { "assistant-ui": { "command": "shadowed" } }',
+        );
+      }
+      expect(updated).toContain('// Keep inputs\r\n  "inputs": [ ]');
+      expect(updated.replaceAll("\r\n", "")).not.toMatch(/[\r\n]/);
+
+      await mcp.parseAsync(["node", "mcp", "--vscode"], { from: "node" });
+      expect(fs.readFileSync(configPath, "utf-8")).toBe(updated);
+    },
+  );
+
+  it.each([
     '{"servers": {',
     '{"servers": {},,}',
     "{/* unfinished",

--- a/packages/cli/test/commands/mcp.test.ts
+++ b/packages/cli/test/commands/mcp.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { parse as parseJsonc } from "jsonc-parser";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mcp } from "../../src/commands/mcp";
 import { SpawnExitError } from "../../src/lib/run-spawn";
@@ -125,6 +126,128 @@ describe("mcp command", () => {
         "assistant-ui": { type: "http", url: HOSTED_MCP_URL },
       },
     });
+  });
+
+  it.each(["\n", "\r\n"])(
+    "preserves VS Code comments and other settings with %j line endings",
+    async (eol) => {
+      const configPath = path.join(tempDir, ".vscode", "mcp.json");
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      const content = [
+        "{",
+        "  // Keep these server notes",
+        '  "servers": {',
+        '    "other": { "type": "http", "url": "https://example.com/mcp" },',
+        "  },",
+        "  /* Keep input settings too */",
+        '  "inputs": [],',
+        "}",
+        "",
+      ].join(eol);
+      fs.writeFileSync(configPath, content);
+
+      await mcp.parseAsync(["node", "mcp", "--vscode"], { from: "node" });
+
+      const updated = fs.readFileSync(configPath, "utf-8");
+      expect(updated).toContain("// Keep these server notes");
+      expect(updated).toContain("/* Keep input settings too */");
+      expect(updated.split(eol).join("")).not.toMatch(/[\r\n]/);
+      expect(parseJsonc(updated, [], { allowTrailingComma: true })).toEqual({
+        servers: {
+          other: { type: "http", url: "https://example.com/mcp" },
+          "assistant-ui": { type: "http", url: HOSTED_MCP_URL },
+        },
+        inputs: [],
+      });
+
+      await mcp.parseAsync(["node", "mcp", "--vscode"], { from: "node" });
+      expect(fs.readFileSync(configPath, "utf-8")).toBe(updated);
+    },
+  );
+
+  it("replaces the VS Code assistant-ui entry without rewriting unrelated settings", async () => {
+    const configPath = path.join(tempDir, ".vscode", "mcp.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      `{
+  "servers": {
+    "assistant-ui": { "command": "npx", "args": ["old-server"] },
+    // Keep this custom server
+    "other": { "command": "custom", "args": [] }
+  },
+  "inputs": [ ]
+}\n`,
+    );
+
+    await mcp.parseAsync(["node", "mcp", "--vscode"], { from: "node" });
+
+    const updated = fs.readFileSync(configPath, "utf-8");
+    expect(updated).toContain(
+      '// Keep this custom server\n    "other": { "command": "custom", "args": [] }',
+    );
+    expect(updated).toContain('"inputs": [ ]');
+    expect(parseJsonc(updated).servers["assistant-ui"]).toEqual({
+      type: "http",
+      url: HOSTED_MCP_URL,
+    });
+  });
+
+  it.each([
+    "",
+    "  \n",
+    "// Server configuration\n",
+    '{"inputs": [], /* no servers yet */}',
+  ])("initializes VS Code server settings from %j", async (content) => {
+    const configPath = path.join(tempDir, ".vscode", "mcp.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, content);
+
+    await mcp.parseAsync(["node", "mcp", "--vscode"], { from: "node" });
+
+    const updated = fs.readFileSync(configPath, "utf-8");
+    expect(
+      parseJsonc(updated, [], { allowTrailingComma: true }).servers,
+    ).toEqual({
+      "assistant-ui": { type: "http", url: HOSTED_MCP_URL },
+    });
+    if (content.includes("//"))
+      expect(updated).toContain("// Server configuration");
+    if (content.includes("/*"))
+      expect(updated).toContain("/* no servers yet */");
+  });
+
+  it.each([
+    '{"servers": {',
+    '{"servers": {},,}',
+    "{/* unfinished",
+    "null",
+    "[]",
+    '"settings"',
+  ])("does not overwrite invalid VS Code configuration %j", async (content) => {
+    const configPath = path.join(tempDir, ".vscode", "mcp.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, content);
+
+    await expect(
+      mcp.parseAsync(["node", "mcp", "--vscode"], { from: "node" }),
+    ).rejects.toThrow("process.exit");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(content);
+  });
+
+  it("keeps strict JSON parsing for other targets", async () => {
+    const configPath = path.join(tempDir, ".cursor", "mcp.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const content = '{\n// A comment\n"mcpServers": {}\n}';
+    fs.writeFileSync(configPath, content);
+
+    await expect(
+      mcp.parseAsync(["node", "mcp", "--cursor"], { from: "node" }),
+    ).rejects.toThrow("process.exit");
+
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(content);
   });
 
   it("replaces an existing stdio assistant-ui entry wholesale for an http client", async () => {


### PR DESCRIPTION
Fixes #7251

## Problem

`assistant-ui mcp --vscode` rejects valid VS Code MCP configuration containing comments or trailing commas. Users have to strip supported configuration syntax before installing the server.

For example, this `.vscode/mcp.json` fails before the fix:

```jsonc
{
  // Keep my existing servers.
  "servers": {
    "example": { "type": "http", "url": "https://example.com/mcp" },
  },
}
```

Reproduced against source commit `c41d93a84231a54256e0e1fe6f64951603a039d7`, where the `assistant-ui` CLI declares version `0.0.115`. The [issue contains a complete isolated reproduction](https://github.com/assistant-ui/assistant-ui/issues/7251).

The same failure also affects `assistant-ui mcp --zed`: Zed accepts commented settings, but the installer still used strict JSON and rewrote unrelated editor settings. The follow-up covers that existing defect through the same mechanism without changing Zed's server command or file locations.

## Root cause

The installer uses `JSON.parse` for every file-based target and then rewrites the entire configuration with `JSON.stringify`. The parser rejects JSONC, and a whole-file rewrite would discard comments even if parsing were relaxed.

## Change

Use the existing `jsonc-parser` dependency for VS Code and Zed. The target table declares the JSONC server key: `servers` for VS Code and `context_servers` for Zed. Apply a targeted edit to the effective `assistant-ui` entry. VS Code keeps its wholesale replacement semantics; Zed keeps its existing merge behavior, including custom server settings and environment variables.

This accepts comments, trailing commas, and empty or comment-only files for both JSONC targets. It preserves unrelated servers, settings, comments outside the replaced entry, and the file's LF/CRLF convention. Invalid syntax and non-object roots still fail without overwriting the file. Other targets keep their current behavior. Empty `servers: null` is initialized, and duplicate keys follow the parser's last-key-wins behavior so the effective server entry is updated rather than a shadowed one.

## Verification

Verified on Node 24.19.0 with the lockfile's Vitest 5.0.0. Five additional regression cases fail on the previous PR head and pass with the follow-up: null servers, duplicate server entries, duplicate servers blocks, and repeat installation. Existing comment preservation, LF/CRLF, malformed input, and other-target tests remain green. Nine Zed cases cover commented settings with LF/CRLF, custom server options, repeat installation, unrelated formatting, null server maps, duplicate keys, and invalid input. Eight fail without the Zed follow-up and pass with it.

- `pnpm --filter assistant-ui test test/commands/mcp.test.ts`: 36 passed.
- `pnpm --filter assistant-ui test`: 367 passed.
- `pnpm --filter assistant-ui... build`: passed.
- `pnpm exec oxlint packages/cli/src/commands/mcp.ts packages/cli/test/commands/mcp.test.ts`: passed.
- `pnpm exec oxfmt packages/cli/src/commands/mcp.ts packages/cli/test/commands/mcp.test.ts`: applied repository formatting.
- `node scripts/check-changesets.mjs` and `git diff --check`: passed.

Fresh GitHub CI still needs to validate the pushed revision. No published npm artifact was tested.

## Public surface

Patch changeset for the `assistant-ui` CLI. No new dependency, export, command flag, documentation claim, API-reference output, or template change.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.De0wFwVroBl499RCWgATrsQHGXz72TqrmzVS6wKbNqtnTtFk5gFHFiIsP20?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->