### PR TITLE
fix(cloud): keep pending loads from restoring reset mappings

### DIFF
--- a/.changeset/cloud-load-reset-mapping.md
+++ b/.changeset/cloud-load-reset-mapping.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: prevent pending history loads from restoring message mappings after reset.

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -162,8 +162,8 @@ export class CloudMessagePersistence {
   /**
    * Reset the ID mapping (call when switching threads).
    *
-   * Pending `load()` calls are not cancelled and still settle normally,
-   * but their results no longer populate the ID mapping.
+   * Pending `load()` and `append()` calls are not cancelled and still settle
+   * normally, but their results no longer populate the ID mapping.
    */
   reset() {
     this.idMapping = new Map();

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -125,6 +125,7 @@ export class CloudMessagePersistence {
    * @returns Array of cloud messages
    */
   async load(threadId: string, format?: string) {
+    const idMapping = this.idMapping;
     const cloud = this.getCloud();
     const messages: CloudMessage[] = [];
     const seen = new Set<string>();
@@ -150,9 +151,10 @@ export class CloudMessagePersistence {
       after = last.id;
     }
 
-    // Populate ID mapping so isPersisted() recognizes loaded messages
-    for (const m of messages) {
-      this.idMapping.set(m.id, m.id);
+    if (this.idMapping === idMapping) {
+      for (const m of messages) {
+        idMapping.set(m.id, m.id);
+      }
     }
     return messages;
   }
@@ -161,6 +163,6 @@ export class CloudMessagePersistence {
    * Reset the ID mapping (call when switching threads).
    */
   reset() {
-    this.idMapping.clear();
+    this.idMapping = new Map();
   }
 }

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -161,6 +161,9 @@ export class CloudMessagePersistence {
 
   /**
    * Reset the ID mapping (call when switching threads).
+   *
+   * Pending `load()` calls are not cancelled and still settle normally,
+   * but their results no longer populate the ID mapping.
    */
   reset() {
     this.idMapping = new Map();

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -475,6 +475,30 @@ describe("CloudMessagePersistence", () => {
     expect(persistence.isPersisted("local-1")).toBe(false);
   });
 
+  it("does not restore an append mapping after reset", async () => {
+    let resolveAppend!: (value: { message_id: string }) => void;
+    vi.mocked(cloud.threads.messages.create).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveAppend = resolve;
+        }),
+    );
+
+    const append = persistence.append(
+      "thread-1",
+      "local-1",
+      null,
+      "aui/v0",
+      {},
+    );
+    persistence.reset();
+    resolveAppend({ message_id: "remote-1" });
+
+    await expect(append).resolves.toBeUndefined();
+    expect(persistence.isPersisted("local-1")).toBe(false);
+    expect(await persistence.getRemoteId("local-1")).toBeUndefined();
+  });
+
   it("reset clears all ID mappings", async () => {
     vi.mocked(cloud.threads.messages.create).mockResolvedValue({
       message_id: "remote-1",

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -254,6 +254,98 @@ describe("CloudMessagePersistence", () => {
     expect(persistence.isPersisted("msg-1")).toBe(true);
   });
 
+  it("does not restore IDs from a load that finishes after reset", async () => {
+    const oldMessages = createCloudMessages(1);
+    const newMessages = [{ ...oldMessages[0]!, id: "new-message" }];
+    let resolveOld!: (value: { messages: typeof oldMessages }) => void;
+    vi.mocked(cloud.threads.messages.list)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOld = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ messages: newMessages });
+
+    const oldLoad = persistence.load("old-thread");
+    persistence.reset();
+    await persistence.load("new-thread");
+    resolveOld({ messages: oldMessages });
+
+    expect(await oldLoad).toEqual(oldMessages);
+    expect(persistence.isPersisted("message-1")).toBe(false);
+    expect(persistence.isPersisted("new-message")).toBe(true);
+  });
+
+  it("keeps a new append mapping when an old load returns the same ID", async () => {
+    const messages = createCloudMessages(1);
+    let resolveOld!: (value: { messages: typeof messages }) => void;
+    vi.mocked(cloud.threads.messages.list).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOld = resolve;
+        }),
+    );
+    vi.mocked(cloud.threads.messages.create).mockResolvedValue({
+      message_id: "new-remote-id",
+    });
+
+    const oldLoad = persistence.load("old-thread");
+    persistence.reset();
+    await persistence.append("new-thread", "message-1", null, "aui/v0", {});
+    resolveOld({ messages });
+    await oldLoad;
+
+    expect(await persistence.getRemoteId("message-1")).toBe("new-remote-id");
+  });
+
+  it("does not populate any old IDs when reset happens between history pages", async () => {
+    const messages = createCloudMessages(201);
+    let resolveLast!: (value: { messages: typeof messages }) => void;
+    vi.mocked(cloud.threads.messages.list)
+      .mockResolvedValueOnce({ messages: messages.slice(0, 200) })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveLast = resolve;
+          }),
+      );
+
+    const load = persistence.load("old-thread");
+    await vi.waitFor(() =>
+      expect(cloud.threads.messages.list).toHaveBeenCalledTimes(2),
+    );
+    persistence.reset();
+    resolveLast({ messages: messages.slice(200) });
+
+    expect(await load).toEqual(messages);
+    expect(
+      messages.some((message) => persistence.isPersisted(message.id)),
+    ).toBe(false);
+  });
+
+  it("propagates an old load failure without disturbing post-reset state", async () => {
+    let rejectOld!: (error: Error) => void;
+    vi.mocked(cloud.threads.messages.list).mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectOld = reject;
+        }),
+    );
+    vi.mocked(cloud.threads.messages.create).mockResolvedValue({
+      message_id: "new-remote-id",
+    });
+    const failure = new Error("history failed");
+    const oldLoad = persistence.load("old-thread");
+    const rejected = expect(oldLoad).rejects.toBe(failure);
+    persistence.reset();
+    await persistence.append("new-thread", "new-message", null, "aui/v0", {});
+    rejectOld(failure);
+
+    await rejected;
+    expect(await persistence.getRemoteId("new-message")).toBe("new-remote-id");
+  });
+
   it("maps prototype-named loaded messages", async () => {
     vi.mocked(cloud.threads.messages.list).mockResolvedValue({
       messages: [


### PR DESCRIPTION
Fixes #7252

## Problem

An in-flight `CloudMessagePersistence.load()` can restore old message IDs after `reset()`.

Minimal sequence:

1. Start loading an old thread and leave its response pending.
2. Call `reset()`, then load or append messages in the new state.
3. Let the old response finish.
4. Old IDs become persisted again, and a colliding ID can replace the new mapping.

The [issue includes a runnable deferred-response reproduction](https://github.com/assistant-ui/assistant-ui/issues/7252). The regression was verified against source commit `c41d93a84231a54256e0e1fe6f64951603a039d7`, where `assistant-cloud` declares version `0.2.0`.

This fixes the exported class's reset contract. It is not a claim of a production cross-account leak; first-party integrations use separate persistence instances per thread.

## Root cause

`load()` waits for all history pages, then writes their IDs into the current map. Clearing that map during `reset()` does not invalidate the pending load's later writes.

## Change

Capture the map at the start of a load. Reset replaces the map, and a completed load populates it only if that map is still current.

The old caller still receives its result or rejection normally. Existing append ownership checks continue to work. No cancellation behavior, thread-keyed mapping, or public scope identifier is introduced.

## Verification

Three reset/load regressions fail without the change. With the fix, all 23 persistence tests and all 223 Cloud tests pass. Coverage includes a late response after a new load, a new append with a colliding ID, reset between pagination responses, and old-load rejection.

From `packages/cloud`:

```sh
./node_modules/.bin/vitest run src/tests/CloudMessagePersistence.test.ts
node --input-type=module -e 'import { startVitest } from "vitest/node"; const context = await startVitest("test", [], { run: true, watch: false }, { test: { clearMocks: true } }); await context.close();'
./node_modules/.bin/aui-build
```

From the repository root:

```sh
./node_modules/.bin/oxlint packages/cloud/src/CloudMessagePersistence.ts packages/cloud/src/tests/CloudMessagePersistence.test.ts
./node_modules/.bin/oxfmt --check packages/cloud/src/CloudMessagePersistence.ts packages/cloud/src/tests/CloudMessagePersistence.test.ts
node scripts/check-changesets.mjs
git diff --check origin/main...HEAD
```

These checks passed, with the full suite and build repeated after rebasing onto `b23c50501`.

The local size measurement for the main Cloud entry is over the recorded budget on both unchanged main and this branch: 8,280 gzip bytes on `b23c50501`, 8,289 with this fix, against a 7,987-byte budget. The fix adds 9 bytes. The other Cloud entries remain within budget. This comparison uses the repository's `measureEntry` and `budgetStatus` helpers against separately built base/head dists. No budget was rewritten from this older local toolchain; CI still needs to establish the result with declared dependencies.

Local verification used Node 23.11.0 and Vitest 4.1.11 from the existing workspace installation. The full-suite command enables mock clearing to match the declared Vitest 5 default without changing repository configuration. GitHub CI still needs to verify the declared Node >=24/Vitest 5 environment. No published npm artifact was tested.

## Public surface

Patch changeset for `assistant-cloud`. The `reset()` JSDoc now documents that pending loads settle normally without repopulating the reset mapping. No new exports, signatures, or templates.

Documentation follow-up verification: all 23 persistence tests, the Cloud build, and scoped lint/format passed. Both docs generators completed successfully using their direct `tsx` commands (`scripts/generate-api-reference.mts --strict` and `scripts/generate-type-docs.mts`). The `pnpm` wrapper could not run with this worktree's symlinked dependency directory, so the underlying scripts were invoked directly. The new JSDoc is present in the built TypeScript declarations. No tracked MDX drift was produced: the current class extractor emits empty method descriptions, so this method-level text does not yet appear in the site reference table. Changing that shared generator is outside this follow-up.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.TPavBnXDVGafDwTAnT6lS6ucm9TQ_VlhQNXb1OJX4c4aFN_xn59S6hPM8-U?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

### Review follow-up

`f45350951` clarifies that pending `load()` and `append()` calls settle normally after reset without restoring their mappings. Added a pending-append contract test; it also passes with the old `clear()` implementation because append already checked task ownership, so this is not claimed as a new append behavior fix.

Latest verification: Node 24.19.0, 23 focused persistence tests, 223 Cloud tests under each default and peer-v6 configuration, `aui-build`, scoped oxlint/oxfmt, and `git diff --check` passed. The emitted `CloudMessagePersistence.d.ts` includes the updated JSDoc.

The pre-existing same-map load/append collision was reproduced on both main and this PR and is tracked separately in #7266; it is not fixed by reset invalidation.
