### PR TITLE
fix(docs): include class member descriptions in the API reference

### DIFF
--- a/apps/docs/scripts/generated-docs/extract.mts
+++ b/apps/docs/scripts/generated-docs/extract.mts
@@ -1085,14 +1085,13 @@ export function processComponentDeclaration(
   );
 }
 
-function classExtractedShape(
+export function processClassDeclaration(
   declaration: TsNode,
   typeName: string,
+  options?: JsDocRenderOptions,
 ): PropModel[] | undefined {
   if (!Node.isClassDeclaration(declaration)) return undefined;
   const parameters: PropModel[] = [];
-  // Class members carry no per-member required-ness or JSDoc here. Match
-  // legacy api-surface output exactly: empty description, required omitted.
   for (const ctor of declaration.getConstructors()) {
     if (!isPublicClassMember(ctor)) continue;
     const t = `(${ctor.getParameters().map(parameterSignature).join(", ")}) => ${typeName}`;
@@ -1100,7 +1099,7 @@ function classExtractedShape(
       name: "constructor",
       rawType: t,
       declaredType: t,
-      description: "",
+      description: propertyJsDocMeta(ctor, options).description ?? "",
     });
   }
   for (const property of declaration.getProperties()) {
@@ -1110,7 +1109,7 @@ function classExtractedShape(
       name: `${classMemberPrefix(property)}${property.getName()}`,
       rawType: t,
       declaredType: t,
-      description: "",
+      description: propertyJsDocMeta(property, options).description ?? "",
     });
   }
   for (const method of declaration.getMethods()) {
@@ -1120,7 +1119,7 @@ function classExtractedShape(
       name: `${classMemberPrefix(method)}${method.getName()}`,
       rawType: t,
       declaredType: t,
-      description: "",
+      description: propertyJsDocMeta(method, options).description ?? "",
     });
   }
   if (parameters.length === 0) return undefined;
@@ -1172,7 +1171,7 @@ function shapeForDeclaration(
   }
   // Match legacy: only attempt class extraction here, no callable fallback for
   // "value" kind exports (those render their signature in MDX, not a table).
-  const params = classExtractedShape(declaration, name);
+  const params = processClassDeclaration(declaration, name, options);
   return params ? { kind: "class", name, parameters: params } : undefined;
 }
 

--- a/apps/docs/scripts/generated-docs/extract.test.ts
+++ b/apps/docs/scripts/generated-docs/extract.test.ts
@@ -1,9 +1,13 @@
 import { Project } from "ts-morph";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   cleanSignatureText,
   cleanTypeText,
   extractSignature,
+  processClassDeclaration,
 } from "./extract.mts";
+import { REPO_ROOT } from "./paths.mts";
 
 describe("signature text cleanup", () => {
   it("preserves undefined in callable return types", () => {
@@ -52,5 +56,126 @@ describe("signature text cleanup", () => {
         "const useWidget: () => WidgetAdapters;",
       ].join("\n\n"),
     );
+  });
+});
+
+describe("class member descriptions", () => {
+  it("keeps constructor, property and method prose without changing their shape", () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const source = project.createSourceFile(
+      "client.ts",
+      `
+      export class Client {
+        /** Creates a client. */
+        constructor() {}
+        /** The optional **label**. */
+        label?: string;
+        /** Loads the next page. */
+        load(): void {}
+      }
+    `,
+    );
+    expect(
+      processClassDeclaration(source.getClassOrThrow("Client"), "Client"),
+    ).toEqual([
+      {
+        name: "constructor",
+        rawType: "() => Client",
+        declaredType: "() => Client",
+        description: "Creates a client.",
+      },
+      {
+        name: "label",
+        rawType: "string",
+        declaredType: "string",
+        description: "The optional **label**.",
+      },
+      {
+        name: "load",
+        rawType: "() => void",
+        declaredType: "() => void",
+        description: "Loads the next page.",
+      },
+    ]);
+  });
+
+  it("uses the configured JSDoc link renderer for each member kind", () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const source = project.createSourceFile(
+      "links.ts",
+      `
+      export class Client {
+        /** Creates a {@link Client}. */
+        constructor() {}
+        /** See {@link Client | the client}. */
+        label: string;
+        /** Loads from {@link https://example.com | the service}. */
+        load(): void {}
+      }
+    `,
+    );
+    const members = processClassDeclaration(
+      source.getClassOrThrow("Client"),
+      "Client",
+      {
+        linkResolver: (name) =>
+          name === "Client" ? "/docs/client" : undefined,
+      },
+    );
+    expect(members?.map((member) => member.description)).toEqual([
+      "Creates a [Client](/docs/client).",
+      "See [the client](/docs/client).",
+      "Loads from [the service](https://example.com).",
+    ]);
+  });
+
+  it("keeps undocumented members blank and excludes non-public members", () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const source = project.createSourceFile(
+      "visibility.ts",
+      `
+      export class Client {
+        constructor() {}
+        label: string;
+        load(): void {}
+        /** Shared default. */
+        static shared: string;
+        /** Private data. */
+        private secret: string;
+        /** Protected method. */
+        protected internal(): void {}
+      }
+    `,
+    );
+    const members = processClassDeclaration(
+      source.getClassOrThrow("Client"),
+      "Client",
+    );
+    expect(
+      members?.map(({ name, description }) => ({ name, description })),
+    ).toEqual([
+      { name: "constructor", description: "" },
+      { name: "label", description: "" },
+      { name: "static shared", description: "Shared default." },
+      { name: "load", description: "" },
+    ]);
+  });
+
+  it("retains CloudMessagePersistence.load documentation from its source", () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const source = project.createSourceFile(
+      "CloudMessagePersistence.ts",
+      readFileSync(
+        join(REPO_ROOT, "packages/cloud/src/CloudMessagePersistence.ts"),
+        "utf8",
+      ),
+    );
+    const members = processClassDeclaration(
+      source.getClassOrThrow("CloudMessagePersistence"),
+      "CloudMessagePersistence",
+    );
+    expect(
+      members?.find((member) => member.name === "load")?.description,
+    ).toContain("Load messages from the cloud and populate the ID mapping.");
   });
 });

--- a/apps/docs/scripts/generated-docs/extract.test.ts
+++ b/apps/docs/scripts/generated-docs/extract.test.ts
@@ -1,13 +1,10 @@
 import { Project } from "ts-morph";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import {
   cleanSignatureText,
   cleanTypeText,
   extractSignature,
   processClassDeclaration,
 } from "./extract.mts";
-import { REPO_ROOT } from "./paths.mts";
 
 describe("signature text cleanup", () => {
   it("preserves undefined in callable return types", () => {
@@ -159,23 +156,5 @@ describe("class member descriptions", () => {
       { name: "static shared", description: "Shared default." },
       { name: "load", description: "" },
     ]);
-  });
-
-  it("retains CloudMessagePersistence.load documentation from its source", () => {
-    const project = new Project({ useInMemoryFileSystem: true });
-    const source = project.createSourceFile(
-      "CloudMessagePersistence.ts",
-      readFileSync(
-        join(REPO_ROOT, "packages/cloud/src/CloudMessagePersistence.ts"),
-        "utf8",
-      ),
-    );
-    const members = processClassDeclaration(
-      source.getClassOrThrow("CloudMessagePersistence"),
-      "CloudMessagePersistence",
-    );
-    expect(
-      members?.find((member) => member.name === "load")?.description,
-    ).toContain("Load messages from the cloud and populate the ID mapping.");
   });
 });


### PR DESCRIPTION
## Problem

Closes #7261.

The generated API reference lists public class members but drops their JSDoc descriptions. On main `2a550becf98d36a400cc1886bd57dfbe08e07279`, CloudMessagePersistence.load has useful pagination and ID-mapping documentation in the source, while its generated method description is empty. The issue includes a minimal extractor reproduction.

## Root cause

The class-specific extractor hardcodes an empty description for constructors, properties and methods to preserve legacy output. Regenerating the pages cannot recover prose that this extraction step discards.

## Change

Use the existing propertyJsDocMeta helper for class-member descriptions and pass through the configured JSDoc link renderer. This deliberately replaces the legacy blank-description rule while leaving member selection, names, signatures, requiredness and other metadata unchanged.

Expose the internal class extractor alongside the other declaration processors so it can be tested with small in-memory source fixtures. Cover constructors, properties, methods, links, undocumented members, TypeScript visibility modifiers, static names.

## Verification

Node 24.21.0, frozen-lockfile install:

- New description assertions fail with the previous empty-description behavior and pass after the change.
- `pnpm -C apps/docs exec vitest run scripts/generated-docs --maxWorkers=1`: 8 tests passed.
- `pnpm -C apps/docs exec vitest run scripts --maxWorkers=1`: 18 tests passed.
- `pnpm -C apps/docs generate:type-docs`
- `pnpm -C apps/docs generate:api-reference --strict`
- Focused oxlint, repository-wide `oxfmt --check` and `git diff --check` passed.

The generated integration data now contains 12 additional member descriptions. A before/after comparison with descriptions removed is exactly equal, so names, signatures and other generated integration data did not change. CloudMessagePersistence.load now includes its pagination and mapping explanation.

Both generators completed with existing unresolved-link warnings. Generated type-doc data is gitignored and produced during the docs build; tracked MDX pages already consume that data and did not change. No generated pages were hand-edited.

## Public surface

- Documentation generator and generated class-member prose only.
- No published package exports, runtime behavior, templates or signatures changed.
- No changeset: apps/docs is private.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4feT9OeSLn66nz_2WHlbgD1cVc3UlfyhUwf_hlzuepOR_8DEpGx3yjO7pRI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
