### PR TITLE
fix(cloud): stop queued events after telemetry is disabled

### DIFF
--- a/.changeset/quiet-events-stop.md
+++ b/.changeset/quiet-events-stop.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: stop sending queued engagement events after telemetry is disabled

--- a/packages/cloud/src/AssistantCloudEvents.test.ts
+++ b/packages/cloud/src/AssistantCloudEvents.test.ts
@@ -12,11 +12,11 @@ const event = (index: number): AssistantCloudEvent => ({
   thread_id: `thread-${index}`,
 });
 
-const createEvents = (enabled = true) => {
+const createEvents = (enabled: boolean | (() => boolean) = true) => {
   const makeRequest = vi.fn().mockResolvedValue({ accepted: 1 });
   const events = new AssistantCloudEvents(
     { makeRequest } as unknown as AssistantCloudAPI,
-    () => enabled,
+    typeof enabled === "function" ? enabled : () => enabled,
   );
   return { events, makeRequest };
 };
@@ -104,6 +104,31 @@ describe("AssistantCloudEvents", () => {
 
     await vi.advanceTimersByTimeAsync(2_000);
     expect(makeRequest).not.toHaveBeenCalled();
+  });
+
+  it("does not send queued batches after telemetry is disabled", async () => {
+    let enabled = true;
+    let resolveFirstRequest!: (value: { accepted: number }) => void;
+    const { events, makeRequest } = createEvents(() => enabled);
+    makeRequest.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirstRequest = resolve;
+        }),
+    );
+
+    for (let index = 0; index < 51; index++) events.track(event(index));
+    await vi.waitFor(() => expect(makeRequest).toHaveBeenCalledOnce());
+
+    enabled = false;
+    resolveFirstRequest({ accepted: 50 });
+
+    await vi.waitFor(() =>
+      expect(makeRequest.mock.results[0]?.value).resolves.toEqual({
+        accepted: 50,
+      }),
+    );
+    expect(makeRequest).toHaveBeenCalledOnce();
   });
 
   it("keeps every request below the server batch limit", async () => {

--- a/packages/cloud/src/AssistantCloudEvents.ts
+++ b/packages/cloud/src/AssistantCloudEvents.ts
@@ -118,6 +118,11 @@ export class AssistantCloudEvents {
 
   private async flushPending(): Promise<void> {
     while (this.buffer.length > 0) {
+      if (!this.isEnabled()) {
+        this.buffer = [];
+        return;
+      }
+
       const events = this.buffer.splice(0, MAX_BATCH_SIZE);
       try {
         await this.cloud.makeRequest("/events", {


### PR DESCRIPTION
## Problem

Disabling `cloud.telemetry.enabled` or `cloud.telemetry.events` while an engagement-event batch is in flight does not stop later buffered batches. With 51 queued events, the first 20-event batch can complete after telemetry is disabled and immediately start a second request for the remaining 31 events.

Closes #7259.

## Root cause

`flush()` checks the live telemetry predicate once, before `flushPending()` starts. `flushPending()` then drains every batch across awaited requests without checking whether telemetry was disabled while a request was in flight.

## Change

Recheck the telemetry predicate before each batch. When telemetry becomes disabled, discard events that have not started sending. An already in-flight request is allowed to settle.

## Verification

- Added a regression that holds the first 20-event batch open, disables telemetry, and verifies the remaining 31 events do not start another request.
- `pnpm --dir packages/cloud exec vitest run src/AssistantCloudEvents.test.ts`
- `pnpm --filter assistant-stream build`
- `pnpm --filter assistant-cloud build`
- `pnpm changesets:check`

## Public surface

`assistant-cloud` behavior changes when telemetry is disabled at runtime. No exports or types change. Includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.9xY07GHmTwKae-hhHZ9Sjcyciz2u-rLEUdWWFJ2juRveRFqOw-h5a38I5rc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->