### PR TITLE
fix(react-ink): locate cursor graphemes without scanning the prefix

### DIFF
--- a/.changeset/quick-terminal-cursor.md
+++ b/.changeset/quick-terminal-cursor.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-ink": patch
 ---
 
-fix: avoid scanning long prompt prefixes when moving the cursor left or looking up its grapheme
+fix: avoid scanning long prompt prefixes when moving, editing or looking up cursor graphemes

--- a/.changeset/quick-terminal-cursor.md
+++ b/.changeset/quick-terminal-cursor.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix: avoid scanning long prompt prefixes when moving the cursor left or looking up its grapheme

--- a/packages/react-ink/package.json
+++ b/packages/react-ink/package.json
@@ -35,7 +35,7 @@
     "build": "aui-build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "bench": "vitest bench --run",
+    "bench": "vitest bench --run src/primitives/textInput/useTextBuffer.bench.ts",
     "benchmark": "tsx benchmarks/run.ts"
   },
   "dependencies": {

--- a/packages/react-ink/package.json
+++ b/packages/react-ink/package.json
@@ -35,6 +35,7 @@
     "build": "aui-build",
     "test": "vitest run",
     "test:watch": "vitest",
+    "bench": "vitest bench --run",
     "benchmark": "tsx benchmarks/run.ts"
   },
   "dependencies": {

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.bench.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.bench.ts
@@ -11,5 +11,14 @@ describe("terminal cursor near the end of a long prompt", () => {
         getGraphemeAt(text, moved.cursorOffset);
       }).run();
     });
+    const nearEnd = { ...state, cursorOffset: size - 1 };
+    test(`${size} characters, editing before the end`, async ({ bench }) => {
+      await bench(`${size} characters, editing before the end`, () => {
+        textBufferReducer(nearEnd, { type: "move-right" });
+        textBufferReducer(nearEnd, { type: "insert", text: "!" });
+        textBufferReducer(nearEnd, { type: "delete-backward" });
+        getGraphemeAt(text, nearEnd.cursorOffset);
+      }).run();
+    });
   }
 });

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.bench.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.bench.ts
@@ -1,0 +1,15 @@
+import { describe, test } from "vitest";
+import { getGraphemeAt, textBufferReducer } from "./useTextBuffer";
+
+describe("terminal cursor near the end of a long prompt", () => {
+  for (const size of [10_000, 100_000, 1_000_000]) {
+    const text = "x".repeat(size);
+    const state = { text, cursorOffset: size, preferredColumn: undefined };
+    test(`${size} characters`, async ({ bench }) => {
+      await bench(`${size} characters`, () => {
+        const moved = textBufferReducer(state, { type: "move-left" });
+        getGraphemeAt(text, moved.cursorOffset);
+      }).run();
+    });
+  }
+});

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.cursor.test.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.cursor.test.ts
@@ -18,6 +18,23 @@ describe("cursor grapheme lookup", () => {
           textBufferReducer(state, { type: "move-left" }).cursorOffset,
         ).toBe(1);
       }
+      for (let cursorOffset = 1; cursorOffset < end; cursorOffset++) {
+        const state = { text, cursorOffset, preferredColumn: undefined };
+        expect(
+          textBufferReducer(state, { type: "move-right" }).cursorOffset,
+        ).toBe(end);
+        expect(
+          textBufferReducer(state, { type: "set-cursor", cursorOffset })
+            .cursorOffset,
+        ).toBe(1);
+      }
+      const start = { text, cursorOffset: 1, preferredColumn: undefined };
+      expect(textBufferReducer(start, { type: "delete-forward" }).text).toBe(
+        "xy",
+      );
+      expect(
+        textBufferReducer(start, { type: "insert", text: "!" }).cursorOffset,
+      ).toBe(2);
       const state = { text, cursorOffset: end, preferredColumn: undefined };
       expect(textBufferReducer(state, { type: "delete-backward" }).text).toBe(
         "xy",
@@ -42,12 +59,13 @@ describe("cursor grapheme lookup", () => {
   });
 
   it.each([128, 8192])(
-    "does not iterate over a %i-character prefix to move or render the cursor",
+    "does not iterate over a %i-character prefix to move, edit or render near the end",
     (size) => {
-      const text = `${"x".repeat(size)}😀`;
+      const prefix = "x".repeat(size);
+      const text = `${prefix}😀y`;
       const state = {
         text,
-        cursorOffset: text.length,
+        cursorOffset: text.length - 1,
         preferredColumn: undefined,
       };
       const segment = Intl.Segmenter.prototype.segment;
@@ -67,16 +85,44 @@ describe("cursor grapheme lookup", () => {
         });
       let cursorOffset: number;
       let grapheme: string;
+      let results: ReturnType<typeof textBufferReducer>[] = [];
       try {
         cursorOffset = textBufferReducer(state, {
           type: "move-left",
         }).cursorOffset;
         grapheme = getGraphemeAt(text, cursorOffset);
+        const start = { ...state, cursorOffset: size };
+        results = [
+          textBufferReducer(start, { type: "move-right" }),
+          textBufferReducer(start, { type: "insert", text: "!" }),
+          textBufferReducer(state, { type: "delete-backward" }),
+          textBufferReducer(start, { type: "delete-forward" }),
+          textBufferReducer(state, {
+            type: "set-cursor",
+            cursorOffset: size + 1,
+          }),
+        ];
       } finally {
         segmentation.mockRestore();
       }
       expect(cursorOffset).toBe(size);
       expect(grapheme).toBe("😀");
+      expect(results.map((result) => result.cursorOffset)).toEqual([
+        size + 2,
+        size + 1,
+        size,
+        size,
+        size,
+      ]);
+      expect(results.map((result) => result.text.slice(size))).toEqual([
+        "😀y",
+        "!😀y",
+        "y",
+        "y",
+        "😀y",
+      ]);
+      for (const result of results)
+        expect(result.text.slice(0, size)).toBe(prefix);
       expect(visited).toBe(0);
     },
   );

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.cursor.test.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.cursor.test.ts
@@ -18,6 +18,14 @@ describe("cursor grapheme lookup", () => {
           textBufferReducer(state, { type: "move-left" }).cursorOffset,
         ).toBe(1);
       }
+      const fractional = {
+        text,
+        cursorOffset: 1.5,
+        preferredColumn: undefined,
+      };
+      expect(
+        textBufferReducer(fractional, { type: "move-left" }).cursorOffset,
+      ).toBe(1);
       for (let cursorOffset = 1; cursorOffset < end; cursorOffset++) {
         const state = { text, cursorOffset, preferredColumn: undefined };
         expect(

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.test.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { getGraphemeAt, textBufferReducer } from "./useTextBuffer";
+
+describe("cursor grapheme lookup", () => {
+  it.each(["a", "😀", "👍🏽", "👩‍💻", "🇪🇹", "e\u0301", "\r\n"])(
+    "preserves the boundaries of %j",
+    (grapheme) => {
+      const text = `x${grapheme}y`;
+      const end = 1 + grapheme.length;
+      expect(getGraphemeAt(text, 1)).toBe(grapheme);
+      expect(getGraphemeAt(text, end)).toBe("y");
+      for (let offset = 2; offset < end; offset++) {
+        expect(getGraphemeAt(text, offset)).toBe("");
+      }
+      for (let cursorOffset = 2; cursorOffset <= end; cursorOffset++) {
+        const state = { text, cursorOffset, preferredColumn: undefined };
+        expect(
+          textBufferReducer(state, { type: "move-left" }).cursorOffset,
+        ).toBe(1);
+      }
+      const state = { text, cursorOffset: end, preferredColumn: undefined };
+      expect(textBufferReducer(state, { type: "delete-backward" }).text).toBe(
+        "xy",
+      );
+    },
+  );
+
+  it("preserves empty and out-of-range lookups", () => {
+    for (const text of ["", "x", "😀"]) {
+      for (const offset of [-1, 0.5, text.length, text.length + 1]) {
+        expect(getGraphemeAt(text, offset)).toBe("");
+      }
+      const state = { text, cursorOffset: 0, preferredColumn: undefined };
+      expect(textBufferReducer(state, { type: "move-left" }).cursorOffset).toBe(
+        0,
+      );
+    }
+    const state = { text: "x😀", cursorOffset: 99, preferredColumn: undefined };
+    expect(textBufferReducer(state, { type: "move-left" }).cursorOffset).toBe(
+      1,
+    );
+  });
+
+  it.each([128, 8192])(
+    "does not iterate over a %i-character prefix to move or render the cursor",
+    (size) => {
+      const text = `${"x".repeat(size)}😀`;
+      const state = {
+        text,
+        cursorOffset: text.length,
+        preferredColumn: undefined,
+      };
+      const segment = Intl.Segmenter.prototype.segment;
+      let visited = 0;
+      const segmentation = vi
+        .spyOn(Intl.Segmenter.prototype, "segment")
+        .mockImplementation(function (this: Intl.Segmenter, input) {
+          const segments = segment.call(this, input);
+          const iterate = segments[Symbol.iterator].bind(segments);
+          segments[Symbol.iterator] = function* () {
+            for (const entry of iterate()) {
+              visited++;
+              yield entry;
+            }
+          };
+          return segments;
+        });
+      let cursorOffset: number;
+      let grapheme: string;
+      try {
+        cursorOffset = textBufferReducer(state, {
+          type: "move-left",
+        }).cursorOffset;
+        grapheme = getGraphemeAt(text, cursorOffset);
+      } finally {
+        segmentation.mockRestore();
+      }
+      expect(cursorOffset).toBe(size);
+      expect(grapheme).toBe("😀");
+      expect(visited).toBe(0);
+    },
+  );
+});

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
@@ -37,12 +37,11 @@ const wordSegmenter = new Intl.Segmenter(undefined, { granularity: "word" });
 
 const stepGraphemeLeft = (text: string, offset: number) => {
   if (offset <= 0) return 0;
-  let previous = 0;
-  for (const { index } of graphemeSegmenter.segment(text)) {
-    if (index >= offset) break;
-    previous = index;
-  }
-  return previous;
+  return (
+    graphemeSegmenter
+      .segment(text)
+      .containing(Math.min(offset, text.length) - 1)?.index ?? 0
+  );
 };
 
 const snapToGraphemeBoundary = (text: string, offset: number) => {
@@ -77,12 +76,9 @@ const stepGraphemeRight = (text: string, offset: number) => {
 };
 
 export const getGraphemeAt = (text: string, offset: number) => {
-  if (offset >= text.length) return "";
-  for (const { index, segment } of graphemeSegmenter.segment(text)) {
-    if (index === offset) return segment;
-    if (index > offset) return "";
-  }
-  return "";
+  if (offset < 0 || offset >= text.length) return "";
+  const segment = graphemeSegmenter.segment(text).containing(offset);
+  return segment?.index === offset ? segment.segment : "";
 };
 
 const getLineStart = (text: string, cursorOffset: number) => {

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
@@ -47,32 +47,20 @@ const stepGraphemeLeft = (text: string, offset: number) => {
 const snapToGraphemeBoundary = (text: string, offset: number) => {
   if (offset <= 0) return 0;
   if (offset >= text.length) return text.length;
-  let previous = 0;
-  for (const { index } of graphemeSegmenter.segment(text)) {
-    if (index === offset) return offset;
-    if (index > offset) break;
-    previous = index;
-  }
-  return previous;
+  return graphemeSegmenter.segment(text).containing(offset)!.index;
 };
 
 const snapToNextGraphemeBoundary = (text: string, offset: number) => {
   if (offset <= 0) return 0;
   if (offset >= text.length) return text.length;
-  for (const { index, segment } of graphemeSegmenter.segment(text)) {
-    const end = index + segment.length;
-    if (offset <= end) return end;
-  }
-  return text.length;
+  const entry = graphemeSegmenter.segment(text).containing(offset)!;
+  return entry.index === offset ? offset : entry.index + entry.segment.length;
 };
 
 const stepGraphemeRight = (text: string, offset: number) => {
   if (offset >= text.length) return text.length;
-  for (const { index, segment } of graphemeSegmenter.segment(text)) {
-    const end = index + segment.length;
-    if (end > offset) return end;
-  }
-  return text.length;
+  const entry = graphemeSegmenter.segment(text).containing(Math.max(offset, 0));
+  return entry ? entry.index + entry.segment.length : text.length;
 };
 
 export const getGraphemeAt = (text: string, offset: number) => {

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
@@ -40,7 +40,7 @@ const stepGraphemeLeft = (text: string, offset: number) => {
   return (
     graphemeSegmenter
       .segment(text)
-      .containing(Math.min(offset, text.length) - 1)?.index ?? 0
+      .containing(Math.ceil(Math.min(offset, text.length)) - 1)?.index ?? 0
   );
 };
 


### PR DESCRIPTION
## Problem

Closes #7258.

On main `2a550becf98d36a400cc1886bd57dfbe08e07279` (@assistant-ui/react-ink 0.0.42 source), cursor movement, editing near the end of a long prompt and looking up the cursor grapheme iterate from the start of the text. The issue includes a runnable reproduction at 10,000, 100,000 and 1,000,000 characters.

## Root cause

The five local grapheme helpers iterate preceding Intl.Segmenter results just to locate a boundary next to the cursor. Focused rendering calls the lookup separately, so it can repeat the same prefix walk.

## Change

Use Segments.containing for movement in both directions, edit/cursor boundary snapping and the cursor's current grapheme. Keep the existing distinction between a grapheme start and an offset inside a cluster, along with empty, negative, fractional, end and out-of-range behavior.

This uses the same Intl.Segmenter capability already required by the text buffer, not a new dependency or code-unit-based fallback. Word movement and vertical display-column calculations remain unchanged because they need word-like segments or accumulated terminal-cell widths, not just the grapheme next to the cursor. Add focused Unicode tests, an exact prefix-iteration regression contract and a colocated internal benchmark, following the package-internal benchmark exception in packages/x-performance/README.md.

## Verification

Node 24.21.0, frozen-lockfile install:

- `pnpm exec turbo build --filter=@assistant-ui/react-ink`
- `pnpm -C packages/react-ink test`: 293 tests passed after building the workspace dependencies.
- `pnpm -C packages/react-ink bench`: six cursor cases passed, covering both the end of the buffer and edits one character before the end.
- Focused oxlint and repository-wide `oxfmt --check` passed.
- `pnpm changesets:check`
- `pnpm size:check`: built entries within budget.

The initial prefix-iteration contract failed on main. The expanded near-end edit contract also failed on the initial two-helper implementation (774 and 49,158 visited prefix segments) and passes with zero after covering all five helpers. A separate 2,688-case before/after comparison across Unicode combinations, integer cursor offsets, movement, insertion and deletion produced identical states. Unicode coverage includes surrogate pairs, skin-tone modifiers, ZWJ sequences, flags, combining marks, CRLF and interior offsets. Fractional-offset cases fail before ceiling the lookup position and pass with the preserved boundary behavior. Existing terminal-cell-width and rendering tests pass.

Local seven-sample medians for the source-level issue probe:

| Prompt length | Move left, before / after | Cursor lookup, before / after |
| --- | --- | --- |
| 10,000 | 0.59 / 0.005 ms | 0.61 / 0.004 ms |
| 100,000 | 5.77 / 0.026 ms | 5.81 / 0.029 ms |
| 1,000,000 | 55.11 / 0.319 ms | 59.20 / 0.238 ms |

These are machine-dependent helper measurements, not end-to-end rendering guarantees or CI timing thresholds. Direct lookup avoids JavaScript prefix iteration; it does not promise constant-time processing of arbitrarily large strings.

## Public surface

- @assistant-ui/react-ink patch changeset.
- No new exports, dependencies, engine requirements or user-facing behavior.
- No documentation, generated API reference or template changes required.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.7hSNapJjePgf2oD8yWTjY91-oL0z1ozsdPwljKkpF9UXy2gaQLL4EVWrD88?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

