### PR TITLE
fix(assistant-stream): scan fragmented SSE lines incrementally

### DIFF
--- a/.changeset/bright-lines-stream.md
+++ b/.changeset/bright-lines-stream.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: avoid repeatedly scanning unfinished SSE lines when events arrive in small chunks

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts
@@ -186,9 +186,9 @@ describe("SSEEventDecoder", () => {
   });
 
   it.each(["\n", "\r", "\r\n"])(
-    "decodes fragmented large events with %j delimiters",
+    "decodes fragmented events with %j delimiters",
     (newline) => {
-      const data = "x".repeat(128 * 1024);
+      const data = "x".repeat(4 * 1024);
       const wire = `\uFEFFid: 7${newline}retry: 1000${newline}event: update${newline}data: ${data}${newline}data: end${newline}${newline}data: next${newline}${newline}`;
       for (const chunkSize of [1, 1024, 4093]) {
         const decoder = new SSEEventDecoder();

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts
@@ -184,4 +184,42 @@ describe("SSEEventDecoder", () => {
     expect(decoder.flush()).toEqual({ data: "x" });
     expect(decoder.flush()).toBeNull();
   });
+
+  it.each(["\n", "\r", "\r\n"])(
+    "decodes fragmented large events with %j delimiters",
+    (newline) => {
+      const data = "x".repeat(128 * 1024);
+      const wire = `\uFEFFid: 7${newline}retry: 1000${newline}event: update${newline}data: ${data}${newline}data: end${newline}${newline}data: next${newline}${newline}`;
+      for (const chunkSize of [1, 1024, 4093]) {
+        const decoder = new SSEEventDecoder();
+        const events = [];
+        for (let i = 0; i < wire.length; i += chunkSize) {
+          events.push(...decoder.push(wire.slice(i, i + chunkSize)));
+          events.push(...decoder.push(""));
+        }
+        expect(events).toEqual([
+          { id: "7", retry: 1000, event: "update", data: `${data}\nend` },
+          { id: "7", retry: 1000, data: "next" },
+        ]);
+        expect(decoder.flush()).toBeNull();
+      }
+    },
+  );
+
+  it.each(["drop", "dispatch"] as const)(
+    "clears fragmented trailing data with the %s policy",
+    (trailing) => {
+      const decoder = new SSEEventDecoder({ trailing });
+      const data = "x".repeat(8192);
+      decoder.push("data: ");
+      for (let i = 0; i < data.length; i += 128) {
+        expect(decoder.push(data.slice(i, i + 128))).toEqual([]);
+      }
+      expect(decoder.flush()).toEqual(
+        trailing === "dispatch" ? { data } : null,
+      );
+      expect(decoder.flush()).toBeNull();
+      expect(decoder.push("data: fresh\n\n")).toEqual([{ data: "fresh" }]);
+    },
+  );
 });

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts
@@ -6,7 +6,7 @@ export type SSEEvent = {
 };
 
 export class SSEEventDecoder {
-  private lineBuffer = "";
+  private lineChunks: string[] = [];
   private dataLines: string[] = [];
   private eventName: string | undefined;
   private lastEventId: string | undefined;
@@ -34,14 +34,16 @@ export class SSEEventDecoder {
     if (this.pendingLF && text.startsWith("\n")) text = text.slice(1);
     this.pendingLF = text.endsWith("\r");
 
-    this.lineBuffer += text;
-    const lines = this.lineBuffer.split(/\r\n|\r|\n/);
-    this.lineBuffer = lines.pop()!;
+    const lines = text.split(/\r\n|\r|\n/);
+    const remainder = lines.pop()!;
 
     for (const line of lines) {
-      const event = this.processLine(line);
+      this.lineChunks.push(line);
+      const event = this.processLine(this.lineChunks.join(""));
+      this.lineChunks = [];
       if (event) events.push(event);
     }
+    if (remainder !== "") this.lineChunks.push(remainder);
 
     return events;
   }
@@ -49,16 +51,16 @@ export class SSEEventDecoder {
   flush(): SSEEvent | null {
     if (this.trailing === "drop") {
       this.resetFrame();
-      this.lineBuffer = "";
+      this.lineChunks = [];
       this.pendingLF = false;
       return null;
     }
 
-    if (this.lineBuffer.length > 0) {
-      this.processLine(this.lineBuffer);
+    if (this.lineChunks.length > 0) {
+      this.processLine(this.lineChunks.join(""));
     }
 
-    this.lineBuffer = "";
+    this.lineChunks = [];
     this.pendingLF = false;
     return this.dispatchEvent();
   }

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts
@@ -38,9 +38,13 @@ export class SSEEventDecoder {
     const remainder = lines.pop()!;
 
     for (const line of lines) {
-      this.lineChunks.push(line);
-      const event = this.processLine(this.lineChunks.join(""));
-      this.lineChunks = [];
+      let completeLine = line;
+      if (this.lineChunks.length > 0) {
+        this.lineChunks.push(line);
+        completeLine = this.lineChunks.join("");
+        this.lineChunks = [];
+      }
+      const event = this.processLine(completeLine);
       if (event) events.push(event);
     }
     if (remainder !== "") this.lineChunks.push(remainder);

--- a/packages/x-performance/bench/sse-fragmentation.bench.ts
+++ b/packages/x-performance/bench/sse-fragmentation.bench.ts
@@ -1,0 +1,21 @@
+import { describe, test } from "vitest";
+import { SSEEventDecoder } from "assistant-stream/utils";
+
+describe("assistant-stream: fragmented SSE events", () => {
+  for (const size of [100 * 1024, 1024 * 1024]) {
+    const wire = `data: ${JSON.stringify({ content: "x".repeat(size) })}\n\n`;
+    for (const chunkSize of [1024, wire.length]) {
+      const chunks = [];
+      for (let i = 0; i < wire.length; i += chunkSize) {
+        chunks.push(wire.slice(i, i + chunkSize));
+      }
+      const name = `${size / 1024} KiB, ${chunks.length} chunks`;
+      test(name, async ({ bench }) => {
+        await bench(name, () => {
+          const decoder = new SSEEventDecoder();
+          for (const chunk of chunks) decoder.push(chunk);
+        }).run();
+      });
+    }
+  }
+});

--- a/packages/x-performance/contracts/sse-fragmentation.test.ts
+++ b/packages/x-performance/contracts/sse-fragmentation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { SSEEventDecoder } from "assistant-stream/utils";
+
+describe("SSE newline scanning", () => {
+  it.each([1, 128, 4096])(
+    "scans each incoming code unit once with %i-character chunks",
+    (chunkSize) => {
+      const data = "x".repeat(4096);
+      const wire = `data: ${data}\n\n`;
+      const decoder = new SSEEventDecoder();
+      const events = [];
+      const split = String.prototype.split;
+      let scanned = 0;
+      const scan = vi
+        .spyOn(String.prototype, "split")
+        .mockImplementation(function (this: string, separator, limit) {
+          scanned += this.length;
+          return Reflect.apply(split, this, [separator, limit]);
+        });
+      try {
+        for (let i = 0; i < wire.length; i += chunkSize) {
+          events.push(...decoder.push(wire.slice(i, i + chunkSize)));
+        }
+      } finally {
+        scan.mockRestore();
+      }
+
+      expect(events).toEqual([{ data }]);
+      expect(scanned).toBe(wire.length);
+    },
+  );
+});

--- a/packages/x-performance/contracts/sse-fragmentation.test.ts
+++ b/packages/x-performance/contracts/sse-fragmentation.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import { SSEEventDecoder } from "assistant-stream/utils";
 
-describe("SSE newline scanning", () => {
+describe("SSE newline-split input volume", () => {
   it.each([1, 128, 4096])(
-    "scans each incoming code unit once with %i-character chunks",
+    "offers each incoming code unit to split once with %i-character chunks",
     (chunkSize) => {
       const data = "x".repeat(4096);
       const wire = `data: ${data}\n\n`;
       const decoder = new SSEEventDecoder();
       const events = [];
       const split = String.prototype.split;
+      // A different scanning primitive needs its own work counter in this contract.
       let scanned = 0;
       const scan = vi
         .spyOn(String.prototype, "split")


### PR DESCRIPTION
## Problem

Closes #7257.

On current main (`2a550becf98d36a400cc1886bd57dfbe08e07279`, assistant-stream 0.3.42 source), one large SSE data event arriving in many small chunks repeatedly scans its unfinished line. The output is correct, but cumulative scanning grows quadratically. The issue includes a runnable reproduction with a 1 MiB JSON payload delivered in 1 KiB chunks.

## Root cause

Each push appends to the buffered line and splits the entire accumulated string to find newlines, including the prefix already checked on previous pushes.

## Change

Split only the new chunk with the existing newline parser. Keep unfinished fragments separate and join them only when the line terminates or the configured trailing-frame flush needs them. This avoids both repeated scans and repeated flattening of the unfinished prefix.

The existing CR/LF/CRLF and BOM handling stays in place. LineDecoderStream remains unchanged because its incomplete-line flush contract differs from SSEEventDecoder. Complete lines without a buffered prefix go directly to field parsing without allocating fragment arrays. Add fragmentation compatibility tests, an exact scan-volume contract against the built public entry, and an informational benchmark in x-performance.

## Verification

Verified under Node 24.21.0 after a frozen-lockfile install:

- `pnpm exec turbo build --filter=assistant-stream`
- `pnpm -C packages/assistant-stream test:v6`: 553 passed, 22 skipped.
- `pnpm -C packages/assistant-stream test:peer-v5`
- `pnpm -C packages/assistant-stream test:types:peer-v5`
- `pnpm -C packages/x-performance exec vitest run contracts/sse-fragmentation.test.ts`: 3 passed.
- `pnpm -C packages/x-performance exec vitest bench --run bench/sse-fragmentation.bench.ts`: 4 passed.
- `pnpm lint`: passed with existing warnings.
- `pnpm changesets:check`
- `pnpm size:check`: all built assistant-stream entries within budget; other unbuilt packages skipped.

The new contract fails against the unmodified built decoder and passes after rebuilding with this fix. For a 4,104-character event split into single-character pushes, the old parser offered 8,419,357 characters to newline splitting; the new parser offers exactly 4,104.

Local seven-sample median diagnostic, with exact output assertions:

| Payload | Delivery | Before | After |
| --- | --- | --- | --- |
| 100 KiB | 1 KiB chunks | 0.83 ms | 0.05 ms |
| 1 MiB | 1 KiB chunks | 112.42 ms | 0.33 ms |
| 100 KiB | One chunk | 0.011 ms | 0.016 ms |
| 1 MiB | One chunk | 0.20 ms | 0.09 ms |

These are machine-dependent local measurements, not timing thresholds or a claim about every small token event. Correctness coverage includes all newline styles, empty pushes, BOM, IDs, retry values, multiple events and both trailing-frame policies.

## Public surface

- Published package: assistant-stream, with a patch changeset.
- Public exports and decoding behavior unchanged.
- No documentation, API-reference or template changes required.
- Adds private x-performance coverage without new dependencies.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.jouACKT5mvAYzJNdheubSl8y_Vp2wwbxZ-4dBOD5spJ9S__J5dGrKLcnz_w?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
