### PR TITLE
fix(react-mcp): reject non-loopback OAuth discovery hosts

### DIFF
--- a/.changeset/strict-loopback-hosts.md
+++ b/.changeset/strict-loopback-hosts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: reject OAuth discovery hosts that only resemble loopback addresses

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
@@ -239,6 +239,8 @@ describe("normalizePersistedAuthState", () => {
 
   it.each([
     "http://auth.example.com",
+    "http://127.example.com",
+    "http://127.0.0.1.example.com",
     "data:text/plain,auth",
     "file:///tmp/auth",
   ])("drops discovery state with an unsafe URL: %s", (url) => {

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
@@ -148,12 +148,13 @@ const isSecureNetworkUrl = (value: unknown): value is string => {
   if (!isNonEmptyString(value)) return false;
   try {
     const url = new URL(value);
+    const isIpv4Loopback = /^127(?:\.\d{1,3}){3}$/.test(url.hostname);
     return (
       url.protocol === "https:" ||
       (url.protocol === "http:" &&
         (url.hostname === "localhost" ||
           url.hostname.endsWith(".localhost") ||
-          url.hostname.startsWith("127.") ||
+          isIpv4Loopback ||
           url.hostname === "[::1]"))
     );
   } catch {


### PR DESCRIPTION
## Problem

Persisted OAuth discovery state permits HTTP only for loopback development servers. The IPv4 check accepted any hostname beginning with `127.`, including DNS names such as `127.example.com` and `127.0.0.1.example.com`.

## Root cause

The validator used a string-prefix check instead of verifying that the normalized hostname was an IPv4 loopback literal.

## Change

Require normalized IPv4 loopback hosts to match a complete `127.x.x.x` address. HTTPS, localhost names, IPv6 loopback, and URL-normalized alternate IPv4 spellings keep their existing behavior.

## Verification

- Added negative regressions for `127.example.com` and `127.0.0.1.example.com`.
- Existing loopback URL coverage remains green.
- `pnpm --dir packages/react-mcp exec vitest run src/resources/storage/McpLocalStorage.test.ts`
- `pnpm --filter @assistant-ui/react-mcp... build`
- `pnpm changesets:check`

## Public surface

`@assistant-ui/react-mcp` rejects malformed persisted HTTP discovery hosts that are not loopback addresses. No exports or types change. Includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.mdqqR9jvfpDT8s12iNoeOEtg6MsuipMfEmkad5LDOs6i8X47CYgvA9E2m7o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->