### PR TITLE
docs(cloud): clarify telemetry report content

### DIFF
--- a/.changeset/clear-cloud-report-content.md
+++ b/.changeset/clear-cloud-report-content.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+docs: clarify that run telemetry can include assistant output and tool data

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -59,7 +59,10 @@ export type AssistantCloudConfig = (
    *
    * When enabled, the SDK automatically reports run metadata (status, step
    * count, tool calls, and token usage) to Assistant Cloud after each
-   * assistant message is saved. No message content is sent.
+   * assistant message is saved. Reports can also include assistant output,
+   * tool arguments and results, errors, and metadata, which may contain
+   * sensitive content. Use `beforeReport` to redact or drop reports, or
+   * `telemetry: false` to disable reporting.
    *
    * - `true` / `undefined` — enabled with defaults
    * - `false` — disabled


### PR DESCRIPTION
## Problem

Closes #7260.

AssistantCloudConfig.telemetry says that no message content is sent, even though run reports can contain assistant output and tool arguments/results. This is present in assistant-cloud 0.2.0 source on main `2a550becf98d36a400cc1886bd57dfbe08e07279`. The issue includes a minimal report-construction snippet showing the content fields.

## Root cause

The configuration JSDoc was not updated to match the report payload and the existing run reports guide.

## Change

Replace the blanket claim with an explicit warning about assistant output, tool data, errors and metadata. Explain that beforeReport can redact or drop reports and telemetry: false disables reporting. The existing guide already explains these controls, so no new guide is added.

## Verification

Node 24.21.0, frozen-lockfile install:

- `pnpm exec turbo build --filter=assistant-cloud`
- `pnpm -C packages/cloud test:v7`: 218 tests passed.
- `pnpm -C apps/docs generate:type-docs`
- `pnpm -C apps/docs generate:api-reference --strict`
- Focused oxlint, oxfmt and `pnpm changesets:check` passed.

The corrected JSDoc appears in dist/AssistantCloudAPI.d.ts. Both generators completed with existing unresolved-link warnings and no tracked API-reference changes. The payload reproduction remains unchanged because this corrects the documentation, not runtime behavior.

## Public surface

- assistant-cloud configuration JSDoc and a patch changeset.
- No signature, export, collection behavior or template changes.
- Existing telemetry guide remains unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.24Xh2MkVzXMBA4h9vIod4cPSQsV__GJ3byVk0kyl-sqEyk-U5gZ5fX3_B4o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->