### PR TITLE
fix(ui): make attachment preview actions accurate

### DIFF
--- a/packages/ui/src/components/react/assistant-ui/elements/attachment.aui.radix.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/attachment.aui.radix.tsx
@@ -43,14 +43,15 @@ import { cn } from "@/lib/utils";
 
 type AttachmentPreviewProps = {
   src: string;
+  name: string;
 };
 
-const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
+const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src, name }) => {
   const [isLoaded, setIsLoaded] = useState(false);
   return (
     <img
       src={src}
-      alt="Attachment preview"
+      alt={`Preview of ${name}`}
       className={cn(
         "block h-auto max-h-[80vh] w-auto max-w-full rounded-sm object-contain transition-opacity duration-300 motion-reduce:transition-none",
         isLoaded
@@ -62,9 +63,16 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
   );
 };
 
-const AttachmentPreviewDialog: FC<PropsWithChildren> = ({ children }) => {
-  const src = useAttachmentSrc();
+type AttachmentPreviewDialogProps = PropsWithChildren<{
+  src: string | undefined;
+  name: string;
+}>;
 
+const AttachmentPreviewDialog: FC<AttachmentPreviewDialogProps> = ({
+  children,
+  src,
+  name,
+}) => {
   if (!src) return children;
 
   return (
@@ -81,24 +89,22 @@ const AttachmentPreviewDialog: FC<PropsWithChildren> = ({ children }) => {
       </DialogTrigger>
       <DialogContent className="aui-attachment-preview-dialog-content [&>button]:bg-foreground/60 [&>button]:hover:bg-foreground/80 [&_svg]:text-background p-2 sm:max-w-3xl [&>button]:rounded-full [&>button]:p-1 [&>button]:opacity-100 [&>button]:ring-0!">
         <DialogTitle className="aui-sr-only sr-only">
-          Image Attachment Preview
+          Preview {name}
         </DialogTitle>
         <div className="aui-attachment-preview bg-background relative mx-auto flex max-h-[80dvh] w-full items-center justify-center overflow-hidden rounded-sm">
-          <AttachmentPreview src={src} />
+          <AttachmentPreview src={src} name={name} />
         </div>
       </DialogContent>
     </Dialog>
   );
 };
 
-const AttachmentThumb: FC = () => {
-  const src = useAttachmentSrc();
-
+const AttachmentThumb: FC<{ src: string | undefined }> = ({ src }) => {
   return (
     <Avatar className="aui-attachment-tile-avatar h-full w-full rounded-none">
       <AvatarImage
         src={src}
-        alt="Attachment preview"
+        alt=""
         className="aui-attachment-tile-image rounded-none object-cover"
       />
       <AvatarFallback>
@@ -111,8 +117,10 @@ const AttachmentThumb: FC = () => {
 const AttachmentUI: FC = () => {
   const aui = useAui();
   const isComposer = aui.attachment.source !== "message";
+  const src = useAttachmentSrc();
 
   const isImage = useAuiState((s) => s.attachment.type === "image");
+  const name = useAuiState((s) => s.attachment.name);
   const typeLabel = useAuiState((s) => {
     const type = s.attachment.type;
     switch (type) {
@@ -158,32 +166,41 @@ const AttachmentUI: FC = () => {
               "aui-attachment-root-message only:*:first:size-24",
           )}
         >
-          <AttachmentPreviewDialog>
+          <AttachmentPreviewDialog src={src} name={name}>
             <TooltipTrigger asChild>
               <div
                 className={cn(
-                  "aui-attachment-tile bg-muted hover:after:bg-foreground/10 focus-visible:ring-ring/50 relative size-14 cursor-pointer overflow-hidden rounded-[calc(var(--composer-radius,1.5rem)-var(--composer-padding,8px))] transition-transform outline-none after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:ring-1 after:ring-black/10 after:transition-colors after:ring-inset focus-visible:ring-1 active:scale-[0.96] motion-reduce:transition-none dark:after:ring-white/10",
+                  "aui-attachment-tile bg-muted hover:after:bg-foreground/10 focus-visible:ring-ring/50 relative size-14 overflow-hidden rounded-[calc(var(--composer-radius,1.5rem)-var(--composer-padding,8px))] transition-transform outline-none after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:ring-1 after:ring-black/10 after:transition-colors after:ring-inset focus-visible:ring-1 motion-reduce:transition-none dark:after:ring-white/10",
+                  src ? "cursor-zoom-in active:scale-[0.96]" : "cursor-default",
                   isError &&
                     "after:ring-destructive/60 dark:after:ring-destructive/60",
                 )}
-                role="button"
+                role={src ? "button" : "group"}
                 tabIndex={0}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    e.currentTarget.click();
-                  } else if (e.key === " ") {
-                    e.preventDefault();
-                  }
-                }}
-                onKeyUp={(e) => {
-                  if (e.key === " ") e.currentTarget.click();
-                }}
-                aria-label={`${typeLabel} attachment${
+                onKeyDown={
+                  src
+                    ? (e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          e.currentTarget.click();
+                        } else if (e.key === " ") {
+                          e.preventDefault();
+                        }
+                      }
+                    : undefined
+                }
+                onKeyUp={
+                  src
+                    ? (e) => {
+                        if (e.key === " ") e.currentTarget.click();
+                      }
+                    : undefined
+                }
+                aria-label={`${src ? `Preview ${name}` : `${typeLabel} attachment ${name}`}${
                   isError ? ", upload failed" : isUploading ? ", uploading" : ""
                 }`}
               >
-                <AttachmentThumb />
+                <AttachmentThumb src={src} />
                 {isUploading && (
                   <div
                     aria-hidden="true"
@@ -203,7 +220,7 @@ const AttachmentUI: FC = () => {
               </div>
             </TooltipTrigger>
           </AttachmentPreviewDialog>
-          {isComposer && <AttachmentRemove />}
+          {isComposer && <AttachmentRemove name={name} />}
         </AttachmentPrimitive.Root>
         <TooltipContent side="top">
           <AttachmentPrimitive.Name />
@@ -216,11 +233,12 @@ const AttachmentUI: FC = () => {
   );
 };
 
-const AttachmentRemove: FC = () => {
+const AttachmentRemove: FC<{ name: string }> = ({ name }) => {
   return (
     <AttachmentPrimitive.Remove asChild>
       <TooltipIconButton
-        tooltip="Remove file"
+        tooltip={`Remove ${name}`}
+        aria-label={`Remove ${name}`}
         className="aui-attachment-tile-remove absolute end-1 top-1 size-5 rounded-full bg-black/50! text-white after:absolute after:-inset-1.5 hover:bg-black/70! hover:text-white! active:scale-[0.96] motion-reduce:transition-none"
         side="top"
       >

--- a/packages/ui/src/components/react/assistant-ui/elements/attachment.aui.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/attachment.aui.test.tsx
@@ -1,0 +1,144 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  AssistantRuntimeProvider,
+  CompositeAttachmentAdapter,
+  SimpleImageAttachmentAdapter,
+  SimpleTextAttachmentAdapter,
+  type ChatModelAdapter,
+  useAui,
+  useLocalRuntime,
+} from "@assistant-ui/react";
+import { useEffect, type ComponentType } from "react";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { ComposerAttachments as BaseComposerAttachments } from "./attachment.aui";
+import { ComposerAttachments as RadixComposerAttachments } from "./attachment.aui.radix";
+
+const model: ChatModelAdapter = {
+  async *run() {},
+};
+
+const attachmentAdapter = new CompositeAttachmentAdapter([
+  new SimpleImageAttachmentAdapter(),
+  new SimpleTextAttachmentAdapter(),
+]);
+
+const AddAttachment = ({ file }: { file: File }) => {
+  const aui = useAui();
+
+  useEffect(() => {
+    void aui.composer.addAttachment(file);
+  }, [aui, file]);
+
+  return null;
+};
+
+const TestAttachments = ({
+  file,
+  Attachments,
+}: {
+  file: File;
+  Attachments: ComponentType;
+}) => {
+  const runtime = useLocalRuntime(model, {
+    adapters: { attachments: attachmentAdapter },
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <AddAttachment file={file} />
+      <Attachments />
+    </AssistantRuntimeProvider>
+  );
+};
+
+const flavors: Array<[string, ComponentType]> = [
+  ["Base", BaseComposerAttachments],
+  ["Radix", RadixComposerAttachments],
+];
+
+beforeAll(() => {
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+beforeEach(() => {
+  let id = 0;
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn(() => `blob:attachment-${id++}`),
+    revokeObjectURL: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe.each(flavors)("%s attachment element", (_, Attachments) => {
+  it("creates one preview URL and names the preview and remove actions", async () => {
+    render(
+      <TestAttachments
+        file={new File(["image"], "screenshot.png", { type: "image/png" })}
+        Attachments={Attachments}
+      />,
+    );
+
+    const preview = await screen.findByRole("button", {
+      name: "Preview screenshot.png",
+    });
+    await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalledTimes(1));
+    expect(preview.className).toContain("cursor-zoom-in");
+    expect(preview.className).toContain("active:scale-[0.96]");
+    expect(
+      screen.getByRole("button", { name: "Remove screenshot.png" }),
+    ).toBeTruthy();
+
+    fireEvent.click(preview);
+
+    expect(
+      await screen.findByRole("heading", { name: "Preview screenshot.png" }),
+    ).toBeTruthy();
+    expect(screen.getByAltText("Preview of screenshot.png")).toBeTruthy();
+  });
+
+  it("keeps a file without a preview out of the button interaction model", async () => {
+    render(
+      <TestAttachments
+        file={new File(["report"], "report.txt", { type: "text/plain" })}
+        Attachments={Attachments}
+      />,
+    );
+
+    const tile = await screen.findByRole("group", {
+      name: "Document attachment report.txt",
+    });
+    expect(tile.className).toContain("cursor-default");
+    expect(tile.className).not.toContain("active:scale-[0.96]");
+    expect(
+      screen.queryByRole("button", { name: "Document attachment report.txt" }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Remove report.txt" }),
+    ).toBeTruthy();
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/react/assistant-ui/elements/attachment.aui.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/attachment.aui.tsx
@@ -39,14 +39,15 @@ import { cn } from "@/lib/utils";
 
 type AttachmentPreviewProps = {
   src: string;
+  name: string;
 };
 
-const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
+const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src, name }) => {
   const [isLoaded, setIsLoaded] = useState(false);
   return (
     <img
       src={src}
-      alt="Attachment preview"
+      alt={`Preview of ${name}`}
       className={cn(
         "block h-auto max-h-[80vh] w-auto max-w-full rounded-sm object-contain transition-opacity duration-300 motion-reduce:transition-none",
         isLoaded
@@ -58,9 +59,16 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
   );
 };
 
-const AttachmentPreviewDialog: FC<PropsWithChildren> = ({ children }) => {
-  const src = useAttachmentSrc();
+type AttachmentPreviewDialogProps = PropsWithChildren<{
+  src: string | undefined;
+  name: string;
+}>;
 
+const AttachmentPreviewDialog: FC<AttachmentPreviewDialogProps> = ({
+  children,
+  src,
+  name,
+}) => {
   if (!src) return children;
 
   return (
@@ -78,24 +86,22 @@ const AttachmentPreviewDialog: FC<PropsWithChildren> = ({ children }) => {
       />
       <DialogContent className="aui-attachment-preview-dialog-content [&>button]:bg-foreground/60 [&>button]:hover:bg-foreground/80 [&_svg]:text-background p-2 sm:max-w-3xl [&>button]:rounded-full [&>button]:p-1 [&>button]:opacity-100 [&>button]:ring-0!">
         <DialogTitle className="aui-sr-only sr-only">
-          Image Attachment Preview
+          Preview {name}
         </DialogTitle>
         <div className="aui-attachment-preview bg-background relative mx-auto flex max-h-[80dvh] w-full items-center justify-center overflow-hidden rounded-sm">
-          <AttachmentPreview src={src} />
+          <AttachmentPreview src={src} name={name} />
         </div>
       </DialogContent>
     </Dialog>
   );
 };
 
-const AttachmentThumb: FC = () => {
-  const src = useAttachmentSrc();
-
+const AttachmentThumb: FC<{ src: string | undefined }> = ({ src }) => {
   return (
     <Avatar className="aui-attachment-tile-avatar h-full w-full rounded-none after:hidden">
       <AvatarImage
         src={src}
-        alt="Attachment preview"
+        alt=""
         className="aui-attachment-tile-image rounded-none object-cover"
       />
       <AvatarFallback>
@@ -108,8 +114,10 @@ const AttachmentThumb: FC = () => {
 const AttachmentUI: FC = () => {
   const aui = useAui();
   const isComposer = aui.attachment.source !== "message";
+  const src = useAttachmentSrc();
 
   const isImage = useAuiState((s) => s.attachment.type === "image");
+  const name = useAuiState((s) => s.attachment.name);
   const typeLabel = useAuiState((s) => {
     const type = s.attachment.type;
     switch (type) {
@@ -155,18 +163,21 @@ const AttachmentUI: FC = () => {
               "aui-attachment-root-message only:*:first:size-24",
           )}
         >
-          <AttachmentPreviewDialog>
+          <AttachmentPreviewDialog src={src} name={name}>
             <TooltipTrigger
               render={
                 <div
                   className={cn(
-                    "aui-attachment-tile bg-muted hover:after:bg-foreground/10 focus-visible:ring-ring/50 relative size-14 cursor-pointer overflow-hidden rounded-[calc(var(--composer-radius,1.5rem)-var(--composer-padding,8px))] transition-transform outline-none after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:ring-1 after:ring-black/10 after:transition-colors after:ring-inset focus-visible:ring-1 active:scale-[0.96] motion-reduce:transition-none dark:after:ring-white/10",
+                    "aui-attachment-tile bg-muted hover:after:bg-foreground/10 focus-visible:ring-ring/50 relative size-14 overflow-hidden rounded-[calc(var(--composer-radius,1.5rem)-var(--composer-padding,8px))] transition-transform outline-none after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:ring-1 after:ring-black/10 after:transition-colors after:ring-inset focus-visible:ring-1 motion-reduce:transition-none dark:after:ring-white/10",
+                    src
+                      ? "cursor-zoom-in active:scale-[0.96]"
+                      : "cursor-default",
                     isError &&
                       "after:ring-destructive/60 dark:after:ring-destructive/60",
                   )}
-                  role="button"
+                  role={src ? "button" : "group"}
                   tabIndex={0}
-                  aria-label={`${typeLabel} attachment${
+                  aria-label={`${src ? `Preview ${name}` : `${typeLabel} attachment ${name}`}${
                     isError
                       ? ", upload failed"
                       : isUploading
@@ -176,7 +187,7 @@ const AttachmentUI: FC = () => {
                 />
               }
             >
-              <AttachmentThumb />
+              <AttachmentThumb src={src} />
               {isUploading && (
                 <div
                   aria-hidden="true"
@@ -195,7 +206,7 @@ const AttachmentUI: FC = () => {
               )}
             </TooltipTrigger>
           </AttachmentPreviewDialog>
-          {isComposer && <AttachmentRemove />}
+          {isComposer && <AttachmentRemove name={name} />}
         </AttachmentPrimitive.Root>
         <TooltipContent side="top">
           <AttachmentPrimitive.Name />
@@ -208,12 +219,13 @@ const AttachmentUI: FC = () => {
   );
 };
 
-const AttachmentRemove: FC = () => {
+const AttachmentRemove: FC<{ name: string }> = ({ name }) => {
   return (
     <AttachmentPrimitive.Remove
       render={
         <TooltipIconButton
-          tooltip="Remove file"
+          tooltip={`Remove ${name}`}
+          aria-label={`Remove ${name}`}
           className="aui-attachment-tile-remove absolute end-1 top-1 size-5 rounded-full bg-black/50! text-white after:absolute after:-inset-1.5 hover:bg-black/70! hover:text-white! active:scale-[0.96] motion-reduce:transition-none"
           side="top"
         />

--- a/templates/minimal/components/assistant-ui/elements/attachment.aui.tsx
+++ b/templates/minimal/components/assistant-ui/elements/attachment.aui.tsx
@@ -39,14 +39,15 @@ import { cn } from "@/lib/utils";
 
 type AttachmentPreviewProps = {
   src: string;
+  name: string;
 };
 
-const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
+const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src, name }) => {
   const [isLoaded, setIsLoaded] = useState(false);
   return (
     <img
       src={src}
-      alt="Attachment preview"
+      alt={`Preview of ${name}`}
       className={cn(
         "block h-auto max-h-[80vh] w-auto max-w-full rounded-sm object-contain transition-opacity duration-300 motion-reduce:transition-none",
         isLoaded
@@ -58,9 +59,16 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
   );
 };
 
-const AttachmentPreviewDialog: FC<PropsWithChildren> = ({ children }) => {
-  const src = useAttachmentSrc();
+type AttachmentPreviewDialogProps = PropsWithChildren<{
+  src: string | undefined;
+  name: string;
+}>;
 
+const AttachmentPreviewDialog: FC<AttachmentPreviewDialogProps> = ({
+  children,
+  src,
+  name,
+}) => {
   if (!src) return children;
 
   return (
@@ -78,24 +86,22 @@ const AttachmentPreviewDialog: FC<PropsWithChildren> = ({ children }) => {
       />
       <DialogContent className="aui-attachment-preview-dialog-content [&>button]:bg-foreground/60 [&>button]:hover:bg-foreground/80 [&_svg]:text-background p-2 sm:max-w-3xl [&>button]:rounded-full [&>button]:p-1 [&>button]:opacity-100 [&>button]:ring-0!">
         <DialogTitle className="aui-sr-only sr-only">
-          Image Attachment Preview
+          Preview {name}
         </DialogTitle>
         <div className="aui-attachment-preview bg-background relative mx-auto flex max-h-[80dvh] w-full items-center justify-center overflow-hidden rounded-sm">
-          <AttachmentPreview src={src} />
+          <AttachmentPreview src={src} name={name} />
         </div>
       </DialogContent>
     </Dialog>
   );
 };
 
-const AttachmentThumb: FC = () => {
-  const src = useAttachmentSrc();
-
+const AttachmentThumb: FC<{ src: string | undefined }> = ({ src }) => {
   return (
     <Avatar className="aui-attachment-tile-avatar h-full w-full rounded-none after:hidden">
       <AvatarImage
         src={src}
-        alt="Attachment preview"
+        alt=""
         className="aui-attachment-tile-image rounded-none object-cover"
       />
       <AvatarFallback>
@@ -108,8 +114,10 @@ const AttachmentThumb: FC = () => {
 const AttachmentUI: FC = () => {
   const aui = useAui();
   const isComposer = aui.attachment.source !== "message";
+  const src = useAttachmentSrc();
 
   const isImage = useAuiState((s) => s.attachment.type === "image");
+  const name = useAuiState((s) => s.attachment.name);
   const typeLabel = useAuiState((s) => {
     const type = s.attachment.type;
     switch (type) {
@@ -155,18 +163,21 @@ const AttachmentUI: FC = () => {
               "aui-attachment-root-message only:*:first:size-24",
           )}
         >
-          <AttachmentPreviewDialog>
+          <AttachmentPreviewDialog src={src} name={name}>
             <TooltipTrigger
               render={
                 <div
                   className={cn(
-                    "aui-attachment-tile bg-muted hover:after:bg-foreground/10 focus-visible:ring-ring/50 relative size-14 cursor-pointer overflow-hidden rounded-[calc(var(--composer-radius,1.5rem)-var(--composer-padding,8px))] transition-transform outline-none after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:ring-1 after:ring-black/10 after:transition-colors after:ring-inset focus-visible:ring-1 active:scale-[0.96] motion-reduce:transition-none dark:after:ring-white/10",
+                    "aui-attachment-tile bg-muted hover:after:bg-foreground/10 focus-visible:ring-ring/50 relative size-14 overflow-hidden rounded-[calc(var(--composer-radius,1.5rem)-var(--composer-padding,8px))] transition-transform outline-none after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:ring-1 after:ring-black/10 after:transition-colors after:ring-inset focus-visible:ring-1 motion-reduce:transition-none dark:after:ring-white/10",
+                    src
+                      ? "cursor-zoom-in active:scale-[0.96]"
+                      : "cursor-default",
                     isError &&
                       "after:ring-destructive/60 dark:after:ring-destructive/60",
                   )}
-                  role="button"
+                  role={src ? "button" : "group"}
                   tabIndex={0}
-                  aria-label={`${typeLabel} attachment${
+                  aria-label={`${src ? `Preview ${name}` : `${typeLabel} attachment ${name}`}${
                     isError
                       ? ", upload failed"
                       : isUploading
@@ -176,7 +187,7 @@ const AttachmentUI: FC = () => {
                 />
               }
             >
-              <AttachmentThumb />
+              <AttachmentThumb src={src} />
               {isUploading && (
                 <div
                   aria-hidden="true"
@@ -195,7 +206,7 @@ const AttachmentUI: FC = () => {
               )}
             </TooltipTrigger>
           </AttachmentPreviewDialog>
-          {isComposer && <AttachmentRemove />}
+          {isComposer && <AttachmentRemove name={name} />}
         </AttachmentPrimitive.Root>
         <TooltipContent side="top">
           <AttachmentPrimitive.Name />
@@ -208,12 +219,13 @@ const AttachmentUI: FC = () => {
   );
 };
 
-const AttachmentRemove: FC = () => {
+const AttachmentRemove: FC<{ name: string }> = ({ name }) => {
   return (
     <AttachmentPrimitive.Remove
       render={
         <TooltipIconButton
-          tooltip="Remove file"
+          tooltip={`Remove ${name}`}
+          aria-label={`Remove ${name}`}
           className="aui-attachment-tile-remove absolute end-1 top-1 size-5 rounded-full bg-black/50! text-white after:absolute after:-inset-1.5 hover:bg-black/70! hover:text-white! active:scale-[0.96] motion-reduce:transition-none"
           side="top"
         />


### PR DESCRIPTION
## Problem

The canonical attachment element resolves its preview source twice for every image tile. For a local file, that means two `URL.createObjectURL()` allocations and two effect-driven updates for one preview.

Document and generic file tiles also keep button semantics, pointer/press styling, and Radix keyboard activation even when no preview source exists, so they advertise an action that cannot do anything. Their accessible labels describe only the type, which makes multiple files difficult to distinguish.

## Root cause

The thumbnail and preview dialog each call `useAttachmentSrc()` independently, while the tile interaction props are applied before the dialog decides whether a preview is available.

## Change

Resolve the preview source once in the attachment tile and pass it to the thumbnail and dialog. Previewable images keep button semantics and press feedback. Attachments without a preview use non-action group semantics and a default cursor.

The preview, dialog title, and remove action now include the attachment name in their accessible labels. The thumbnail image is decorative because the containing preview action already provides the accessible name. Base and Radix flavors remain aligned, and the Base version is synced to the minimal template.

Closes #7268.

## Verification

- `attachment.aui.test.tsx`: 4 tests passed across Base and Radix
- Focused oxlint passed with warnings denied
- Focused oxfmt check passed
- `bash scripts/sync-templates.sh` passed
- `git diff --check` passed

## Public surface

- `@assistant-ui/ui`: private registry source updated
- Minimal template: synced
- Exports, API reference, and documentation: no changes
- Changeset: none, because the affected package and template are private

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.MGyCtn_K-CPFvSiJH2QSI4kY-w0oLw25DOzwcnlwYlSaC_cZeSFr25FNigY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->