### PR TITLE
fix(core): isolate Cloud runtime state by scope

### DIFF
--- a/.changeset/cloud-runtime-scope-state.md
+++ b/.changeset/cloud-runtime-scope-state.md
@@ -2,6 +2,8 @@
 "@assistant-ui/core": patch
 "@assistant-ui/ai-sdk": patch
 "@assistant-ui/react-google-adk": patch
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-langgraph": patch
 ---
 
 fix: isolate Cloud attachment URLs and message mappings by account or workspace scope.

--- a/.changeset/cloud-runtime-scope-state.md
+++ b/.changeset/cloud-runtime-scope-state.md
@@ -1,5 +1,7 @@
 ---
 "@assistant-ui/core": patch
+"@assistant-ui/ai-sdk": patch
+"@assistant-ui/react-google-adk": patch
 ---
 
 fix: isolate Cloud attachment URLs and message mappings by account or workspace scope.

--- a/.changeset/cloud-runtime-scope-state.md
+++ b/.changeset/cloud-runtime-scope-state.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: isolate Cloud attachment URLs and message mappings by account or workspace scope.

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -30,6 +30,7 @@ declare const AISDKThreads: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknow
 type AISDKThreadsOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Omit<ChatThreadOptions<UI_MESSAGE>, "id" | "messages" | "transport"> & {
   transport?: ChatTransport<UI_MESSAGE> | (() => ChatTransport<UI_MESSAGE>) | undefined;
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   threadId?: string | undefined;
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
 };
@@ -2288,6 +2289,7 @@ type Unsubscribe = () => void;
 
 type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatThreadOptions<UI_MESSAGE> & {
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
 };
 

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1216,6 +1216,7 @@ type CloudThread = {
 
 type CloudThreadListAdapter = {
   cloud: AssistantCloud;
+  scopeId?: string;
   runtimeHook: () => AssistantRuntime;
   create?(): Promise<ThreadData>;
   delete?(threadId: string): Promise<void>;
@@ -1223,6 +1224,7 @@ type CloudThreadListAdapter = {
 
 type CloudThreadListAdapterOptions = {
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   sdk?: SdkIdentity | undefined;
   create?: (() => Promise<ThreadData$1>) | undefined;
   delete?: ((threadId: string) => Promise<void>) | undefined;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1216,7 +1216,7 @@ type CloudThread = {
 
 type CloudThreadListAdapter = {
   cloud: AssistantCloud;
-  scopeId?: string;
+  scopeId?: string | undefined;
   runtimeHook: () => AssistantRuntime;
   create?(): Promise<ThreadData>;
   delete?(threadId: string): Promise<void>;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -2491,6 +2491,7 @@ declare class LocalRuntimeCore extends BaseAssistantRuntimeCore {
 
 type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   initialMessages?: readonly ThreadMessageLike[] | undefined;
   adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
 };
@@ -6375,6 +6376,7 @@ declare const shouldContinue: (result: ThreadAssistantMessage, humanToolNames: s
 declare const splitLocalRuntimeOptions: <T extends LocalRuntimeOptions>(options: T) => {
   localRuntimeOptions: {
     cloud: AssistantCloud | undefined;
+    scopeId: string | undefined;
     initialMessages: readonly ThreadMessageLike[] | undefined;
     maxSteps: number | undefined;
     adapters: Omit<{
@@ -6392,7 +6394,7 @@ declare const splitLocalRuntimeOptions: <T extends LocalRuntimeOptions>(options:
     unstable_queueClearOnRewind: boolean | undefined;
     unstable_queueClearOnCancel: boolean | undefined;
   };
-  otherOptions: Omit<T, "adapters" | "cloud" | "initialMessages" | "maxSteps" | "unstable_enableMessageQueue" | "unstable_humanToolNames" | "unstable_queueClearOnCancel" | "unstable_queueClearOnRewind">;
+  otherOptions: Omit<T, "adapters" | "cloud" | "initialMessages" | "maxSteps" | "scopeId" | "unstable_enableMessageQueue" | "unstable_humanToolNames" | "unstable_queueClearOnCancel" | "unstable_queueClearOnRewind">;
 };
 
 declare const stableStringifyToolArgs: (keyOrderCache: Map<string, Map<string, string[]>> | undefined, cacheKey: string, args: ReadonlyJSONObject) => string;

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -30,6 +30,7 @@ declare const AISDKThreads: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknow
 type AISDKThreadsOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Omit<ChatThreadOptions<UI_MESSAGE>, "id" | "messages" | "transport"> & {
   transport?: ChatTransport<UI_MESSAGE> | (() => ChatTransport<UI_MESSAGE>) | undefined;
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   threadId?: string | undefined;
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
 };
@@ -2288,6 +2289,7 @@ type Unsubscribe = () => void;
 
 type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatThreadOptions<UI_MESSAGE> & {
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
 };
 

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -957,6 +957,7 @@ type LanguageModelV1CallSettings = {
 
 type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   initialMessages?: readonly ThreadMessageLike[] | undefined;
   adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
 };

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -2580,6 +2580,7 @@ type UseAdkRuntimeOptions = ExternalStoreSharedOptions & {
     onAgentTransfer?: OnAdkAgentTransferCallback;
   } | undefined;
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   sessionAdapter?: RemoteThreadListAdapter | undefined;
 };
 

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -1995,6 +1995,7 @@ type LoadingTextProps = ComponentProps<typeof Text> & {
 
 type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   initialMessages?: readonly ThreadMessageLike[] | undefined;
   adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
 };

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -1138,6 +1138,7 @@ type LangChainMessageConverterMetadata = useExternalMessageConverter.Metadata & 
 type LangChainRuntimeExtraOptions = ExternalStoreSharedOptions & {
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   adapters?: {
     attachments?: AttachmentAdapter | undefined;
     speech?: SpeechSynthesisAdapter | undefined;

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -2484,6 +2484,7 @@ type UseLangGraphRuntimeOptions = ExternalStoreSharedOptions & {
     renderers?: Record<string, DataMessagePartComponent>;
   } | undefined;
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   unstable_threadListAdapter?: RemoteThreadListAdapter | undefined;
 };
 

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -1774,6 +1774,7 @@ type LanguageModelV1CallSettings = {
 
 type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   initialMessages?: readonly ThreadMessageLike[] | undefined;
   adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
 };

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2655,6 +2655,7 @@ type LanguageModelV1CallSettings = {
 
 type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   initialMessages?: readonly ThreadMessageLike[] | undefined;
   adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
 };
@@ -6235,6 +6236,7 @@ declare namespace selectionToolbar_d_exports {
 declare const splitLocalRuntimeOptions: <T extends LocalRuntimeOptions>(options: T) => {
   localRuntimeOptions: {
     cloud: AssistantCloud | undefined;
+    scopeId: string | undefined;
     initialMessages: readonly ThreadMessageLike[] | undefined;
     maxSteps: number | undefined;
     adapters: Omit<{
@@ -6252,7 +6254,7 @@ declare const splitLocalRuntimeOptions: <T extends LocalRuntimeOptions>(options:
     unstable_queueClearOnRewind: boolean | undefined;
     unstable_queueClearOnCancel: boolean | undefined;
   };
-  otherOptions: Omit<T, "adapters" | "cloud" | "initialMessages" | "maxSteps" | "unstable_enableMessageQueue" | "unstable_humanToolNames" | "unstable_queueClearOnCancel" | "unstable_queueClearOnRewind">;
+  otherOptions: Omit<T, "adapters" | "cloud" | "initialMessages" | "maxSteps" | "scopeId" | "unstable_enableMessageQueue" | "unstable_humanToolNames" | "unstable_queueClearOnCancel" | "unstable_queueClearOnRewind">;
 };
 
 declare function stubTool(): never;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -1404,6 +1404,7 @@ type CloudThread = {
 
 type CloudThreadListAdapter = {
   cloud: AssistantCloud;
+  scopeId?: string;
   runtimeHook: () => AssistantRuntime;
   create?(): Promise<ThreadData>;
   delete?(threadId: string): Promise<void>;
@@ -1411,6 +1412,7 @@ type CloudThreadListAdapter = {
 
 type CloudThreadListAdapterOptions = {
   cloud?: AssistantCloud | undefined;
+  scopeId?: string | undefined;
   sdk?: SdkIdentity | undefined;
   create?: (() => Promise<ThreadData$1>) | undefined;
   delete?: ((threadId: string) => Promise<void>) | undefined;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -1404,7 +1404,7 @@ type CloudThread = {
 
 type CloudThreadListAdapter = {
   cloud: AssistantCloud;
-  scopeId?: string;
+  scopeId?: string | undefined;
   runtimeHook: () => AssistantRuntime;
   create?(): Promise<ThreadData>;
   delete?(threadId: string): Promise<void>;

--- a/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
@@ -306,6 +306,12 @@ export async function POST(req: Request) {
         "The cloud client. Omit it on React to use an anonymous client built from NEXT_PUBLIC_ASSISTANT_BASE_URL; without either, the thread list stays in memory.",
     },
     {
+      name: "scopeId",
+      type: "string",
+      description:
+        "Stable account or workspace identity for Cloud runtime state. Provide it from the first render and change it when the owning scope changes; defer mounting the runtime until an asynchronously resolved ID is available.",
+    },
+    {
       name: "onThreadIdChange",
       type: "(threadId: string | undefined) => void",
       description:
@@ -376,7 +382,7 @@ The remaining AI SDK chat options are accepted as on `useChat`.
 
 ### Store hosts
 
-Apps built on `AuiConfig` or `createAssistantClient` use `AISDKThreads({ cloud, threadId, onThreadIdChange })` as their thread list resource. With `cloud` set it is a remote thread list with the same behaviour as above; `threadId` controls the selected thread and is ignored without `cloud`.
+Apps built on `AuiConfig` or `createAssistantClient` use `AISDKThreads({ cloud, scopeId, threadId, onThreadIdChange })` as their thread list resource. With `cloud` set it is a remote thread list with the same behaviour as above; `scopeId` follows the same account and workspace rules as on `useChatRuntime`, and `threadId` controls the selected thread and is ignored without `cloud`.
 
 ## What is reported
 

--- a/apps/docs/content/docs/cloud/langgraph.mdx
+++ b/apps/docs/content/docs/cloud/langgraph.mdx
@@ -36,7 +36,7 @@ const runtime = useLangGraphRuntime({
 });
 ```
 
-`useStreamRuntime` from `@assistant-ui/react-langchain` and `useAdkRuntime` from `@assistant-ui/react-google-adk` take the same `cloud`, `create` and `delete` options and behave the same way; when `create` is omitted, the thread's own initialization supplies the external id. Google ADK also accepts `scopeId`: provide the stable account or workspace ID from the first render and change it with the owning scope. `unstable_threadListAdapter` replaces the cloud list with your own adapter, and `cloud`, `create` and `delete` are then ignored.
+`useStreamRuntime` from `@assistant-ui/react-langchain` and `useAdkRuntime` from `@assistant-ui/react-google-adk` take the same `cloud`, `create` and `delete` options and behave the same way; when `create` is omitted, the thread's own initialization supplies the external id. All three runtimes accept `scopeId`: provide the stable account or workspace ID from the first render and change it with the owning scope. `unstable_threadListAdapter` replaces the cloud list with your own adapter, and `cloud`, `create` and `delete` are then ignored.
 
 The rest of the setup, the environment variable per platform, the client for React Native and Ink, and the thread list UI, is the same as on the [AI SDK + assistant-ui](/docs/cloud/ai-sdk-assistant-ui#setup) page; the LangGraph runtime itself, its `stream` function and the thread list component are on [LangGraph threads](/docs/runtimes/langgraph/threads).
 

--- a/apps/docs/content/docs/cloud/langgraph.mdx
+++ b/apps/docs/content/docs/cloud/langgraph.mdx
@@ -36,7 +36,7 @@ const runtime = useLangGraphRuntime({
 });
 ```
 
-`useStreamRuntime` from `@assistant-ui/react-langchain` and `useAdkRuntime` from `@assistant-ui/react-google-adk` take the same `cloud`, `create` and `delete` options and behave the same way; when `create` is omitted, the thread's own initialization supplies the external id. `unstable_threadListAdapter` replaces the cloud list with your own adapter, and `cloud`, `create` and `delete` are then ignored.
+`useStreamRuntime` from `@assistant-ui/react-langchain` and `useAdkRuntime` from `@assistant-ui/react-google-adk` take the same `cloud`, `create` and `delete` options and behave the same way; when `create` is omitted, the thread's own initialization supplies the external id. Google ADK also accepts `scopeId`: provide the stable account or workspace ID from the first render and change it with the owning scope. `unstable_threadListAdapter` replaces the cloud list with your own adapter, and `cloud`, `create` and `delete` are then ignored.
 
 The rest of the setup, the environment variable per platform, the client for React Native and Ink, and the thread list UI, is the same as on the [AI SDK + assistant-ui](/docs/cloud/ai-sdk-assistant-ui#setup) page; the LangGraph runtime itself, its `stream` function and the thread list component are on [LangGraph threads](/docs/runtimes/langgraph/threads).
 

--- a/apps/docs/content/docs/cloud/local-runtime.mdx
+++ b/apps/docs/content/docs/cloud/local-runtime.mdx
@@ -108,7 +108,7 @@ const runtime = useCloudThreadListRuntime({
 | Option | Meaning |
 |---|---|
 | `cloud` | The client the list is backed by. |
-| `scopeId` | Stable account or workspace identity for cached attachments and message mappings. Change it when the owning scope changes. If omitted, replacing `cloud` starts a new scope. |
+| `scopeId` | Stable account or workspace identity for cached attachments and message mappings. Change it when the owning scope changes. If omitted, replacing `cloud` preserves cached state. |
 | `runtimeHook` | A hook returning the per thread runtime; it is called once per mounted thread. |
 | `create` | Called when a new thread is created; return your backend's id and it is stored as the cloud thread's `external_id`. |
 | `delete` | Called with the thread before the cloud thread is deleted. |

--- a/apps/docs/content/docs/cloud/local-runtime.mdx
+++ b/apps/docs/content/docs/cloud/local-runtime.mdx
@@ -108,7 +108,7 @@ const runtime = useCloudThreadListRuntime({
 | Option | Meaning |
 |---|---|
 | `cloud` | The client the list is backed by. |
-| `scopeId` | Stable account or workspace identity for cached attachments and message mappings. Change it when the owning scope changes. If omitted, replacing `cloud` preserves cached state. |
+| `scopeId` | Stable account or workspace identity for cached attachments and message mappings. Change it when the owning scope changes; this runtime resets and reloads its thread list. If omitted, replacing `cloud` preserves cached state. |
 | `runtimeHook` | A hook returning the per thread runtime; it is called once per mounted thread. |
 | `create` | Called when a new thread is created; return your backend's id and it is stored as the cloud thread's `external_id`. |
 | `delete` | Called with the thread before the cloud thread is deleted. |
@@ -125,7 +125,7 @@ const runtime = useCloudThreadListRuntime({
 });
 ```
 
-The lower level `useCloudThreadListAdapter({ cloud, scopeId, create, delete, sdk })` returns the adapter alone, and `createCloudThreadListAdapter` builds it outside React. Both register the calling package's identity on the client through `sdk`, so the project's Settings › Telemetry lists your integration next to the SDK version.
+The lower level `useCloudThreadListAdapter({ cloud, scopeId, create, delete, sdk })` returns the adapter alone, and `createCloudThreadListAdapter` builds it outside React. When either `cloud` or `scopeId` changes, publish the replacement adapter and call the thread-list `reload()` method, as required by the `RemoteThreadList` adapter replacement contract. Both register the calling package's identity on the client through `sdk`, so the project's Settings › Telemetry lists your integration next to the SDK version.
 
 ## Custom history adapters
 

--- a/apps/docs/content/docs/cloud/local-runtime.mdx
+++ b/apps/docs/content/docs/cloud/local-runtime.mdx
@@ -108,7 +108,7 @@ const runtime = useCloudThreadListRuntime({
 | Option | Meaning |
 |---|---|
 | `cloud` | The client the list is backed by. |
-| `scopeId` | Stable account or workspace identity for cached attachments and message mappings. Change it when the owning scope changes; this runtime resets and reloads its thread list. If omitted, replacing `cloud` preserves cached state. |
+| `scopeId` | Stable account or workspace identity for cached attachments and message mappings. Provide it from the runtime's first render; changing from `undefined` to an ID is a scope switch, so defer mounting this runtime until the ID is available. Change it when the owning scope changes; this runtime resets and reloads its thread list. If omitted, replacing `cloud` preserves cached state. |
 | `runtimeHook` | A hook returning the per thread runtime; it is called once per mounted thread. |
 | `create` | Called when a new thread is created; return your backend's id and it is stored as the cloud thread's `external_id`. |
 | `delete` | Called with the thread before the cloud thread is deleted. |

--- a/apps/docs/content/docs/cloud/local-runtime.mdx
+++ b/apps/docs/content/docs/cloud/local-runtime.mdx
@@ -66,9 +66,9 @@ export default function ChatPage() {
 }
 ```
 
-On React, `useLocalRuntime(adapter)` with `NEXT_PUBLIC_ASSISTANT_BASE_URL` set and no `cloud` uses an anonymous client, the same as the AI SDK runtime. On React Native and Ink construct the client from `assistant-cloud` and pass it.
+On React, `useLocalRuntime(adapter)` with `NEXT_PUBLIC_ASSISTANT_BASE_URL` set and no `cloud` uses an anonymous client, the same as the AI SDK runtime. On React Native and Ink construct the client from `assistant-cloud` and pass it. If the mounted runtime can switch accounts or workspaces, pass their stable ID as `scopeId` from the first render; defer mounting the runtime until that ID is available.
 
-`useDataStreamRuntime` from `@assistant-ui/react-data-stream`, the runtime for a route that returns an assistant-stream response, accepts every local runtime option including `cloud`, and gets the same integration.
+`useDataStreamRuntime` from `@assistant-ui/react-data-stream`, the runtime for a route that returns an assistant-stream response, accepts every local runtime option including `cloud` and `scopeId`, and gets the same integration.
 
 ## What the runtime does with the cloud
 

--- a/apps/docs/content/docs/cloud/local-runtime.mdx
+++ b/apps/docs/content/docs/cloud/local-runtime.mdx
@@ -108,7 +108,7 @@ const runtime = useCloudThreadListRuntime({
 | Option | Meaning |
 |---|---|
 | `cloud` | The client the list is backed by. |
-| `scopeId` | Stable account or workspace identity for cached attachments and message mappings. Provide it from the runtime's first render; changing from `undefined` to an ID is a scope switch, so defer mounting this runtime until the ID is available. Change it when the owning scope changes; this runtime resets and reloads its thread list. If omitted, replacing `cloud` preserves cached state. |
+| `scopeId` | Stable account or workspace identity for cached attachments and message mappings. Provide it from the runtime's first render; changing from `undefined` to an ID is a scope switch, so defer mounting this runtime until the ID is available. Change it when the owning scope changes; this runtime resets and reloads its thread list. If omitted, replacing `cloud` preserves attachment URLs and message mappings, but still reloads the thread list; history operations attempted before that reload settles are skipped. |
 | `runtimeHook` | A hook returning the per thread runtime; it is called once per mounted thread. |
 | `create` | Called when a new thread is created; return your backend's id and it is stored as the cloud thread's `external_id`. |
 | `delete` | Called with the thread before the cloud thread is deleted. |

--- a/apps/docs/content/docs/cloud/local-runtime.mdx
+++ b/apps/docs/content/docs/cloud/local-runtime.mdx
@@ -98,7 +98,7 @@ import { useCloudThreadListRuntime } from "@assistant-ui/react";
 
 const runtime = useCloudThreadListRuntime({
   cloud,
-  scopeId: workspace.id,
+  scopeId: workspace.id, // your app's stable account or workspace ID
   runtimeHook: useMyThreadRuntime,
   create: async () => ({ externalId: await backend.createThread() }),
   delete: async (threadId) => backend.deleteThread(threadId),

--- a/apps/docs/content/docs/cloud/local-runtime.mdx
+++ b/apps/docs/content/docs/cloud/local-runtime.mdx
@@ -98,6 +98,7 @@ import { useCloudThreadListRuntime } from "@assistant-ui/react";
 
 const runtime = useCloudThreadListRuntime({
   cloud,
+  scopeId: workspace.id,
   runtimeHook: useMyThreadRuntime,
   create: async () => ({ externalId: await backend.createThread() }),
   delete: async (threadId) => backend.deleteThread(threadId),
@@ -107,6 +108,7 @@ const runtime = useCloudThreadListRuntime({
 | Option | Meaning |
 |---|---|
 | `cloud` | The client the list is backed by. |
+| `scopeId` | Stable account or workspace identity for cached attachments and message mappings. Change it when the owning scope changes. If omitted, replacing `cloud` starts a new scope. |
 | `runtimeHook` | A hook returning the per thread runtime; it is called once per mounted thread. |
 | `create` | Called when a new thread is created; return your backend's id and it is stored as the cloud thread's `external_id`. |
 | `delete` | Called with the thread before the cloud thread is deleted. |
@@ -123,7 +125,7 @@ const runtime = useCloudThreadListRuntime({
 });
 ```
 
-The lower level `useCloudThreadListAdapter({ cloud, create, delete, sdk })` returns the adapter alone, and `createCloudThreadListAdapter` builds it outside React. Both register the calling package's identity on the client through `sdk`, so the project's Settings › Telemetry lists your integration next to the SDK version.
+The lower level `useCloudThreadListAdapter({ cloud, scopeId, create, delete, sdk })` returns the adapter alone, and `createCloudThreadListAdapter` builds it outside React. Both register the calling package's identity on the client through `sdk`, so the project's Settings › Telemetry lists your integration next to the SDK version.
 
 ## Custom history adapters
 

--- a/packages/ai-sdk/src/runtime/AISDKThreads.cloud.test.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.cloud.test.ts
@@ -72,10 +72,12 @@ import { AI_SDK_SDK } from "./sdkIdentity";
 describe("AISDKThreads cloud", () => {
   it("reloads history when switching a keyed cloud thread", async () => {
     const cloud = {} as AssistantCloud;
+    const scopeId = "workspace-1";
     const handle = createAssistantClient(
       AuiConfig({
         threads: AISDKThreads({
           cloud,
+          scopeId,
           threadId: "t1",
         }),
       }),
@@ -91,6 +93,7 @@ describe("AISDKThreads cloud", () => {
     });
     expect(mocks.useCloudThreadListAdapter).toHaveBeenCalledWith({
       cloud,
+      scopeId,
       sdk: AI_SDK_SDK,
     });
     const afterFirst = load.mock.calls.length;

--- a/packages/ai-sdk/src/runtime/AISDKThreads.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.ts
@@ -49,6 +49,11 @@ export type AISDKThreadsOptions<UI_MESSAGE extends UIMessage = UIMessage> =
      */
     cloud?: AssistantCloud | undefined;
     /**
+     * Stable identity for the account or workspace owning Cloud runtime state.
+     * Provide it from the first render and change it when that scope changes.
+     */
+    scopeId?: string | undefined;
+    /**
      * Controlled thread id for the cloud list. Ignored without `cloud`.
      */
     threadId?: string | undefined;
@@ -60,7 +65,7 @@ export type AISDKThreadsOptions<UI_MESSAGE extends UIMessage = UIMessage> =
 
 type AISDKThreadChatOptions<UI_MESSAGE extends UIMessage = UIMessage> = Omit<
   AISDKThreadsOptions<UI_MESSAGE>,
-  "cloud" | "threadId" | "onThreadIdChange"
+  "cloud" | "scopeId" | "threadId" | "onThreadIdChange"
 >;
 
 type ChatEntry<UI_MESSAGE extends UIMessage> = {
@@ -170,7 +175,8 @@ const AISDKChatThread = resource(useAISDKChatThread);
 const useAISDKThreads = <UI_MESSAGE extends UIMessage = UIMessage>(
   options?: AISDKThreadsOptions<UI_MESSAGE>,
 ) => {
-  const { cloud, threadId, onThreadIdChange, ...threadOptions } = options ?? {};
+  const { cloud, scopeId, threadId, onThreadIdChange, ...threadOptions } =
+    options ?? {};
   const [chats] = useState(() => new Map<string, ChatEntry<UI_MESSAGE>>());
   const bindCloud = cloud !== undefined;
 
@@ -180,7 +186,11 @@ const useAISDKThreads = <UI_MESSAGE extends UIMessage = UIMessage>(
     }
   });
 
-  const cloudAdapter = useCloudThreadListAdapter({ cloud, sdk: AI_SDK_SDK });
+  const cloudAdapter = useCloudThreadListAdapter({
+    cloud,
+    scopeId,
+    sdk: AI_SDK_SDK,
+  });
   const thread = (id: string) => {
     const element = AISDKChatThread({
       threadId: id,

--- a/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
@@ -2,6 +2,7 @@
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AssistantCloud } from "assistant-cloud";
 
 const mocks = vi.hoisted(() => {
   const state = {
@@ -76,6 +77,7 @@ import {
   createResumableSessionStorage,
   RESUMABLE_STREAM_ID_HEADER,
 } from "../transport/resumable";
+import { AI_SDK_SDK } from "./sdkIdentity";
 import { useChatRuntime } from "./useChatRuntime";
 
 const sendMessagesOptions = {
@@ -93,6 +95,23 @@ describe("useChatRuntime", () => {
     mocks.state.mainThreadId = "thread-id";
     mocks.subscribers.clear();
     window.sessionStorage.clear();
+  });
+
+  it("forwards the Cloud scope to the thread-list adapter", () => {
+    const cloud = {} as AssistantCloud;
+    mocks.useCloudThreadListAdapter.mockClear();
+    mocks.useChat.mockReturnValue({
+      resumeStream: vi.fn(),
+      status: "ready",
+    });
+
+    renderHook(() => useChatRuntime({ cloud, scopeId: "workspace-1" }));
+
+    expect(mocks.useCloudThreadListAdapter).toHaveBeenCalledWith({
+      cloud,
+      scopeId: "workspace-1",
+      sdk: AI_SDK_SDK,
+    });
   });
 
   it("forwards a defined chat update throttle to useChat", () => {

--- a/packages/ai-sdk/src/runtime/useChatRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.ts
@@ -14,6 +14,11 @@ import { AI_SDK_SDK } from "./sdkIdentity";
 export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
   ChatThreadOptions<UI_MESSAGE> & {
     cloud?: AssistantCloud | undefined;
+    /**
+     * Stable identity for the account or workspace owning Cloud runtime state.
+     * Provide it from the first render and change it when that scope changes.
+     */
+    scopeId?: string | undefined;
     onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   };
 
@@ -36,10 +41,15 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
 
 export const useChatRuntime = <UI_MESSAGE extends UIMessage = UIMessage>({
   cloud,
+  scopeId,
   onThreadIdChange,
   ...options
 }: UseChatRuntimeOptions<UI_MESSAGE> = {}): AssistantRuntime => {
-  const cloudAdapter = useCloudThreadListAdapter({ cloud, sdk: AI_SDK_SDK });
+  const cloudAdapter = useCloudThreadListAdapter({
+    cloud,
+    scopeId,
+    sdk: AI_SDK_SDK,
+  });
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
       return useChatThreadRuntime(options);

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.load-error.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.load-error.test.ts
@@ -59,6 +59,8 @@ describe("RemoteThreadListThreadListRuntimeCore load errors", () => {
     expect(core.threadIds).toEqual([]);
     expect(core.archivedThreadIds).toEqual([]);
     expect(core.getItemById("thread-1")).toBeUndefined();
+    expect(core.mainThreadId).not.toBe("thread-1");
+    expect(core.getItemById(core.mainThreadId!)).toBeDefined();
     expect(core.loadError).toBe(error);
   });
 

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -439,7 +439,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
   });
 
-  it("preserves message mappings only within the same Cloud scope", async () => {
+  it("waits for the replacement scope to claim a remote thread", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const firstCloud = makeCloud();
     const secondCloud = makeCloud();
@@ -451,8 +451,13 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     });
     const cloudRef = { current: firstCloud };
     const scopeRef = { current: "workspace-a" };
+    const ownershipRef = { current: new Set(["thread-1"]) };
     const { result } = renderHook(() =>
-      useScopedAssistantCloudThreadHistoryAdapter(cloudRef, scopeRef),
+      useScopedAssistantCloudThreadHistoryAdapter(
+        cloudRef,
+        scopeRef,
+        ownershipRef,
+      ),
     );
     const message = makeAssistantMessage("local-message-1");
 
@@ -467,6 +472,16 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
 
     scopeRef.current = "workspace-b";
+    ownershipRef.current = new Set();
+    await expect(
+      result.current.update({ parentId: null, message }),
+    ).rejects.toThrow(
+      "Cloud thread does not belong to the current account or workspace scope",
+    );
+
+    expect(secondCloud.threads.messages.create).not.toHaveBeenCalled();
+
+    ownershipRef.current.add("thread-1");
     await result.current.update({ parentId: null, message });
 
     expect(secondCloud.threads.messages.create).toHaveBeenCalledWith(

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -5,7 +5,6 @@ import type { AssistantCloud } from "assistant-cloud";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadAssistantMessage } from "../../../types/message";
 import {
-  DEFAULT_CLOUD_SCOPE,
   useAssistantCloudThreadHistoryAdapter,
   useScopedAssistantCloudThreadHistoryAdapter,
 } from "./AssistantCloudThreadHistoryAdapter";
@@ -440,58 +439,6 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
   });
 
-  it("waits for the replacement scope to claim a remote thread", async () => {
-    mocks.aui = mocks.makeClient("thread-1");
-    const firstCloud = makeCloud();
-    const secondCloud = makeCloud();
-    vi.mocked(firstCloud.threads.messages.create).mockResolvedValue({
-      message_id: "remote-a",
-    });
-    vi.mocked(secondCloud.threads.messages.create).mockResolvedValue({
-      message_id: "remote-b",
-    });
-    const cloudRef = { current: firstCloud };
-    const scopeRef = { current: "workspace-a" };
-    const ownershipRef = { current: new Set(["thread-1"]) };
-    const { result } = renderHook(() =>
-      useScopedAssistantCloudThreadHistoryAdapter(
-        cloudRef,
-        scopeRef,
-        ownershipRef,
-      ),
-    );
-    const message = makeAssistantMessage("local-message-1");
-
-    await result.current.append({ parentId: null, message });
-    cloudRef.current = secondCloud;
-    await result.current.update({ parentId: null, message });
-
-    expect(secondCloud.threads.messages.update).toHaveBeenCalledWith(
-      "thread-1",
-      "remote-a",
-      expect.anything(),
-    );
-
-    scopeRef.current = DEFAULT_CLOUD_SCOPE;
-    ownershipRef.current = new Set();
-    await expect(
-      result.current.update({ parentId: null, message }),
-    ).rejects.toThrow(
-      "Cloud thread does not belong to the current account or workspace scope",
-    );
-
-    expect(secondCloud.threads.messages.create).not.toHaveBeenCalled();
-
-    ownershipRef.current.add("thread-1");
-    await result.current.update({ parentId: null, message });
-
-    expect(secondCloud.threads.messages.create).toHaveBeenCalledWith(
-      "thread-1",
-      expect.objectContaining({ parent_id: null }),
-    );
-    expect(secondCloud.threads.messages.update).toHaveBeenCalledOnce();
-  });
-
   it("keeps a stale append from populating the replacement Cloud scope", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     let resolveFirst!: (value: { message_id: string }) => void;
@@ -613,6 +560,67 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     await rejected;
     expect(firstCloud.threads.messages.create).not.toHaveBeenCalled();
     expect(secondCloud.threads.messages.create).not.toHaveBeenCalled();
+  });
+
+  it("routes existing-thread operations through the thread-list generation guard", async () => {
+    const client = mocks.makeClient("thread-1");
+    mocks.aui = client;
+    const cloud = makeCloud();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter({ current: cloud }),
+    );
+    const plainMessage = makeAssistantMessage("plain-message");
+    const formattedMessage = makeAssistantMessage("formatted-message");
+    const formatted = result.current.withFormat({
+      format: "aui/v0",
+      encode: ({ message }) => message,
+      decode: ({ parent_id, content }) => ({
+        parentId: parent_id,
+        message: content as ThreadAssistantMessage,
+      }),
+      getId: (message: ThreadAssistantMessage) => message.id,
+    });
+
+    await result.current.append({ parentId: null, message: plainMessage });
+    await formatted.append({ parentId: null, message: formattedMessage });
+    vi.mocked(cloud.threads.messages.create).mockClear();
+    vi.mocked(cloud.threads.messages.update).mockClear();
+    vi.mocked(cloud.threads.messages.list).mockClear();
+    vi.mocked(cloud.threads.messages.feedback).mockClear();
+    vi.mocked(cloud.runs.report).mockClear();
+
+    const adapterChanged = new Error("thread-list adapter changed");
+    client.threadListItem.initialize = vi
+      .fn()
+      .mockRejectedValue(adapterChanged);
+
+    await expect(
+      result.current.update({ parentId: null, message: plainMessage }),
+    ).rejects.toBe(adapterChanged);
+    await expect(result.current.load()).rejects.toBe(adapterChanged);
+    await expect(
+      formatted.update(
+        { parentId: null, message: formattedMessage },
+        formattedMessage.id,
+      ),
+    ).rejects.toBe(adapterChanged);
+    await expect(formatted.load()).rejects.toBe(adapterChanged);
+    result.current.feedback.submit({ message: plainMessage, type: "positive" });
+    formatted.reportTelemetry([{ parentId: null, message: formattedMessage }]);
+
+    await waitFor(() =>
+      expect(client.threadListItem.initialize).toHaveBeenCalledTimes(6),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[assistant-ui] Cloud feedback submission failed:",
+      adapterChanged,
+    );
+    expect(cloud.threads.messages.create).not.toHaveBeenCalled();
+    expect(cloud.threads.messages.update).not.toHaveBeenCalled();
+    expect(cloud.threads.messages.list).not.toHaveBeenCalled();
+    expect(cloud.threads.messages.feedback).not.toHaveBeenCalled();
+    expect(cloud.runs.report).not.toHaveBeenCalled();
   });
 
   it("resolves formatted persistence against the current threadListItem", async () => {
@@ -829,6 +837,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     rerender();
     await formatted.update(item, "message-1");
     formatted.reportTelemetry([item]);
+    await waitFor(() => expect(cloud.runs.report).toHaveBeenCalled());
 
     expect(cloud.threads.messages.create).toHaveBeenCalledWith(
       "thread-1",
@@ -937,7 +946,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
   });
 
-  it("omits a clean outcome and an unknown cloud message ID", () => {
+  it("omits a clean outcome and an unknown cloud message ID", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();
     const { result } = renderHook(() =>
@@ -964,13 +973,14 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
         },
       },
     ]);
+    await waitFor(() => expect(cloud.runs.report).toHaveBeenCalled());
 
     const report = vi.mocked(cloud.runs.report).mock.calls[0]![0]!;
     expect(report).not.toHaveProperty("outcome_type");
     expect(report).not.toHaveProperty("message_id");
   });
 
-  it("reports frontend and MCP sources for ai-sdk/v6 tool calls", () => {
+  it("reports frontend and MCP sources for ai-sdk/v6 tool calls", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();
     const cloudRef = { current: cloud };
@@ -1023,6 +1033,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
         },
       },
     ]);
+    await waitFor(() => expect(cloud.runs.report).toHaveBeenCalled());
 
     expect(cloud.runs.report).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1071,7 +1082,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
   });
 
-  it("reports a single ai-sdk/v6 step with its tool calls", () => {
+  it("reports a single ai-sdk/v6 step with its tool calls", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();
     const { result } = renderHook(() =>
@@ -1105,6 +1116,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
         },
       },
     ]);
+    await waitFor(() => expect(cloud.runs.report).toHaveBeenCalled());
 
     expect(cloud.runs.report).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1124,7 +1136,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
   });
 
-  it("reads the status of an ai-sdk/v6 run from its finish reason", () => {
+  it("reads the status of an ai-sdk/v6 run from its finish reason", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();
     const { result } = renderHook(() =>
@@ -1151,13 +1163,14 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
         },
       },
     ]);
+    await waitFor(() => expect(cloud.runs.report).toHaveBeenCalled());
 
     expect(cloud.runs.report).toHaveBeenCalledWith(
       expect.objectContaining({ status: "incomplete", outcome_type: "length" }),
     );
   });
 
-  it("reads the error and timing of an ai-sdk/v6 run from the thread message", () => {
+  it("reads the error and timing of an ai-sdk/v6 run from the thread message", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();
     const { result } = renderHook(() =>
@@ -1206,6 +1219,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
       ],
       { message },
     );
+    await waitFor(() => expect(cloud.runs.report).toHaveBeenCalled());
 
     expect(cloud.runs.report).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1217,7 +1231,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
   });
 
-  it("reports a run that failed before any assistant message was stored", () => {
+  it("reports a run that failed before any assistant message was stored", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();
     const { result } = renderHook(() =>
@@ -1243,6 +1257,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     };
 
     formatted.reportTelemetry([], { message, durationMs: 120 });
+    await waitFor(() => expect(cloud.runs.report).toHaveBeenCalled());
 
     expect(cloud.runs.report).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1254,7 +1269,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
   });
 
-  it("reports the model ID carried by aui/v0 step metadata", () => {
+  it("reports the model ID carried by aui/v0 step metadata", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();
     const cloudRef = { current: cloud };
@@ -1285,13 +1300,14 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
         },
       },
     ]);
+    await waitFor(() => expect(cloud.runs.report).toHaveBeenCalled());
 
     expect(cloud.runs.report).toHaveBeenCalledWith(
       expect.objectContaining({ model_id: "provider/model-1" }),
     );
   });
 
-  it("reports the model ID carried by ai-sdk/v6 step metadata", () => {
+  it("reports the model ID carried by ai-sdk/v6 step metadata", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();
     const cloudRef = { current: cloud };
@@ -1321,6 +1337,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
         },
       },
     ]);
+    await waitFor(() => expect(cloud.runs.report).toHaveBeenCalled());
 
     expect(cloud.runs.report).toHaveBeenCalledWith(
       expect.objectContaining({ model_id: "provider/model-1" }),

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -314,6 +314,31 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     expect(secondCloud.events.track).not.toHaveBeenCalled();
   });
 
+  it("drops engagement events while the thread-list adapter is changing", async () => {
+    const listeners = new Map<string, (payload: any) => void>();
+    const client = mocks.makeClient("thread-1");
+    client.threadListItem.initialize = vi
+      .fn()
+      .mockRejectedValue(new Error("thread-list adapter changed"));
+    client.on = vi.fn((selector, callback) => {
+      listeners.set(selector.event, callback);
+      return () => listeners.delete(selector.event);
+    });
+    mocks.aui = client;
+    const cloud = makeCloud();
+    renderHook(() => useAssistantCloudThreadHistoryAdapter({ current: cloud }));
+    await waitFor(() => expect(listeners.has("message.copied")).toBe(true));
+
+    listeners.get("message.copied")!({
+      threadId: "thread-1",
+      messageId: "message-1",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(client.threadListItem.initialize).toHaveBeenCalledOnce();
+    expect(cloud.events.track).not.toHaveBeenCalled();
+  });
+
   it("keeps engagement state across same-scope Cloud client changes", async () => {
     const now = vi.spyOn(Date, "now").mockReturnValue(100);
     const listeners = new Map<string, (payload: any) => void>();

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -106,6 +106,14 @@ const makeAssistantMessage = (id: string): ThreadAssistantMessage => ({
   },
 });
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -266,6 +274,46 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     ).toHaveLength(1);
   });
 
+  it("drops engagement events resolved after the Cloud scope changes", async () => {
+    const initialization = deferred<{
+      remoteId: string;
+      externalId: undefined;
+    }>();
+    const listeners = new Map<string, (payload: any) => void>();
+    const client = mocks.makeClient(undefined);
+    client.threadListItem.initialize = vi.fn(() => initialization.promise);
+    client.on = vi.fn((selector, callback) => {
+      listeners.set(selector.event, callback);
+      return () => listeners.delete(selector.event);
+    });
+    mocks.aui = client;
+    const firstCloud = makeCloud();
+    const secondCloud = makeCloud();
+    const cloudRef = { current: firstCloud };
+    const scopeRef = { current: "workspace-a" };
+    renderHook(() =>
+      useScopedAssistantCloudThreadHistoryAdapter(cloudRef, scopeRef),
+    );
+    await waitFor(() => expect(listeners.has("composer.send")).toBe(true));
+
+    listeners.get("composer.send")!({
+      threadId: "local-thread",
+      chars: 5,
+      attachments: 0,
+    });
+    await vi.waitFor(() =>
+      expect(client.threadListItem.initialize).toHaveBeenCalledOnce(),
+    );
+
+    cloudRef.current = secondCloud;
+    scopeRef.current = "workspace-b";
+    initialization.resolve({ remoteId: "thread-a", externalId: undefined });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(firstCloud.events.track).not.toHaveBeenCalled();
+    expect(secondCloud.events.track).not.toHaveBeenCalled();
+  });
+
   it("refreshes formatted persistence when the Cloud client changes", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const firstCloud = makeCloud();
@@ -301,6 +349,33 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
       format: "test",
       limit: 200,
     });
+  });
+
+  it("resets default message mappings when the Cloud client changes", async () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const firstCloud = makeCloud();
+    const secondCloud = makeCloud();
+    vi.mocked(firstCloud.threads.messages.create).mockResolvedValue({
+      message_id: "remote-a",
+    });
+    vi.mocked(secondCloud.threads.messages.create).mockResolvedValue({
+      message_id: "remote-b",
+    });
+    const cloudRef = { current: firstCloud };
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter(cloudRef),
+    );
+    const message = makeAssistantMessage("local-message-1");
+
+    await result.current.append({ parentId: null, message });
+    cloudRef.current = secondCloud;
+    await result.current.update({ parentId: null, message });
+
+    expect(secondCloud.threads.messages.create).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({ parent_id: null }),
+    );
+    expect(secondCloud.threads.messages.update).not.toHaveBeenCalled();
   });
 
   it("preserves message mappings only within the same Cloud scope", async () => {
@@ -377,6 +452,90 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
       "remote-b",
       expect.anything(),
     );
+  });
+
+  it("rejects an append when its scope changes during thread initialization", async () => {
+    const initialization = deferred<{
+      remoteId: string;
+      externalId: undefined;
+    }>();
+    const client = mocks.makeClient(undefined);
+    client.threadListItem.initialize = vi.fn(() => initialization.promise);
+    mocks.aui = client;
+    const firstCloud = makeCloud();
+    const secondCloud = makeCloud();
+    const cloudRef = { current: firstCloud };
+    const scopeRef = { current: "workspace-a" };
+    const { result } = renderHook(() =>
+      useScopedAssistantCloudThreadHistoryAdapter(cloudRef, scopeRef),
+    );
+
+    const append = result.current.append({
+      parentId: null,
+      message: makeAssistantMessage("local-message-1"),
+    });
+    const rejected = expect(append).rejects.toThrow(
+      "Cloud scope changed during the persistence operation",
+    );
+    await vi.waitFor(() =>
+      expect(client.threadListItem.initialize).toHaveBeenCalledOnce(),
+    );
+
+    cloudRef.current = secondCloud;
+    scopeRef.current = "workspace-b";
+    initialization.resolve({ remoteId: "thread-a", externalId: undefined });
+
+    await rejected;
+    expect(firstCloud.threads.messages.create).not.toHaveBeenCalled();
+    expect(secondCloud.threads.messages.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a formatted append when its scope changes during initialization", async () => {
+    const initialization = deferred<{
+      remoteId: string;
+      externalId: undefined;
+    }>();
+    const client = mocks.makeClient(undefined);
+    client.threadListItem.initialize = vi.fn(() => initialization.promise);
+    mocks.aui = client;
+    const firstCloud = makeCloud();
+    const secondCloud = makeCloud();
+    const cloudRef = { current: firstCloud };
+    const scopeRef = { current: "workspace-a" };
+    const { result } = renderHook(() =>
+      useScopedAssistantCloudThreadHistoryAdapter(cloudRef, scopeRef),
+    );
+    const formatted = result.current.withFormat<
+      { id: string },
+      Record<string, unknown>
+    >({
+      format: "test",
+      encode: ({ message }) => message,
+      decode: ({ parent_id, content }) => ({
+        parentId: parent_id,
+        message: content as { id: string },
+      }),
+      getId: (message) => message.id,
+    });
+
+    const append = formatted.append({
+      parentId: null,
+      message: { id: "local-message-1" },
+    });
+    const rejected = expect(append).rejects.toThrow(
+      "Cloud scope changed during the persistence operation",
+    );
+    await vi.waitFor(() =>
+      expect(client.threadListItem.initialize).toHaveBeenCalledOnce(),
+    );
+
+    cloudRef.current = secondCloud;
+    scopeRef.current = "workspace-b";
+    initialization.resolve({ remoteId: "thread-a", externalId: undefined });
+
+    await rejected;
+    expect(firstCloud.threads.messages.create).not.toHaveBeenCalled();
+    expect(secondCloud.threads.messages.create).not.toHaveBeenCalled();
   });
 
   it("resolves formatted persistence against the current threadListItem", async () => {
@@ -457,6 +616,44 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
         { type: "positive" },
       );
     });
+  });
+
+  it("drops feedback resolved after the Cloud scope changes", async () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const created = deferred<{ message_id: string }>();
+    const firstCloud = makeCloud();
+    vi.mocked(firstCloud.threads.messages.create).mockReturnValue(
+      created.promise,
+    );
+    const secondCloud = makeCloud();
+    const cloudRef = { current: firstCloud };
+    const scopeRef = { current: "workspace-a" };
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useScopedAssistantCloudThreadHistoryAdapter(cloudRef, scopeRef),
+    );
+    const message = makeAssistantMessage("local-message-1");
+    const append = result.current.append({ parentId: null, message });
+    await vi.waitFor(() =>
+      expect(firstCloud.threads.messages.create).toHaveBeenCalledOnce(),
+    );
+
+    result.current.feedback.submit({ message, type: "positive" });
+    cloudRef.current = secondCloud;
+    scopeRef.current = "workspace-b";
+    created.resolve({ message_id: "remote-a" });
+    await append;
+    await vi.waitFor(() =>
+      expect(errorSpy).toHaveBeenCalledWith(
+        "[assistant-ui] Cloud feedback submission failed:",
+        expect.objectContaining({
+          message: "Cloud scope changed during the persistence operation",
+        }),
+      ),
+    );
+
+    expect(firstCloud.threads.messages.feedback).not.toHaveBeenCalled();
+    expect(secondCloud.threads.messages.feedback).not.toHaveBeenCalled();
   });
 
   it("warns and skips feedback before the thread has a remote ID", async () => {

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -415,6 +415,30 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     expect(secondCloud.threads.messages.create).not.toHaveBeenCalled();
   });
 
+  it("preserves default message mappings across adapter mounts", async () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const cloud = makeCloud();
+    const cloudRef = { current: cloud };
+    const message = makeAssistantMessage("local-message-1");
+    const first = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter(cloudRef),
+    );
+
+    await first.result.current.append({ parentId: null, message });
+
+    const second = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter(cloudRef),
+    );
+    await second.result.current.update({ parentId: null, message });
+
+    expect(cloud.threads.messages.create).toHaveBeenCalledOnce();
+    expect(cloud.threads.messages.update).toHaveBeenCalledWith(
+      "thread-1",
+      "remote-message-1",
+      expect.anything(),
+    );
+  });
+
   it("preserves message mappings only within the same Cloud scope", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const firstCloud = makeCloud();

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -4,7 +4,10 @@ import { renderHook, waitFor } from "@testing-library/react";
 import type { AssistantCloud } from "assistant-cloud";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadAssistantMessage } from "../../../types/message";
-import { useAssistantCloudThreadHistoryAdapter } from "./AssistantCloudThreadHistoryAdapter";
+import {
+  useAssistantCloudThreadHistoryAdapter,
+  useScopedAssistantCloudThreadHistoryAdapter,
+} from "./AssistantCloudThreadHistoryAdapter";
 
 const mocks = vi.hoisted(() => {
   const makeClient = (
@@ -298,6 +301,82 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
       format: "test",
       limit: 200,
     });
+  });
+
+  it("preserves message mappings only within the same Cloud scope", async () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const firstCloud = makeCloud();
+    const secondCloud = makeCloud();
+    vi.mocked(firstCloud.threads.messages.create).mockResolvedValue({
+      message_id: "remote-a",
+    });
+    vi.mocked(secondCloud.threads.messages.create).mockResolvedValue({
+      message_id: "remote-b",
+    });
+    const cloudRef = { current: firstCloud };
+    const scopeRef = { current: "workspace-a" };
+    const { result } = renderHook(() =>
+      useScopedAssistantCloudThreadHistoryAdapter(cloudRef, scopeRef),
+    );
+    const message = makeAssistantMessage("local-message-1");
+
+    await result.current.append({ parentId: null, message });
+    cloudRef.current = secondCloud;
+    await result.current.update({ parentId: null, message });
+
+    expect(secondCloud.threads.messages.update).toHaveBeenCalledWith(
+      "thread-1",
+      "remote-a",
+      expect.anything(),
+    );
+
+    scopeRef.current = "workspace-b";
+    await result.current.update({ parentId: null, message });
+
+    expect(secondCloud.threads.messages.create).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({ parent_id: null }),
+    );
+    expect(secondCloud.threads.messages.update).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a stale append from populating the replacement Cloud scope", async () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    let resolveFirst!: (value: { message_id: string }) => void;
+    const firstCloud = makeCloud();
+    vi.mocked(firstCloud.threads.messages.create).mockReturnValue(
+      new Promise((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
+    const secondCloud = makeCloud();
+    vi.mocked(secondCloud.threads.messages.create).mockResolvedValue({
+      message_id: "remote-b",
+    });
+    const cloudRef = { current: firstCloud };
+    const scopeRef = { current: "workspace-a" };
+    const { result } = renderHook(() =>
+      useScopedAssistantCloudThreadHistoryAdapter(cloudRef, scopeRef),
+    );
+    const message = makeAssistantMessage("local-message-1");
+
+    const staleAppend = result.current.append({ parentId: null, message });
+    await vi.waitFor(() => {
+      expect(firstCloud.threads.messages.create).toHaveBeenCalledOnce();
+    });
+
+    cloudRef.current = secondCloud;
+    scopeRef.current = "workspace-b";
+    await result.current.append({ parentId: null, message });
+    resolveFirst({ message_id: "remote-a" });
+    await staleAppend;
+    await result.current.update({ parentId: null, message });
+
+    expect(secondCloud.threads.messages.update).toHaveBeenCalledWith(
+      "thread-1",
+      "remote-b",
+      expect.anything(),
+    );
   });
 
   it("resolves formatted persistence against the current threadListItem", async () => {

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -314,6 +314,42 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     expect(secondCloud.events.track).not.toHaveBeenCalled();
   });
 
+  it("keeps engagement state across same-scope Cloud client changes", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(100);
+    const listeners = new Map<string, (payload: any) => void>();
+    const client = mocks.makeClient("thread-1");
+    client.on = vi.fn((selector, callback) => {
+      listeners.set(selector.event, callback);
+      return () => listeners.delete(selector.event);
+    });
+    mocks.aui = client;
+    const firstCloud = makeCloud();
+    const secondCloud = makeCloud();
+    const cloudRef = { current: firstCloud };
+    const scopeRef = { current: "workspace-a" };
+    const { rerender } = renderHook(() =>
+      useScopedAssistantCloudThreadHistoryAdapter(cloudRef, scopeRef),
+    );
+    await waitFor(() => expect(listeners.has("thread.runStart")).toBe(true));
+
+    listeners.get("thread.runStart")!({ threadId: "thread-1" });
+    now.mockReturnValue(125);
+    cloudRef.current = secondCloud;
+    rerender();
+    listeners.get("thread.cancelRun")!({ threadId: "thread-1" });
+
+    await waitFor(() =>
+      expect(secondCloud.events.track).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "run_stopped",
+          thread_id: "thread-1",
+          value: 25,
+        }),
+      ),
+    );
+    expect(firstCloud.events.track).not.toHaveBeenCalled();
+  });
+
   it("refreshes formatted persistence when the Cloud client changes", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const firstCloud = makeCloud();
@@ -351,7 +387,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     });
   });
 
-  it("resets default message mappings when the Cloud client changes", async () => {
+  it("preserves default message mappings when the Cloud client changes", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const firstCloud = makeCloud();
     const secondCloud = makeCloud();
@@ -371,11 +407,12 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     cloudRef.current = secondCloud;
     await result.current.update({ parentId: null, message });
 
-    expect(secondCloud.threads.messages.create).toHaveBeenCalledWith(
+    expect(secondCloud.threads.messages.update).toHaveBeenCalledWith(
       "thread-1",
-      expect.objectContaining({ parent_id: null }),
+      "remote-a",
+      expect.anything(),
     );
-    expect(secondCloud.threads.messages.update).not.toHaveBeenCalled();
+    expect(secondCloud.threads.messages.create).not.toHaveBeenCalled();
   });
 
   it("preserves message mappings only within the same Cloud scope", async () => {

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -5,6 +5,7 @@ import type { AssistantCloud } from "assistant-cloud";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadAssistantMessage } from "../../../types/message";
 import {
+  DEFAULT_CLOUD_SCOPE,
   useAssistantCloudThreadHistoryAdapter,
   useScopedAssistantCloudThreadHistoryAdapter,
 } from "./AssistantCloudThreadHistoryAdapter";
@@ -471,7 +472,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
       expect.anything(),
     );
 
-    scopeRef.current = "workspace-b";
+    scopeRef.current = DEFAULT_CLOUD_SCOPE;
     ownershipRef.current = new Set();
     await expect(
       result.current.update({ parentId: null, message }),

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useRef, useState } from "react";
+import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
 import type {
   GenericThreadHistoryAdapter,
   ThreadHistoryAdapter,
@@ -46,6 +46,15 @@ type ScopedPersistence = {
   scope: unknown;
 };
 
+type CloudScopeSnapshot = {
+  cloud: AssistantCloud;
+  scope: unknown;
+};
+
+type CloudScopeContext = CloudScopeSnapshot & {
+  persistence: CloudMessagePersistence;
+};
+
 const globalPersistence = new WeakMap<
   getClientId.ClientId,
   ScopedPersistence
@@ -55,8 +64,9 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   private cloudRef: RefObject<AssistantCloud>;
   private scopeRef: RefObject<unknown>;
   private getAui: () => AssistantClient;
-  private runReporter: CloudRunReporter;
-  public readonly engagementReporter: CloudEngagementReporter;
+  private engagementContext:
+    | (CloudScopeSnapshot & { reporter: CloudEngagementReporter })
+    | undefined;
 
   constructor(
     cloudRef: RefObject<AssistantCloud>,
@@ -66,23 +76,72 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     this.cloudRef = cloudRef;
     this.scopeRef = scopeRef;
     this.getAui = getAui;
-    this.runReporter = new CloudRunReporter(() => this.cloudRef.current);
-    this.engagementReporter = new CloudEngagementReporter(
-      () => this.cloudRef.current,
-      (threadId, messageId, options) =>
-        this.resolveEngagementEventIds(threadId, messageId, options),
-    );
   }
 
   private get aui(): AssistantClient {
     return this.getAui();
   }
 
+  private captureScopeSnapshot(): CloudScopeSnapshot {
+    return {
+      cloud: this.cloudRef.current,
+      scope: this.scopeRef.current,
+    };
+  }
+
+  private isCurrentScope({ scope }: CloudScopeSnapshot): boolean {
+    return Object.is(this.scopeRef.current, scope);
+  }
+
+  private assertCurrentScope(snapshot: CloudScopeSnapshot): void {
+    if (!this.isCurrentScope(snapshot)) {
+      throw new Error("Cloud scope changed during the persistence operation");
+    }
+  }
+
+  private captureScope(
+    threadListItem: CloudThreadListItem = this.aui.threadListItem,
+  ): CloudScopeContext {
+    const snapshot = this.captureScopeSnapshot();
+    return {
+      ...snapshot,
+      persistence: this.getPersistence(threadListItem, snapshot.scope),
+    };
+  }
+
+  public get engagementReporter(): CloudEngagementReporter {
+    const snapshot = this.captureScopeSnapshot();
+    const current = this.engagementContext;
+    if (
+      current &&
+      Object.is(current.scope, snapshot.scope) &&
+      Object.is(current.cloud, snapshot.cloud)
+    ) {
+      return current.reporter;
+    }
+
+    const reporter = new CloudEngagementReporter(
+      () => {
+        this.assertCurrentScope(snapshot);
+        return snapshot.cloud;
+      },
+      (threadId, messageId, options) =>
+        this.resolveEngagementEventIdsForScope(
+          snapshot,
+          threadId,
+          messageId,
+          options,
+        ),
+    );
+    this.engagementContext = { ...snapshot, reporter };
+    return reporter;
+  }
+
   private getPersistence(
     threadListItem: CloudThreadListItem = this.aui.threadListItem,
+    scope = this.scopeRef.current,
   ): CloudMessagePersistence {
     const key = getClientId(threadListItem);
-    const scope = this.scopeRef.current;
     let entry = globalPersistence.get(key);
     if (!entry || !Object.is(entry.scope, scope)) {
       const cloudRef = { current: this.cloudRef };
@@ -100,10 +159,6 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     return entry.persistence;
   }
 
-  private get _persistence(): CloudMessagePersistence {
-    return this.getPersistence();
-  }
-
   /**
    * A send is the moment the runtime creates the remote thread, so that one
    * event waits for the id; every other event reads the id that already
@@ -115,8 +170,24 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     messageId?: string,
     options?: { awaitThread?: boolean },
   ): Promise<Pick<AssistantCloudEvent, "thread_id" | "message_id">> {
+    return this.resolveEngagementEventIdsForScope(
+      this.captureScopeSnapshot(),
+      threadId,
+      messageId,
+      options,
+    );
+  }
+
+  private async resolveEngagementEventIdsForScope(
+    snapshot: CloudScopeSnapshot,
+    threadId: string,
+    messageId?: string,
+    options?: { awaitThread?: boolean },
+  ): Promise<Pick<AssistantCloudEvent, "thread_id" | "message_id">> {
+    this.assertCurrentScope(snapshot);
     const threadListItem = this.getThreadListItem(threadId);
     if (!threadListItem) return {};
+    const persistence = this.getPersistence(threadListItem, snapshot.scope);
 
     let remoteThreadId = threadListItem.getState().remoteId;
     if (!remoteThreadId && options?.awaitThread) {
@@ -125,8 +196,9 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
         .then((result) => result.remoteId)
         .catch(() => undefined);
     }
+    this.assertCurrentScope(snapshot);
     const remoteMessageId = messageId
-      ? this.getPersistence(threadListItem).getResolvedRemoteId(messageId)
+      ? persistence.getResolvedRemoteId(messageId)
       : undefined;
     return {
       ...(remoteThreadId ? { thread_id: remoteThreadId } : undefined),
@@ -137,6 +209,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   public readonly feedback: FeedbackAdapter = {
     submit: ({ message, type }) => {
       void (async () => {
+        const snapshot = this.captureScopeSnapshot();
         const threadListItem = this.tryGetKeyedThreadListItem();
         const remoteThreadId = threadListItem?.getState().remoteId;
         if (!threadListItem || !remoteThreadId) {
@@ -146,9 +219,9 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
           return;
         }
 
-        const cloudMessageId = await this.getPersistence(
-          threadListItem,
-        ).getRemoteId(message.id);
+        const persistence = this.getPersistence(threadListItem, snapshot.scope);
+        const cloudMessageId = await persistence.getRemoteId(message.id);
+        this.assertCurrentScope(snapshot);
         if (!cloudMessageId) {
           console.warn(
             `[assistant-ui] Skipping feedback for message ${message.id}: no cloud message id is mapped.`,
@@ -156,7 +229,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
           return;
         }
 
-        await this.cloudRef.current.threads.messages.feedback(
+        await snapshot.cloud.threads.messages.feedback(
           remoteThreadId,
           cloudMessageId,
           { type },
@@ -209,8 +282,8 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
       return threadListItem;
     };
     const resolvePinned = () => threadListItem ?? pinCurrent();
-    const getTargetFormatted = (item: CloudThreadListItem) =>
-      createFormattedPersistence(adapter.getPersistence(item), formatAdapter);
+    const getTargetFormatted = (context: CloudScopeContext) =>
+      createFormattedPersistence(context.persistence, formatAdapter);
     return {
       pin() {
         pinCurrent();
@@ -222,15 +295,18 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
             "Cannot persist cloud history without a thread list item.",
           );
         }
+        const context = adapter.captureScope(pinned);
         const remoteId =
           pinned.getState().remoteId ?? (await pinned.initialize()).remoteId;
-        await getTargetFormatted(pinned).append(remoteId, item);
+        adapter.assertCurrentScope(context);
+        await getTargetFormatted(context).append(remoteId, item);
       },
       async update(item: MessageFormatItem<TMessage>, localMessageId: string) {
         const pinned = resolvePinned();
         const remoteId = pinned?.getState().remoteId;
         if (!remoteId || !pinned) return;
-        await getTargetFormatted(pinned).update?.(
+        const context = adapter.captureScope(pinned);
+        await getTargetFormatted(context).update?.(
           remoteId,
           item,
           localMessageId,
@@ -273,15 +349,21 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
         const live = adapter.aui.threadListItem;
         const remoteId = live.source ? live.getState().remoteId : undefined;
         if (!remoteId) return { messages: [] };
-        return getTargetFormatted(pinned ?? live).load(remoteId);
+        const context = adapter.captureScope(pinned ?? live);
+        const repository = await getTargetFormatted(context).load(remoteId);
+        adapter.assertCurrentScope(context);
+        return repository;
       },
     };
   }
 
   async append({ parentId, message }: ExportedMessageRepositoryItem) {
-    const { remoteId } = await this.aui.threadListItem.initialize();
+    const threadListItem = this.aui.threadListItem;
+    const context = this.captureScope(threadListItem);
+    const { remoteId } = await threadListItem.initialize();
+    this.assertCurrentScope(context);
     const encoded = auiV0Encode(message);
-    await this._persistence.append(
+    await context.persistence.append(
       remoteId,
       message.id,
       parentId,
@@ -289,32 +371,36 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
       encoded,
     );
 
-    if (this.cloudRef.current.telemetry.enabled) {
+    if (context.cloud.telemetry.enabled && this.isCurrentScope(context)) {
       this._maybeReportRun(
         remoteId,
         "aui/v0",
         encoded,
         extractRunMessageInfo(message, "aui/v0"),
+        context,
       );
     }
   }
 
   async update(item: ExportedMessageRepositoryItem) {
-    if (!this._persistence.isPersisted(item.message.id)) {
+    const threadListItem = this.aui.threadListItem;
+    const context = this.captureScope(threadListItem);
+    if (!context.persistence.isPersisted(item.message.id)) {
       return this.append(item);
     }
     const { message } = item;
-    const remoteId = this.aui.threadListItem.getState().remoteId;
+    const remoteId = threadListItem.getState().remoteId;
     if (!remoteId) return;
     const encoded = auiV0Encode(message);
-    await this._persistence.update(remoteId, message.id, "aui/v0", encoded);
+    await context.persistence.update(remoteId, message.id, "aui/v0", encoded);
 
-    if (this.cloudRef.current.telemetry.enabled) {
+    if (context.cloud.telemetry.enabled && this.isCurrentScope(context)) {
       this._maybeReportRun(
         remoteId,
         "aui/v0",
         encoded,
         extractRunMessageInfo(message, "aui/v0"),
+        context,
       );
     }
   }
@@ -326,9 +412,12 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   }
 
   async load() {
-    const remoteId = this.aui.threadListItem.getState().remoteId;
+    const threadListItem = this.aui.threadListItem;
+    const context = this.captureScope(threadListItem);
+    const remoteId = threadListItem.getState().remoteId;
     if (!remoteId) return { messages: [] };
-    const messages = await this._persistence.load(remoteId, "aui/v0");
+    const messages = await context.persistence.load(remoteId, "aui/v0");
+    this.assertCurrentScope(context);
     return {
       messages: messages
         .filter(
@@ -350,6 +439,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     messageInfo?: RunMessageInfo,
   ) {
     const item = threadListItem ?? this.aui.threadListItem;
+    const context = this.captureScope(item);
     const remoteId = item.getState().remoteId;
     if (!remoteId) return;
 
@@ -366,7 +456,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
       options?.durationMs,
       options?.stepTimestamps,
       messageInfo,
-      this.getPersistence(item),
+      context,
     );
   }
 
@@ -375,11 +465,19 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     format: string,
     content: T,
     messageInfo?: RunMessageInfo,
+    context = this.captureScope(),
   ) {
     const extracted = extractTelemetry(format, content);
     if (!extracted) return;
 
-    this._sendReport(remoteId, extracted, undefined, undefined, messageInfo);
+    this._sendReport(
+      remoteId,
+      extracted,
+      undefined,
+      undefined,
+      messageInfo,
+      context,
+    );
   }
 
   private _sendReport(
@@ -388,13 +486,14 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     durationMs?: number,
     stepTimestamps?: StepTimestamp[],
     messageInfo?: RunMessageInfo,
-    persistence = this._persistence,
+    context = this.captureScope(),
   ) {
+    if (!this.isCurrentScope(context)) return;
     const mergedSteps = mergeStepTimestamps(data.steps, stepTimestamps);
     const messageId = messageInfo?.localMessageId
-      ? persistence.getResolvedRemoteId(messageInfo.localMessageId)
+      ? context.persistence.getResolvedRemoteId(messageInfo.localMessageId)
       : undefined;
-    void this.runReporter.report({
+    void new CloudRunReporter(context.cloud).report({
       threadId: remoteId,
       status: messageInfo?.status ?? data.status,
       outcome: messageInfo?.outcomeType,
@@ -722,12 +821,20 @@ export function useScopedAssistantCloudThreadHistoryAdapter(
 export function useAssistantCloudThreadHistoryAdapter(
   cloudRef: RefObject<AssistantCloud>,
 ): ThreadHistoryAdapter & { readonly feedback: FeedbackAdapter } {
-  return useScopedAssistantCloudThreadHistoryAdapter(cloudRef, cloudRef);
+  const scopeRef = useMemo(
+    () => ({
+      get current() {
+        return cloudRef.current;
+      },
+    }),
+    [cloudRef],
+  );
+  return useScopedAssistantCloudThreadHistoryAdapter(cloudRef, scopeRef);
 }
 
 type RootEngagementTracker = {
   count: number;
-  engagementReporter: CloudEngagementReporter;
+  adapter: AssistantCloudThreadHistoryAdapter;
   dispose: () => void;
 };
 
@@ -750,20 +857,20 @@ const useRootEngagementEvents = (
     if (!tracker) {
       const created: RootEngagementTracker = {
         count: 0,
-        engagementReporter: adapter.engagementReporter,
+        adapter,
         dispose: () => {},
       };
       created.dispose = aui.on(
         { scope: "*", event: "threads.selectionChanged" },
         (payload) => {
-          created.engagementReporter.threadSwitched(payload.threadId);
+          created.adapter.engagementReporter.threadSwitched(payload.threadId);
         },
       );
       rootEngagementTrackers.set(aui, created);
       tracker = created;
     }
     const active = tracker;
-    active.engagementReporter = adapter.engagementReporter;
+    active.adapter = adapter;
     active.count += 1;
     return () => {
       active.count -= 1;
@@ -782,29 +889,27 @@ const useAssistantCloudEngagementEvents = (
   useRootEngagementEvents(adapter, aui);
 
   useEffect(() => {
-    const reporter = adapter.engagementReporter;
-
     const unsubscribers = [
       aui.on({ scope: "thread", event: "composer.send" }, (payload) => {
         if (payload.messageId) {
-          reporter.messageEdited(payload.threadId, {
+          adapter.engagementReporter.messageEdited(payload.threadId, {
             messageId: payload.messageId,
             chars: payload.chars,
           });
         } else {
-          reporter.messageSent(payload.threadId, {
+          adapter.engagementReporter.messageSent(payload.threadId, {
             chars: payload.chars,
             attachments: payload.attachments,
           });
         }
         if (payload.suggestion) {
-          reporter.suggestionClicked(payload.threadId);
+          adapter.engagementReporter.suggestionClicked(payload.threadId);
         }
       }),
       aui.on(
         { scope: "thread", event: "composer.attachmentAdd" },
         (payload) => {
-          reporter.attachmentAdded(payload.threadId, {
+          adapter.engagementReporter.attachmentAdded(payload.threadId, {
             messageId: payload.messageId,
             contentType: payload.contentType,
           });
@@ -813,44 +918,56 @@ const useAssistantCloudEngagementEvents = (
       aui.on(
         { scope: "thread", event: "composer.attachmentAddError" },
         (payload) => {
-          reporter.attachmentFailed(payload.threadId, {
+          adapter.engagementReporter.attachmentFailed(payload.threadId, {
             messageId: payload.messageId,
             contentType: payload.contentType,
           });
         },
       ),
       aui.on({ scope: "thread", event: "composer.cancel" }, (payload) => {
-        reporter.runStopped(payload.threadId);
+        adapter.engagementReporter.runStopped(payload.threadId);
       }),
       aui.on({ scope: "thread", event: "thread.runStart" }, (payload) => {
-        reporter.runStarted(payload.threadId);
+        adapter.engagementReporter.runStarted(payload.threadId);
       }),
       aui.on({ scope: "thread", event: "thread.runEnd" }, (payload) => {
-        reporter.runEnded(payload.threadId);
+        adapter.engagementReporter.runEnded(payload.threadId);
       }),
       aui.on({ scope: "thread", event: "thread.cancelRun" }, (payload) => {
-        reporter.runStopped(payload.threadId);
+        adapter.engagementReporter.runStopped(payload.threadId);
       }),
       aui.on({ scope: "thread", event: "thread.voiceStarted" }, (payload) => {
-        reporter.voiceStarted(payload.threadId);
+        adapter.engagementReporter.voiceStarted(payload.threadId);
       }),
       aui.on({ scope: "thread", event: "message.reload" }, (payload) => {
-        reporter.messageRegenerated(payload.threadId, payload.messageId);
+        adapter.engagementReporter.messageRegenerated(
+          payload.threadId,
+          payload.messageId,
+        );
       }),
       aui.on(
         { scope: "thread", event: "message.branchSwitched" },
         (payload) => {
-          reporter.branchSwitched(payload.threadId, payload.messageId);
+          adapter.engagementReporter.branchSwitched(
+            payload.threadId,
+            payload.messageId,
+          );
         },
       ),
       aui.on({ scope: "thread", event: "message.copied" }, (payload) => {
-        reporter.messageCopied(payload.threadId, payload.messageId);
+        adapter.engagementReporter.messageCopied(
+          payload.threadId,
+          payload.messageId,
+        );
       }),
       aui.on({ scope: "thread", event: "message.speak" }, (payload) => {
-        reporter.speechStarted(payload.threadId, payload.messageId);
+        adapter.engagementReporter.speechStarted(
+          payload.threadId,
+          payload.messageId,
+        );
       }),
       aui.on({ scope: "thread", event: "message.error" }, (payload) => {
-        reporter.errorShown(payload.threadId, {
+        adapter.engagementReporter.errorShown(payload.threadId, {
           messageId: payload.messageId,
           reason: payload.reason,
         });

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -49,6 +49,7 @@ type ScopedPersistence = {
 type CloudScopeSnapshot = {
   cloud: AssistantCloud;
   scope: unknown;
+  ownership: Pick<ReadonlySet<string>, "has"> | undefined;
 };
 
 type CloudScopeContext = CloudScopeSnapshot & {
@@ -65,6 +66,9 @@ export const DEFAULT_CLOUD_SCOPE = Symbol("assistant-ui:cloud-default-scope");
 class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   private cloudRef: RefObject<AssistantCloud>;
   private scopeRef: RefObject<unknown>;
+  private ownershipRef:
+    | RefObject<Pick<ReadonlySet<string>, "has"> | undefined>
+    | undefined;
   private getAui: () => AssistantClient;
   private engagementContext:
     | { scope: unknown; reporter: CloudEngagementReporter }
@@ -74,9 +78,11 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     cloudRef: RefObject<AssistantCloud>,
     getAui: () => AssistantClient,
     scopeRef: RefObject<unknown>,
+    ownershipRef?: RefObject<Pick<ReadonlySet<string>, "has"> | undefined>,
   ) {
     this.cloudRef = cloudRef;
     this.scopeRef = scopeRef;
+    this.ownershipRef = ownershipRef;
     this.getAui = getAui;
   }
 
@@ -88,6 +94,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     return {
       cloud: this.cloudRef.current,
       scope: this.scopeRef.current,
+      ownership: this.ownershipRef?.current,
     };
   }
 
@@ -101,13 +108,26 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     }
   }
 
+  private assertRemoteThreadOwned(
+    snapshot: CloudScopeSnapshot,
+    remoteId: string,
+  ): void {
+    if (snapshot.ownership && !snapshot.ownership.has(remoteId)) {
+      throw new Error(
+        "Cloud thread does not belong to the current account or workspace scope",
+      );
+    }
+  }
+
   private captureScope(
     threadListItem: CloudThreadListItem = this.aui.threadListItem,
   ): CloudScopeContext {
     const snapshot = this.captureScopeSnapshot();
+    const remoteId = threadListItem.getState().remoteId;
+    if (remoteId) this.assertRemoteThreadOwned(snapshot, remoteId);
     return {
       ...snapshot,
-      persistence: this.getPersistence(threadListItem, snapshot.scope),
+      persistence: this.getPersistence(threadListItem, snapshot),
     };
   }
 
@@ -137,15 +157,17 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
 
   private getPersistence(
     threadListItem: CloudThreadListItem = this.aui.threadListItem,
-    scope = this.scopeRef.current,
+    snapshot = this.captureScopeSnapshot(),
   ): CloudMessagePersistence {
+    const remoteId = threadListItem.getState().remoteId;
+    if (remoteId) this.assertRemoteThreadOwned(snapshot, remoteId);
     const key = getClientId(threadListItem);
     let entry = globalPersistence.get(key);
-    if (!entry || !Object.is(entry.scope, scope)) {
+    if (!entry || !Object.is(entry.scope, snapshot.scope)) {
       const cloudRef = { current: this.cloudRef };
       entry = {
         cloudRef,
-        scope,
+        scope: snapshot.scope,
         persistence: new CloudMessagePersistence(
           () => cloudRef.current.current,
         ),
@@ -187,7 +209,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     this.assertCurrentScope(snapshot);
     const threadListItem = this.getThreadListItem(threadId);
     if (!threadListItem) return {};
-    const persistence = this.getPersistence(threadListItem, snapshot.scope);
+    const persistence = this.getPersistence(threadListItem, snapshot);
 
     let remoteThreadId = threadListItem.getState().remoteId;
     if (!remoteThreadId && options?.awaitThread) {
@@ -197,6 +219,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
         .catch(() => undefined);
     }
     this.assertCurrentScope(snapshot);
+    if (remoteThreadId) this.assertRemoteThreadOwned(snapshot, remoteThreadId);
     const remoteMessageId = messageId
       ? persistence.getResolvedRemoteId(messageId)
       : undefined;
@@ -219,7 +242,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
           return;
         }
 
-        const persistence = this.getPersistence(threadListItem, snapshot.scope);
+        const persistence = this.getPersistence(threadListItem, snapshot);
         const cloudMessageId = await persistence.getRemoteId(message.id);
         this.assertCurrentScope(snapshot);
         if (!cloudMessageId) {
@@ -299,6 +322,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
         const remoteId =
           pinned.getState().remoteId ?? (await pinned.initialize()).remoteId;
         adapter.assertCurrentScope(context);
+        adapter.assertRemoteThreadOwned(context, remoteId);
         await getTargetFormatted(context).append(remoteId, item);
       },
       async update(item: MessageFormatItem<TMessage>, localMessageId: string) {
@@ -362,6 +386,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     const context = this.captureScope(threadListItem);
     const { remoteId } = await threadListItem.initialize();
     this.assertCurrentScope(context);
+    this.assertRemoteThreadOwned(context, remoteId);
     const encoded = auiV0Encode(message);
     await context.persistence.append(
       remoteId,
@@ -799,6 +824,7 @@ export function extractAuiV0<T>(content: T): RunMessageTelemetry | null {
 export function useScopedAssistantCloudThreadHistoryAdapter(
   cloudRef: RefObject<AssistantCloud>,
   scopeRef: RefObject<unknown>,
+  ownershipRef?: RefObject<Pick<ReadonlySet<string>, "has"> | undefined>,
 ): ThreadHistoryAdapter & { readonly feedback: FeedbackAdapter } {
   const aui = useAui();
   // Not useEffectEvent: history adapter methods run during render (SSR load).
@@ -812,6 +838,7 @@ export function useScopedAssistantCloudThreadHistoryAdapter(
         cloudRef,
         () => auiRef.current,
         scopeRef,
+        ownershipRef,
       ),
   );
   useAssistantCloudEngagementEvents(adapter, aui);

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -49,7 +49,6 @@ type ScopedPersistence = {
 type CloudScopeSnapshot = {
   cloud: AssistantCloud;
   scope: unknown;
-  ownership: Pick<ReadonlySet<string>, "has"> | undefined;
 };
 
 type CloudScopeContext = CloudScopeSnapshot & {
@@ -66,9 +65,6 @@ export const DEFAULT_CLOUD_SCOPE = Symbol("assistant-ui:cloud-default-scope");
 class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   private cloudRef: RefObject<AssistantCloud>;
   private scopeRef: RefObject<unknown>;
-  private ownershipRef:
-    | RefObject<Pick<ReadonlySet<string>, "has"> | undefined>
-    | undefined;
   private getAui: () => AssistantClient;
   private engagementContext:
     | { scope: unknown; reporter: CloudEngagementReporter }
@@ -78,11 +74,9 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     cloudRef: RefObject<AssistantCloud>,
     getAui: () => AssistantClient,
     scopeRef: RefObject<unknown>,
-    ownershipRef?: RefObject<Pick<ReadonlySet<string>, "has"> | undefined>,
   ) {
     this.cloudRef = cloudRef;
     this.scopeRef = scopeRef;
-    this.ownershipRef = ownershipRef;
     this.getAui = getAui;
   }
 
@@ -94,7 +88,6 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     return {
       cloud: this.cloudRef.current,
       scope: this.scopeRef.current,
-      ownership: this.ownershipRef?.current,
     };
   }
 
@@ -108,23 +101,10 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     }
   }
 
-  private assertRemoteThreadOwned(
-    snapshot: CloudScopeSnapshot,
-    remoteId: string,
-  ): void {
-    if (snapshot.ownership && !snapshot.ownership.has(remoteId)) {
-      throw new Error(
-        "Cloud thread does not belong to the current account or workspace scope",
-      );
-    }
-  }
-
   private captureScope(
     threadListItem: CloudThreadListItem = this.aui.threadListItem,
   ): CloudScopeContext {
     const snapshot = this.captureScopeSnapshot();
-    const remoteId = threadListItem.getState().remoteId;
-    if (remoteId) this.assertRemoteThreadOwned(snapshot, remoteId);
     return {
       ...snapshot,
       persistence: this.getPersistence(threadListItem, snapshot),
@@ -159,8 +139,6 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     threadListItem: CloudThreadListItem = this.aui.threadListItem,
     snapshot = this.captureScopeSnapshot(),
   ): CloudMessagePersistence {
-    const remoteId = threadListItem.getState().remoteId;
-    if (remoteId) this.assertRemoteThreadOwned(snapshot, remoteId);
     const key = getClientId(threadListItem);
     let entry = globalPersistence.get(key);
     if (!entry || !Object.is(entry.scope, snapshot.scope)) {
@@ -179,6 +157,13 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
       entry.cloudRef.current = this.cloudRef;
     }
     return entry.persistence;
+  }
+
+  private async resolveExistingRemoteId(
+    threadListItem: CloudThreadListItem,
+  ): Promise<string | undefined> {
+    if (!threadListItem.getState().remoteId) return undefined;
+    return (await threadListItem.initialize()).remoteId;
   }
 
   /**
@@ -211,15 +196,14 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     if (!threadListItem) return {};
     const persistence = this.getPersistence(threadListItem, snapshot);
 
-    let remoteThreadId = threadListItem.getState().remoteId;
-    if (!remoteThreadId && options?.awaitThread) {
+    let remoteThreadId: string | undefined;
+    if (threadListItem.getState().remoteId || options?.awaitThread) {
       remoteThreadId = await threadListItem
         .initialize()
         .then((result) => result.remoteId)
         .catch(() => undefined);
     }
     this.assertCurrentScope(snapshot);
-    if (remoteThreadId) this.assertRemoteThreadOwned(snapshot, remoteThreadId);
     const remoteMessageId = messageId
       ? persistence.getResolvedRemoteId(messageId)
       : undefined;
@@ -232,19 +216,22 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   public readonly feedback: FeedbackAdapter = {
     submit: ({ message, type }) => {
       void (async () => {
-        const snapshot = this.captureScopeSnapshot();
         const threadListItem = this.tryGetKeyedThreadListItem();
-        const remoteThreadId = threadListItem?.getState().remoteId;
-        if (!threadListItem || !remoteThreadId) {
+        if (!threadListItem || !threadListItem.getState().remoteId) {
           console.warn(
             `[assistant-ui] Skipping feedback for message ${message.id}: the thread has no remote id.`,
           );
           return;
         }
 
-        const persistence = this.getPersistence(threadListItem, snapshot);
+        const context = this.captureScope(threadListItem);
+        const remoteThreadId =
+          await this.resolveExistingRemoteId(threadListItem);
+        this.assertCurrentScope(context);
+        if (!remoteThreadId) return;
+        const persistence = context.persistence;
         const cloudMessageId = await persistence.getRemoteId(message.id);
-        this.assertCurrentScope(snapshot);
+        this.assertCurrentScope(context);
         if (!cloudMessageId) {
           console.warn(
             `[assistant-ui] Skipping feedback for message ${message.id}: no cloud message id is mapped.`,
@@ -252,7 +239,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
           return;
         }
 
-        await snapshot.cloud.threads.messages.feedback(
+        await context.cloud.threads.messages.feedback(
           remoteThreadId,
           cloudMessageId,
           { type },
@@ -319,17 +306,17 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
           );
         }
         const context = adapter.captureScope(pinned);
-        const remoteId =
-          pinned.getState().remoteId ?? (await pinned.initialize()).remoteId;
+        const { remoteId } = await pinned.initialize();
         adapter.assertCurrentScope(context);
-        adapter.assertRemoteThreadOwned(context, remoteId);
         await getTargetFormatted(context).append(remoteId, item);
       },
       async update(item: MessageFormatItem<TMessage>, localMessageId: string) {
         const pinned = resolvePinned();
-        const remoteId = pinned?.getState().remoteId;
-        if (!remoteId || !pinned) return;
+        if (!pinned || !pinned.getState().remoteId) return;
         const context = adapter.captureScope(pinned);
+        const remoteId = await adapter.resolveExistingRemoteId(pinned);
+        adapter.assertCurrentScope(context);
+        if (!remoteId) return;
         await getTargetFormatted(context).update?.(
           remoteId,
           item,
@@ -371,9 +358,12 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
         // resolve, whichever of the list item or the live graft won the pin.
         const pinned = pinCurrent();
         const live = adapter.aui.threadListItem;
-        const remoteId = live.source ? live.getState().remoteId : undefined;
+        if (!live.source || !live.getState().remoteId) return { messages: [] };
+        const target = pinned ?? live;
+        const context = adapter.captureScope(target);
+        const remoteId = await adapter.resolveExistingRemoteId(target);
+        adapter.assertCurrentScope(context);
         if (!remoteId) return { messages: [] };
-        const context = adapter.captureScope(pinned ?? live);
         const repository = await getTargetFormatted(context).load(remoteId);
         adapter.assertCurrentScope(context);
         return repository;
@@ -386,7 +376,6 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     const context = this.captureScope(threadListItem);
     const { remoteId } = await threadListItem.initialize();
     this.assertCurrentScope(context);
-    this.assertRemoteThreadOwned(context, remoteId);
     const encoded = auiV0Encode(message);
     await context.persistence.append(
       remoteId,
@@ -414,7 +403,8 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
       return this.append(item);
     }
     const { message } = item;
-    const remoteId = threadListItem.getState().remoteId;
+    const remoteId = await this.resolveExistingRemoteId(threadListItem);
+    this.assertCurrentScope(context);
     if (!remoteId) return;
     const encoded = auiV0Encode(message);
     await context.persistence.update(remoteId, message.id, "aui/v0", encoded);
@@ -439,7 +429,8 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   async load() {
     const threadListItem = this.aui.threadListItem;
     const context = this.captureScope(threadListItem);
-    const remoteId = threadListItem.getState().remoteId;
+    const remoteId = await this.resolveExistingRemoteId(threadListItem);
+    this.assertCurrentScope(context);
     if (!remoteId) return { messages: [] };
     const messages = await context.persistence.load(remoteId, "aui/v0");
     this.assertCurrentScope(context);
@@ -465,8 +456,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   ) {
     const item = threadListItem ?? this.aui.threadListItem;
     const context = this.captureScope(item);
-    const remoteId = item.getState().remoteId;
-    if (!remoteId) return;
+    if (!item.getState().remoteId) return;
 
     const extracted =
       extractRunTelemetry(format, runMessages) ??
@@ -475,14 +465,20 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
         : undefined);
     if (!extracted) return;
 
-    this._sendReport(
-      remoteId,
-      extracted,
-      options?.durationMs,
-      options?.stepTimestamps,
-      messageInfo,
-      context,
-    );
+    void this.resolveExistingRemoteId(item)
+      .then((remoteId) => {
+        if (!remoteId) return;
+        this.assertCurrentScope(context);
+        this._sendReport(
+          remoteId,
+          extracted,
+          options?.durationMs,
+          options?.stepTimestamps,
+          messageInfo,
+          context,
+        );
+      })
+      .catch(() => {});
   }
 
   private _maybeReportRun<T>(
@@ -824,7 +820,6 @@ export function extractAuiV0<T>(content: T): RunMessageTelemetry | null {
 export function useScopedAssistantCloudThreadHistoryAdapter(
   cloudRef: RefObject<AssistantCloud>,
   scopeRef: RefObject<unknown>,
-  ownershipRef?: RefObject<Pick<ReadonlySet<string>, "has"> | undefined>,
 ): ThreadHistoryAdapter & { readonly feedback: FeedbackAdapter } {
   const aui = useAui();
   // Not useEffectEvent: history adapter methods run during render (SSR load).
@@ -838,7 +833,6 @@ export function useScopedAssistantCloudThreadHistoryAdapter(
         cloudRef,
         () => auiRef.current,
         scopeRef,
-        ownershipRef,
       ),
   );
   useAssistantCloudEngagementEvents(adapter, aui);

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
+import { type RefObject, useEffect, useRef, useState } from "react";
 import type {
   GenericThreadHistoryAdapter,
   ThreadHistoryAdapter,
@@ -65,7 +65,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   private scopeRef: RefObject<unknown>;
   private getAui: () => AssistantClient;
   private engagementContext:
-    | (CloudScopeSnapshot & { reporter: CloudEngagementReporter })
+    | { scope: unknown; reporter: CloudEngagementReporter }
     | undefined;
 
   constructor(
@@ -112,18 +112,14 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   public get engagementReporter(): CloudEngagementReporter {
     const snapshot = this.captureScopeSnapshot();
     const current = this.engagementContext;
-    if (
-      current &&
-      Object.is(current.scope, snapshot.scope) &&
-      Object.is(current.cloud, snapshot.cloud)
-    ) {
+    if (current && Object.is(current.scope, snapshot.scope)) {
       return current.reporter;
     }
 
     const reporter = new CloudEngagementReporter(
       () => {
         this.assertCurrentScope(snapshot);
-        return snapshot.cloud;
+        return this.cloudRef.current;
       },
       (threadId, messageId, options) =>
         this.resolveEngagementEventIdsForScope(
@@ -133,7 +129,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
           options,
         ),
     );
-    this.engagementContext = { ...snapshot, reporter };
+    this.engagementContext = { scope: snapshot.scope, reporter };
     return reporter;
   }
 
@@ -154,6 +150,8 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
       };
       globalPersistence.set(key, entry);
     } else {
+      // Thread items can outlive the hook that created their persistence, so a
+      // later adapter must reconnect the retained mapping to its live client ref.
       entry.cloudRef.current = this.cloudRef;
     }
     return entry.persistence;
@@ -821,14 +819,7 @@ export function useScopedAssistantCloudThreadHistoryAdapter(
 export function useAssistantCloudThreadHistoryAdapter(
   cloudRef: RefObject<AssistantCloud>,
 ): ThreadHistoryAdapter & { readonly feedback: FeedbackAdapter } {
-  const scopeRef = useMemo(
-    () => ({
-      get current() {
-        return cloudRef.current;
-      },
-    }),
-    [cloudRef],
-  );
+  const [scopeRef] = useState<RefObject<unknown>>(() => ({ current: {} }));
   return useScopedAssistantCloudThreadHistoryAdapter(cloudRef, scopeRef);
 }
 

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -69,6 +69,13 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   private engagementContext:
     | { scope: unknown; reporter: CloudEngagementReporter }
     | undefined;
+  private runReporterContext:
+    | {
+        cloud: AssistantCloud;
+        scope: unknown;
+        reporter: CloudRunReporter;
+      }
+    | undefined;
 
   constructor(
     cloudRef: RefObject<AssistantCloud>,
@@ -510,11 +517,23 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     context = this.captureScope(),
   ) {
     if (!this.isCurrentScope(context)) return;
+    const current = this.runReporterContext;
+    const reporter =
+      current &&
+      current.cloud === context.cloud &&
+      Object.is(current.scope, context.scope)
+        ? current.reporter
+        : new CloudRunReporter(context.cloud);
+    this.runReporterContext = {
+      cloud: context.cloud,
+      scope: context.scope,
+      reporter,
+    };
     const mergedSteps = mergeStepTimestamps(data.steps, stepTimestamps);
     const messageId = messageInfo?.localMessageId
       ? context.persistence.getResolvedRemoteId(messageInfo.localMessageId)
       : undefined;
-    void new CloudRunReporter(context.cloud).report({
+    void reporter.report({
       threadId: remoteId,
       status: messageInfo?.status ?? data.status,
       outcome: messageInfo?.outcomeType,

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -205,10 +205,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
 
     let remoteThreadId: string | undefined;
     if (threadListItem.getState().remoteId || options?.awaitThread) {
-      remoteThreadId = await threadListItem
-        .initialize()
-        .then((result) => result.remoteId)
-        .catch(() => undefined);
+      remoteThreadId = (await threadListItem.initialize()).remoteId;
     }
     this.assertCurrentScope(snapshot);
     const remoteMessageId = messageId

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -40,13 +40,20 @@ type CloudThreadListItem = Pick<
   "getState" | "initialize"
 >;
 
+type ScopedPersistence = {
+  cloudRef: { current: RefObject<AssistantCloud> };
+  persistence: CloudMessagePersistence;
+  scope: unknown;
+};
+
 const globalPersistence = new WeakMap<
   getClientId.ClientId,
-  CloudMessagePersistence
+  ScopedPersistence
 >();
 
 class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   private cloudRef: RefObject<AssistantCloud>;
+  private scopeRef: RefObject<unknown>;
   private getAui: () => AssistantClient;
   private runReporter: CloudRunReporter;
   public readonly engagementReporter: CloudEngagementReporter;
@@ -54,8 +61,10 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   constructor(
     cloudRef: RefObject<AssistantCloud>,
     getAui: () => AssistantClient,
+    scopeRef: RefObject<unknown>,
   ) {
     this.cloudRef = cloudRef;
+    this.scopeRef = scopeRef;
     this.getAui = getAui;
     this.runReporter = new CloudRunReporter(() => this.cloudRef.current);
     this.engagementReporter = new CloudEngagementReporter(
@@ -73,13 +82,22 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     threadListItem: CloudThreadListItem = this.aui.threadListItem,
   ): CloudMessagePersistence {
     const key = getClientId(threadListItem);
-    if (!globalPersistence.has(key)) {
-      globalPersistence.set(
-        key,
-        new CloudMessagePersistence(() => this.cloudRef.current),
-      );
+    const scope = this.scopeRef.current;
+    let entry = globalPersistence.get(key);
+    if (!entry || !Object.is(entry.scope, scope)) {
+      const cloudRef = { current: this.cloudRef };
+      entry = {
+        cloudRef,
+        scope,
+        persistence: new CloudMessagePersistence(
+          () => cloudRef.current.current,
+        ),
+      };
+      globalPersistence.set(key, entry);
+    } else {
+      entry.cloudRef.current = this.cloudRef;
     }
-    return globalPersistence.get(key)!;
+    return entry.persistence;
   }
 
   private get _persistence(): CloudMessagePersistence {
@@ -679,8 +697,9 @@ export function extractAuiV0<T>(content: T): RunMessageTelemetry | null {
   };
 }
 
-export function useAssistantCloudThreadHistoryAdapter(
+export function useScopedAssistantCloudThreadHistoryAdapter(
   cloudRef: RefObject<AssistantCloud>,
+  scopeRef: RefObject<unknown>,
 ): ThreadHistoryAdapter & { readonly feedback: FeedbackAdapter } {
   const aui = useAui();
   // Not useEffectEvent: history adapter methods run during render (SSR load).
@@ -690,10 +709,20 @@ export function useAssistantCloudThreadHistoryAdapter(
   });
   const [adapter] = useState(
     () =>
-      new AssistantCloudThreadHistoryAdapter(cloudRef, () => auiRef.current),
+      new AssistantCloudThreadHistoryAdapter(
+        cloudRef,
+        () => auiRef.current,
+        scopeRef,
+      ),
   );
   useAssistantCloudEngagementEvents(adapter, aui);
   return adapter;
+}
+
+export function useAssistantCloudThreadHistoryAdapter(
+  cloudRef: RefObject<AssistantCloud>,
+): ThreadHistoryAdapter & { readonly feedback: FeedbackAdapter } {
+  return useScopedAssistantCloudThreadHistoryAdapter(cloudRef, cloudRef);
 }
 
 type RootEngagementTracker = {

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -60,6 +60,8 @@ const globalPersistence = new WeakMap<
   ScopedPersistence
 >();
 
+export const DEFAULT_CLOUD_SCOPE = Symbol("assistant-ui:cloud-default-scope");
+
 class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   private cloudRef: RefObject<AssistantCloud>;
   private scopeRef: RefObject<unknown>;
@@ -819,7 +821,7 @@ export function useScopedAssistantCloudThreadHistoryAdapter(
 export function useAssistantCloudThreadHistoryAdapter(
   cloudRef: RefObject<AssistantCloud>,
 ): ThreadHistoryAdapter & { readonly feedback: FeedbackAdapter } {
-  const [scopeRef] = useState<RefObject<unknown>>(() => ({ current: {} }));
+  const scopeRef = useRef<unknown>(DEFAULT_CLOUD_SCOPE);
   return useScopedAssistantCloudThreadHistoryAdapter(cloudRef, scopeRef);
 }
 

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
@@ -219,15 +219,17 @@ describe("CloudFileAttachmentAdapter", () => {
     await expect(adapter.send(ready)).rejects.toThrow(
       "Attachment was uploaded for a different Cloud scope",
     );
+
+    scope = "workspace-a";
+    await expect(adapter.send(ready)).resolves.toEqual(
+      expect.objectContaining({ status: { type: "complete" } }),
+    );
   });
 
-  it("preserves uploaded URLs across same-scope client replacement", async () => {
+  it("preserves uploaded URLs across default-scope client replacement", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
     let cloud = makeCloud();
-    const adapter = createScopedCloudFileAttachmentAdapter(
-      () => cloud,
-      () => "workspace-a",
-    );
+    const adapter = new CloudFileAttachmentAdapter(() => cloud);
     const ready = (await drain(adapter)).at(-1)!;
 
     cloud = makeCloud();
@@ -235,6 +237,26 @@ describe("CloudFileAttachmentAdapter", () => {
     await expect(adapter.send(ready)).resolves.toEqual(
       expect.objectContaining({ status: { type: "complete" } }),
     );
+  });
+
+  it("unsubscribes a removed upload even when its generator is abandoned", async () => {
+    const listeners = new Set<(scope: unknown) => void>();
+    const adapter = createScopedCloudFileAttachmentAdapter(
+      () => makeCloud(),
+      () => "workspace-a",
+      (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    );
+    const generator = adapter.add({ file: makeFile() });
+
+    const running = await generator.next();
+    expect(listeners).toHaveLength(1);
+
+    await adapter.remove(running.value!);
+
+    expect(listeners).toHaveLength(0);
   });
 
   it("does not finish an upload after the Cloud scope changes", async () => {

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AssistantCloud } from "assistant-cloud";
 import type { PendingAttachment } from "../../../types/attachment";
-import { CloudFileAttachmentAdapter } from "./CloudFileAttachmentAdapter";
+import {
+  CloudFileAttachmentAdapter,
+  createScopedCloudFileAttachmentAdapter,
+} from "./CloudFileAttachmentAdapter";
 
 const deferred = <T>() => {
   let resolve!: (value: T) => void;
@@ -197,6 +200,85 @@ describe("CloudFileAttachmentAdapter", () => {
 
     await expect(completion).resolves.toEqual({ done: true, value: undefined });
     expect(errorSpy).not.toHaveBeenCalled();
+    await expect(adapter.send(running.value!)).rejects.toThrow(
+      "Attachment not uploaded",
+    );
+  });
+
+  it("does not send an uploaded URL after the Cloud scope changes", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    let scope = "workspace-a";
+    const adapter = createScopedCloudFileAttachmentAdapter(
+      () => makeCloud(),
+      () => scope,
+    );
+    const ready = (await drain(adapter)).at(-1)!;
+
+    scope = "workspace-b";
+
+    await expect(adapter.send(ready)).rejects.toThrow(
+      "Attachment was uploaded for a different Cloud scope",
+    );
+  });
+
+  it("preserves uploaded URLs across same-scope client replacement", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    let cloud = makeCloud();
+    const adapter = createScopedCloudFileAttachmentAdapter(
+      () => cloud,
+      () => "workspace-a",
+    );
+    const ready = (await drain(adapter)).at(-1)!;
+
+    cloud = makeCloud();
+
+    await expect(adapter.send(ready)).resolves.toEqual(
+      expect.objectContaining({ status: { type: "complete" } }),
+    );
+  });
+
+  it("does not finish an upload after the Cloud scope changes", async () => {
+    const presigned = deferred<{
+      signedUrl: string;
+      publicUrl: string;
+    }>();
+    const cloud = makeCloud();
+    vi.mocked(cloud.files.generatePresignedUploadUrl).mockReturnValue(
+      presigned.promise,
+    );
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    let scope = "workspace-a";
+    const adapter = createScopedCloudFileAttachmentAdapter(
+      () => cloud,
+      () => scope,
+    );
+    const generator = adapter.add({ file: makeFile() });
+
+    const running = await generator.next();
+    const completion = generator.next();
+    await vi.waitFor(() => {
+      expect(cloud.files.generatePresignedUploadUrl).toHaveBeenCalledOnce();
+    });
+
+    scope = "workspace-b";
+    presigned.resolve({
+      signedUrl: "https://storage.example/upload",
+      publicUrl: "https://cdn.example/file.png",
+    });
+
+    await expect(completion).resolves.toEqual({
+      done: false,
+      value: expect.objectContaining({
+        status: {
+          type: "incomplete",
+          reason: "error",
+          message: "Cloud scope changed while uploading the attachment",
+        },
+      }),
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
     await expect(adapter.send(running.value!)).rejects.toThrow(
       "Attachment not uploaded",
     );

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
@@ -283,4 +283,60 @@ describe("CloudFileAttachmentAdapter", () => {
       "Attachment not uploaded",
     );
   });
+
+  it("aborts an in-flight upload when the Cloud scope changes", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const listeners = new Set<(scope: unknown) => void>();
+    const fetchMock = vi.fn((_url: string, init: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init.signal!.addEventListener(
+          "abort",
+          () =>
+            reject(new DOMException("The operation was aborted", "AbortError")),
+          { once: true },
+        );
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    let scope = "workspace-a";
+    const adapter = createScopedCloudFileAttachmentAdapter(
+      () => makeCloud(),
+      () => scope,
+      (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    );
+    const generator = adapter.add({ file: makeFile() });
+
+    await generator.next();
+    const completion = generator.next();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+
+    scope = "workspace-b";
+    for (const listener of listeners) listener(scope);
+
+    expect(vi.mocked(fetchMock).mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+    await expect(completion).resolves.toEqual({
+      done: false,
+      value: expect.objectContaining({
+        status: {
+          type: "incomplete",
+          reason: "error",
+          message: "Cloud scope changed while uploading the attachment",
+        },
+      }),
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[assistant-ui] Failed to upload attachment:",
+      expect.objectContaining({
+        message: "Cloud scope changed while uploading the attachment",
+      }),
+    );
+    await expect(generator.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(listeners).toHaveLength(0);
+  });
 });

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
@@ -16,6 +16,17 @@ const guessAttachmentType = (
   return "file";
 };
 
+const scopeGetters = new WeakMap<CloudFileAttachmentAdapter, () => unknown>();
+
+export const createScopedCloudFileAttachmentAdapter = (
+  getCloud: () => AssistantCloud,
+  getScope: () => unknown,
+) => {
+  const adapter = new CloudFileAttachmentAdapter(getCloud);
+  scopeGetters.set(adapter, getScope);
+  return adapter;
+};
+
 export class CloudFileAttachmentAdapter implements AttachmentAdapter {
   public accept = "*";
 
@@ -27,7 +38,9 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
     this.getCloud = typeof cloud === "function" ? cloud : () => cloud;
   }
 
-  private uploadedUrls = new Map<string, string>();
+  private getScope = () => scopeGetters.get(this)?.() ?? this.getCloud();
+
+  private uploadedUrls = new Map<string, { url: string; scope: unknown }>();
   private activeUploads = new Map<
     string,
     { cancelled: boolean; controller: AbortController }
@@ -50,6 +63,8 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
     };
     const controller = new AbortController();
     const upload = { cancelled: false, controller };
+    const cloud = this.getCloud();
+    const scope = this.getScope();
     this.activeUploads.set(id, upload);
 
     try {
@@ -57,10 +72,13 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
       if (upload.cancelled) return;
 
       const { signedUrl, publicUrl } =
-        await this.getCloud().files.generatePresignedUploadUrl({
+        await cloud.files.generatePresignedUploadUrl({
           filename: file.name,
         });
       if (upload.cancelled) return;
+      if (!Object.is(scope, this.getScope())) {
+        throw new Error("Cloud scope changed while uploading the attachment");
+      }
 
       const res = await fetch(signedUrl, {
         method: "PUT",
@@ -72,13 +90,16 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
         signal: controller.signal,
       });
       if (upload.cancelled) return;
+      if (!Object.is(scope, this.getScope())) {
+        throw new Error("Cloud scope changed while uploading the attachment");
+      }
 
       if (!res.ok) {
         throw new Error(
           `Failed to upload file: ${res.status} ${res.statusText}`,
         );
       }
-      this.uploadedUrls.set(id, publicUrl);
+      this.uploadedUrls.set(id, { url: publicUrl, scope });
       attachment = {
         ...attachment,
         status: { type: "requires-action", reason: "composer-send" },
@@ -117,9 +138,13 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
   public async send(
     attachment: PendingAttachment,
   ): Promise<CompleteAttachment> {
-    const url = this.uploadedUrls.get(attachment.id);
-    if (!url) throw new Error("Attachment not uploaded");
+    const uploaded = this.uploadedUrls.get(attachment.id);
+    if (!uploaded) throw new Error("Attachment not uploaded");
     this.uploadedUrls.delete(attachment.id);
+    if (!Object.is(uploaded.scope, this.getScope())) {
+      throw new Error("Attachment was uploaded for a different Cloud scope");
+    }
+    const { url } = uploaded;
 
     let content: ThreadUserMessagePart[];
     if (attachment.type === "image") {

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
@@ -37,6 +37,7 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
   public accept = "*";
 
   private getCloud: () => AssistantCloud;
+  private readonly defaultScope = {};
 
   constructor(cloud: AssistantCloud);
   constructor(getCloud: () => AssistantCloud);
@@ -45,12 +46,16 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
   }
 
   private getScope = () =>
-    scopeBindings.get(this)?.getScope() ?? this.getCloud();
+    scopeBindings.get(this)?.getScope() ?? this.defaultScope;
 
   private uploadedUrls = new Map<string, { url: string; scope: unknown }>();
   private activeUploads = new Map<
     string,
-    { cancelled: boolean; controller: AbortController }
+    {
+      cancelled: boolean;
+      controller: AbortController;
+      unsubscribe: () => void;
+    }
   >();
 
   public async *add({
@@ -69,20 +74,25 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
       status: { type: "running", reason: "uploading", progress: 0 },
     };
     const controller = new AbortController();
-    const upload = { cancelled: false, controller };
+    const upload = { cancelled: false, controller, unsubscribe: () => {} };
     const cloud = this.getCloud();
     const scope = this.getScope();
     let scopeChanged = false;
-    const unsubscribe = scopeBindings.get(this)?.subscribe?.((nextScope) => {
-      if (Object.is(scope, nextScope)) return;
-      scopeChanged = true;
-      controller.abort();
-    });
+    upload.unsubscribe =
+      scopeBindings.get(this)?.subscribe?.((nextScope) => {
+        if (Object.is(scope, nextScope)) return;
+        scopeChanged = true;
+        upload.unsubscribe();
+        controller.abort();
+      }) ?? upload.unsubscribe;
     this.activeUploads.set(id, upload);
 
     try {
       yield attachment;
       if (upload.cancelled) return;
+      if (scopeChanged) {
+        throw new Error("Cloud scope changed while uploading the attachment");
+      }
 
       const { signedUrl, publicUrl } =
         await cloud.files.generatePresignedUploadUrl({
@@ -135,7 +145,7 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
       };
       yield attachment;
     } finally {
-      unsubscribe?.();
+      upload.unsubscribe();
       if (this.activeUploads.get(id) === upload) {
         this.activeUploads.delete(id);
       }
@@ -146,6 +156,7 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
     const upload = this.activeUploads.get(attachment.id);
     if (upload) {
       upload.cancelled = true;
+      upload.unsubscribe();
       upload.controller.abort();
       this.activeUploads.delete(attachment.id);
     }
@@ -157,10 +168,10 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
   ): Promise<CompleteAttachment> {
     const uploaded = this.uploadedUrls.get(attachment.id);
     if (!uploaded) throw new Error("Attachment not uploaded");
-    this.uploadedUrls.delete(attachment.id);
     if (!Object.is(uploaded.scope, this.getScope())) {
       throw new Error("Attachment was uploaded for a different Cloud scope");
     }
+    this.uploadedUrls.delete(attachment.id);
     const { url } = uploaded;
 
     let content: ThreadUserMessagePart[];

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
@@ -16,14 +16,20 @@ const guessAttachmentType = (
   return "file";
 };
 
-const scopeGetters = new WeakMap<CloudFileAttachmentAdapter, () => unknown>();
+type ScopeBinding = {
+  getScope: () => unknown;
+  subscribe?: ((listener: (scope: unknown) => void) => () => void) | undefined;
+};
+
+const scopeBindings = new WeakMap<CloudFileAttachmentAdapter, ScopeBinding>();
 
 export const createScopedCloudFileAttachmentAdapter = (
   getCloud: () => AssistantCloud,
   getScope: () => unknown,
+  subscribe?: (listener: (scope: unknown) => void) => () => void,
 ) => {
   const adapter = new CloudFileAttachmentAdapter(getCloud);
-  scopeGetters.set(adapter, getScope);
+  scopeBindings.set(adapter, { getScope, subscribe });
   return adapter;
 };
 
@@ -38,7 +44,8 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
     this.getCloud = typeof cloud === "function" ? cloud : () => cloud;
   }
 
-  private getScope = () => scopeGetters.get(this)?.() ?? this.getCloud();
+  private getScope = () =>
+    scopeBindings.get(this)?.getScope() ?? this.getCloud();
 
   private uploadedUrls = new Map<string, { url: string; scope: unknown }>();
   private activeUploads = new Map<
@@ -65,6 +72,12 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
     const upload = { cancelled: false, controller };
     const cloud = this.getCloud();
     const scope = this.getScope();
+    let scopeChanged = false;
+    const unsubscribe = scopeBindings.get(this)?.subscribe?.((nextScope) => {
+      if (Object.is(scope, nextScope)) return;
+      scopeChanged = true;
+      controller.abort();
+    });
     this.activeUploads.set(id, upload);
 
     try {
@@ -108,17 +121,21 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
     } catch (error) {
       if (upload.cancelled) return;
 
-      console.error("[assistant-ui] Failed to upload attachment:", error);
+      const failure = scopeChanged
+        ? new Error("Cloud scope changed while uploading the attachment")
+        : error;
+      console.error("[assistant-ui] Failed to upload attachment:", failure);
       attachment = {
         ...attachment,
         status: {
           type: "incomplete",
           reason: "error",
-          message: error instanceof Error ? error.message : String(error),
+          message: failure instanceof Error ? failure.message : String(failure),
         },
       };
       yield attachment;
     } finally {
+      unsubscribe?.();
       if (this.activeUploads.get(id) === upload) {
         this.activeUploads.delete(id);
       }

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
@@ -4,10 +4,7 @@ import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import type { AssistantCloud } from "assistant-cloud";
 import type { PendingAttachment } from "../../../types/attachment";
-import {
-  createCloudThreadListAdapter,
-  getCloudThreadOwnership,
-} from "./createCloudThreadListAdapter";
+import { createCloudThreadListAdapter } from "./createCloudThreadListAdapter";
 import { CORE_SDK } from "./sdkIdentity";
 
 vi.mock("@assistant-ui/store", async (importOriginal) => ({
@@ -43,19 +40,6 @@ const makeCloud = () =>
     },
     registerSdk: vi.fn(),
   }) as unknown as AssistantCloud;
-
-const makeThread = (id: string) => ({
-  id,
-  title: id,
-  is_archived: false,
-  external_id: null,
-  metadata: null,
-  last_message_at: new Date(0),
-  created_at: new Date(0),
-  updated_at: new Date(0),
-  project_id: "project-1",
-  workspace_id: "workspace-1",
-});
 
 describe("createCloudThreadListAdapter", () => {
   it("falls back to an in-memory list without a cloud instance", async () => {
@@ -106,56 +90,6 @@ describe("createCloudThreadListAdapter", () => {
 
     expect(adapter.unstable_useAdapters).toBeTypeOf("function");
     expect(adapter.unstable_Provider).toBeUndefined();
-  });
-
-  it("records remote ids listed by a scoped adapter", async () => {
-    const cloud = makeCloud();
-    vi.mocked(cloud.threads.list)
-      .mockResolvedValueOnce({ threads: [makeThread("remote-1")] })
-      .mockResolvedValueOnce({ threads: [] });
-    const adapter = createCloudThreadListAdapter({
-      cloud,
-      scopeId: "workspace-a",
-    });
-    const ownership = getCloudThreadOwnership(adapter)!;
-
-    expect(ownership.has("remote-1")).toBe(false);
-    await adapter.list();
-    expect(ownership.has("remote-1")).toBe(true);
-  });
-
-  it("does not transfer explicit ownership into the default scope", async () => {
-    const cloud = makeCloud();
-    vi.mocked(cloud.threads.list)
-      .mockResolvedValueOnce({ threads: [makeThread("explicit-only")] })
-      .mockResolvedValueOnce({ threads: [] });
-    const scoped = createCloudThreadListAdapter({
-      cloud,
-      scopeId: "workspace-a",
-    });
-    await scoped.list();
-
-    const unscoped = createCloudThreadListAdapter({ cloud });
-
-    expect(getCloudThreadOwnership(scoped)!.has("explicit-only")).toBe(true);
-    expect(getCloudThreadOwnership(unscoped)!.has("explicit-only")).toBe(false);
-  });
-
-  it("releases ownership after deleting a thread", async () => {
-    const cloud = makeCloud();
-    vi.mocked(cloud.threads.create).mockResolvedValueOnce({
-      thread_id: "remote-1",
-    });
-    const adapter = createCloudThreadListAdapter({
-      cloud,
-      scopeId: "workspace-a",
-    });
-    const ownership = getCloudThreadOwnership(adapter)!;
-    await adapter.initialize();
-
-    expect(ownership.has("remote-1")).toBe(true);
-    await adapter.delete!("remote-1");
-    expect(ownership.has("remote-1")).toBe(false);
   });
 
   it("registers core and the calling integration identities", () => {

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
@@ -158,6 +158,47 @@ describe("createCloudThreadListAdapter", () => {
     expect(ownership.has("remote-1")).toBe(false);
   });
 
+  it("does not restore deleted ownership from an older list response", async () => {
+    const cloud = makeCloud();
+    const active = Promise.withResolvers<{
+      threads: ReturnType<typeof makeThread>[];
+    }>();
+    vi.mocked(cloud.threads.list)
+      .mockImplementationOnce(() => active.promise)
+      .mockResolvedValueOnce({ threads: [] });
+    const adapter = createCloudThreadListAdapter({
+      cloud,
+      scopeId: "workspace-a",
+    });
+    const ownership = getCloudThreadOwnership(adapter)!;
+    const listing = adapter.list();
+    await vi.waitFor(() => expect(cloud.threads.list).toHaveBeenCalledTimes(2));
+
+    await adapter.delete!("remote-1");
+    active.resolve({ threads: [makeThread("remote-1")] });
+    await listing;
+
+    expect(ownership.has("remote-1")).toBe(false);
+  });
+
+  it("does not restore deleted ownership from an older fetch response", async () => {
+    const cloud = makeCloud();
+    const fetched = Promise.withResolvers<ReturnType<typeof makeThread>>();
+    vi.mocked(cloud.threads.get).mockImplementationOnce(() => fetched.promise);
+    const adapter = createCloudThreadListAdapter({
+      cloud,
+      scopeId: "workspace-a",
+    });
+    const ownership = getCloudThreadOwnership(adapter)!;
+    const fetching = adapter.fetch!("remote-1");
+
+    await adapter.delete!("remote-1");
+    fetched.resolve(makeThread("remote-1"));
+    await fetching;
+
+    expect(ownership.has("remote-1")).toBe(false);
+  });
+
   it("registers core and the calling integration identities", () => {
     const cloud = makeCloud();
     const sdk = { name: "@assistant-ui/ai-sdk", version: "0.0.5" };

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
@@ -158,7 +158,7 @@ describe("createCloudThreadListAdapter", () => {
     expect(ownership.has("remote-1")).toBe(false);
   });
 
-  it("does not restore deleted ownership from an older list response", async () => {
+  it("does not reauthorize a deleted thread from an older list response", async () => {
     const cloud = makeCloud();
     const active = Promise.withResolvers<{
       threads: ReturnType<typeof makeThread>[];
@@ -179,9 +179,15 @@ describe("createCloudThreadListAdapter", () => {
     await listing;
 
     expect(ownership.has("remote-1")).toBe(false);
+
+    vi.mocked(cloud.threads.list)
+      .mockResolvedValueOnce({ threads: [makeThread("remote-1")] })
+      .mockResolvedValueOnce({ threads: [] });
+    await adapter.list();
+    expect(ownership.has("remote-1")).toBe(true);
   });
 
-  it("does not restore deleted ownership from an older fetch response", async () => {
+  it("does not reauthorize a deleted thread from an older fetch response", async () => {
     const cloud = makeCloud();
     const fetched = Promise.withResolvers<ReturnType<typeof makeThread>>();
     vi.mocked(cloud.threads.get).mockImplementationOnce(() => fetched.promise);

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
@@ -124,6 +124,23 @@ describe("createCloudThreadListAdapter", () => {
     expect(ownership.has("remote-1")).toBe(true);
   });
 
+  it("does not transfer explicit ownership into the default scope", async () => {
+    const cloud = makeCloud();
+    vi.mocked(cloud.threads.list)
+      .mockResolvedValueOnce({ threads: [makeThread("explicit-only")] })
+      .mockResolvedValueOnce({ threads: [] });
+    const scoped = createCloudThreadListAdapter({
+      cloud,
+      scopeId: "workspace-a",
+    });
+    await scoped.list();
+
+    const unscoped = createCloudThreadListAdapter({ cloud });
+
+    expect(getCloudThreadOwnership(scoped)!.has("explicit-only")).toBe(true);
+    expect(getCloudThreadOwnership(unscoped)!.has("explicit-only")).toBe(false);
+  });
+
   it("registers core and the calling integration identities", () => {
     const cloud = makeCloud();
     const sdk = { name: "@assistant-ui/ai-sdk", version: "0.0.5" };

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
@@ -4,7 +4,10 @@ import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import type { AssistantCloud } from "assistant-cloud";
 import type { PendingAttachment } from "../../../types/attachment";
-import { createCloudThreadListAdapter } from "./createCloudThreadListAdapter";
+import {
+  createCloudThreadListAdapter,
+  getCloudThreadOwnership,
+} from "./createCloudThreadListAdapter";
 import { CORE_SDK } from "./sdkIdentity";
 
 vi.mock("@assistant-ui/store", async (importOriginal) => ({
@@ -40,6 +43,19 @@ const makeCloud = () =>
     },
     registerSdk: vi.fn(),
   }) as unknown as AssistantCloud;
+
+const makeThread = (id: string) => ({
+  id,
+  title: id,
+  is_archived: false,
+  external_id: null,
+  metadata: null,
+  last_message_at: new Date(0),
+  created_at: new Date(0),
+  updated_at: new Date(0),
+  project_id: "project-1",
+  workspace_id: "workspace-1",
+});
 
 describe("createCloudThreadListAdapter", () => {
   it("falls back to an in-memory list without a cloud instance", async () => {
@@ -90,6 +106,22 @@ describe("createCloudThreadListAdapter", () => {
 
     expect(adapter.unstable_useAdapters).toBeTypeOf("function");
     expect(adapter.unstable_Provider).toBeUndefined();
+  });
+
+  it("records remote ids listed by a scoped adapter", async () => {
+    const cloud = makeCloud();
+    vi.mocked(cloud.threads.list)
+      .mockResolvedValueOnce({ threads: [makeThread("remote-1")] })
+      .mockResolvedValueOnce({ threads: [] });
+    const adapter = createCloudThreadListAdapter({
+      cloud,
+      scopeId: "workspace-a",
+    });
+    const ownership = getCloudThreadOwnership(adapter)!;
+
+    expect(ownership.has("remote-1")).toBe(false);
+    await adapter.list();
+    expect(ownership.has("remote-1")).toBe(true);
   });
 
   it("registers core and the calling integration identities", () => {

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
@@ -141,6 +141,23 @@ describe("createCloudThreadListAdapter", () => {
     expect(getCloudThreadOwnership(unscoped)!.has("explicit-only")).toBe(false);
   });
 
+  it("releases ownership after deleting a thread", async () => {
+    const cloud = makeCloud();
+    vi.mocked(cloud.threads.create).mockResolvedValueOnce({
+      thread_id: "remote-1",
+    });
+    const adapter = createCloudThreadListAdapter({
+      cloud,
+      scopeId: "workspace-a",
+    });
+    const ownership = getCloudThreadOwnership(adapter)!;
+    await adapter.initialize();
+
+    expect(ownership.has("remote-1")).toBe(true);
+    await adapter.delete!("remote-1");
+    expect(ownership.has("remote-1")).toBe(false);
+  });
+
   it("registers core and the calling integration identities", () => {
     const cloud = makeCloud();
     const sdk = { name: "@assistant-ui/ai-sdk", version: "0.0.5" };

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
@@ -158,53 +158,6 @@ describe("createCloudThreadListAdapter", () => {
     expect(ownership.has("remote-1")).toBe(false);
   });
 
-  it("does not reauthorize a deleted thread from an older list response", async () => {
-    const cloud = makeCloud();
-    const active = Promise.withResolvers<{
-      threads: ReturnType<typeof makeThread>[];
-    }>();
-    vi.mocked(cloud.threads.list)
-      .mockImplementationOnce(() => active.promise)
-      .mockResolvedValueOnce({ threads: [] });
-    const adapter = createCloudThreadListAdapter({
-      cloud,
-      scopeId: "workspace-a",
-    });
-    const ownership = getCloudThreadOwnership(adapter)!;
-    const listing = adapter.list();
-    await vi.waitFor(() => expect(cloud.threads.list).toHaveBeenCalledTimes(2));
-
-    await adapter.delete!("remote-1");
-    active.resolve({ threads: [makeThread("remote-1")] });
-    await listing;
-
-    expect(ownership.has("remote-1")).toBe(false);
-
-    vi.mocked(cloud.threads.list)
-      .mockResolvedValueOnce({ threads: [makeThread("remote-1")] })
-      .mockResolvedValueOnce({ threads: [] });
-    await adapter.list();
-    expect(ownership.has("remote-1")).toBe(true);
-  });
-
-  it("does not reauthorize a deleted thread from an older fetch response", async () => {
-    const cloud = makeCloud();
-    const fetched = Promise.withResolvers<ReturnType<typeof makeThread>>();
-    vi.mocked(cloud.threads.get).mockImplementationOnce(() => fetched.promise);
-    const adapter = createCloudThreadListAdapter({
-      cloud,
-      scopeId: "workspace-a",
-    });
-    const ownership = getCloudThreadOwnership(adapter)!;
-    const fetching = adapter.fetch!("remote-1");
-
-    await adapter.delete!("remote-1");
-    fetched.resolve(makeThread("remote-1"));
-    await fetching;
-
-    expect(ownership.has("remote-1")).toBe(false);
-  });
-
   it("registers core and the calling integration identities", () => {
     const cloud = makeCloud();
     const sdk = { name: "@assistant-ui/ai-sdk", version: "0.0.5" };

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import type { AssistantCloud } from "assistant-cloud";
+import type { PendingAttachment } from "../../../types/attachment";
 import { createCloudThreadListAdapter } from "./createCloudThreadListAdapter";
 import { CORE_SDK } from "./sdkIdentity";
 
@@ -31,6 +32,12 @@ const makeCloud = () =>
       get: vi.fn(),
     },
     runs: { stream: vi.fn(async () => new ReadableStream()) },
+    files: {
+      generatePresignedUploadUrl: vi.fn(async () => ({
+        signedUrl: "https://storage.example/upload",
+        publicUrl: "https://cdn.example/file.png",
+      })),
+    },
     registerSdk: vi.fn(),
   }) as unknown as AssistantCloud;
 
@@ -120,5 +127,35 @@ describe("createCloudThreadListAdapter", () => {
     rerender();
     expect(result.current!.history).toBe(first.history);
     expect(result.current!.attachments).toBe(first.attachments);
+  });
+
+  it("captures Cloud and scope with the standalone adapter", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    onTestFinished(() => vi.unstubAllGlobals());
+    const firstCloud = makeCloud();
+    const secondCloud = makeCloud();
+    const options = { cloud: firstCloud, scopeId: "workspace-a" };
+    const adapter = createCloudThreadListAdapter(() => options);
+    const { result, rerender } = renderHook(() =>
+      adapter.unstable_useAdapters!(),
+    );
+    const attachments = result.current!.attachments!;
+    const file = new File([new Uint8Array([1, 2, 3])], "pixel.png", {
+      type: "image/png",
+    });
+    let ready: PendingAttachment | undefined;
+    for await (const attachment of attachments.add({ file })) {
+      ready = attachment;
+    }
+
+    options.cloud = secondCloud;
+    options.scopeId = "workspace-b";
+    rerender();
+
+    await expect(attachments.send(ready!)).resolves.toMatchObject({
+      status: { type: "complete" },
+    });
+    expect(firstCloud.files.generatePresignedUploadUrl).toHaveBeenCalledOnce();
+    expect(secondCloud.files.generatePresignedUploadUrl).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -1,6 +1,6 @@
 declare const process: { env: Record<string, string | undefined> };
 
-import { type RefObject, useMemo, useState } from "react";
+import { type RefObject, useInsertionEffect, useMemo, useState } from "react";
 import { AssistantCloud, type SdkIdentity } from "assistant-cloud";
 import type {
   RemoteThreadListAdapter,
@@ -40,18 +40,48 @@ export const autoCloud = baseUrl
   ? new AssistantCloud({ baseUrl, anonymous: true })
   : undefined;
 
+type CommittedScopeRef = RefObject<unknown> & {
+  update(scope: unknown): void;
+  subscribe(listener: (scope: unknown) => void): () => void;
+};
+
+const createCommittedScopeRef = (initialScope: unknown): CommittedScopeRef => {
+  let current = initialScope;
+  const listeners = new Set<(scope: unknown) => void>();
+  return {
+    get current() {
+      return current;
+    },
+    update(scope) {
+      if (Object.is(current, scope)) return;
+      current = scope;
+      for (const listener of listeners) listener(scope);
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+};
+
 export const useCloudRuntimeAdapters = (
   cloudRef: RefObject<AssistantCloud>,
   scopeRef: RefObject<unknown> = cloudRef,
 ): RuntimeAdapters => {
+  const scope = scopeRef.current;
+  const [committedScopeRef] = useState(() => createCommittedScopeRef(scope));
+  useInsertionEffect(() => {
+    committedScopeRef.update(scope);
+  }, [committedScopeRef, scope]);
   const history = useScopedAssistantCloudThreadHistoryAdapter(
     cloudRef,
-    scopeRef,
+    committedScopeRef,
   );
   const [attachments] = useState(() =>
     createScopedCloudFileAttachmentAdapter(
       () => cloudRef.current,
-      () => scopeRef.current,
+      () => committedScopeRef.current,
+      (listener) => committedScopeRef.subscribe(listener),
     ),
   );
   return useMemo(

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -7,8 +7,8 @@ import type {
   RuntimeAdapters,
 } from "../../../runtimes/remote-thread-list/types";
 import { InMemoryThreadListAdapter } from "../../../runtimes/remote-thread-list/adapter/in-memory";
-import { useAssistantCloudThreadHistoryAdapter } from "./AssistantCloudThreadHistoryAdapter";
-import { CloudFileAttachmentAdapter } from "./CloudFileAttachmentAdapter";
+import { useScopedAssistantCloudThreadHistoryAdapter } from "./AssistantCloudThreadHistoryAdapter";
+import { createScopedCloudFileAttachmentAdapter } from "./CloudFileAttachmentAdapter";
 import { isRecord } from "../../../utils/json/is-json";
 import { CORE_SDK } from "./sdkIdentity";
 
@@ -18,6 +18,12 @@ type ThreadData = {
 
 export type CloudThreadListAdapterOptions = {
   cloud?: AssistantCloud | undefined;
+  /**
+   * Stable identity for the account or workspace owning Cloud runtime state.
+   * Change it when that scope changes. When omitted, the Cloud client instance
+   * is used as the scope identity.
+   */
+  scopeId?: string | undefined;
   sdk?: SdkIdentity | undefined;
 
   create?: (() => Promise<ThreadData>) | undefined;
@@ -36,10 +42,17 @@ export const autoCloud = baseUrl
 
 export const useCloudRuntimeAdapters = (
   cloudRef: RefObject<AssistantCloud>,
+  scopeRef: RefObject<unknown> = cloudRef,
 ): RuntimeAdapters => {
-  const history = useAssistantCloudThreadHistoryAdapter(cloudRef);
-  const [attachments] = useState(
-    () => new CloudFileAttachmentAdapter(() => cloudRef.current),
+  const history = useScopedAssistantCloudThreadHistoryAdapter(
+    cloudRef,
+    scopeRef,
+  );
+  const [attachments] = useState(() =>
+    createScopedCloudFileAttachmentAdapter(
+      () => cloudRef.current,
+      () => scopeRef.current,
+    ),
   );
   return useMemo(
     () => ({
@@ -101,11 +114,18 @@ export const createCloudThreadListAdapter = (
   const getOptions = typeof options === "function" ? options : () => options;
 
   const unstable_useAdapters = function useCloudAdapters(): RuntimeAdapters {
-    return useCloudRuntimeAdapters({
+    const cloudRef = {
       get current() {
         return getOptions().cloud ?? autoCloud!;
       },
-    });
+    };
+    const scopeRef = {
+      get current() {
+        const current = getOptions();
+        return current.scopeId ?? current.cloud ?? autoCloud!;
+      },
+    };
+    return useCloudRuntimeAdapters(cloudRef, scopeRef);
   };
 
   const cloud = getOptions().cloud ?? autoCloud;

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -19,25 +19,6 @@ type ThreadData = {
   externalId: string | undefined;
 };
 
-type CloudThreadOwnership = Pick<ReadonlySet<string>, "has">;
-type MutableCloudThreadOwnership = Set<string>;
-
-const cloudThreadOwnership = new WeakMap<
-  RemoteThreadListAdapter,
-  MutableCloudThreadOwnership
->();
-
-export const getCloudThreadOwnership = (
-  adapter: RemoteThreadListAdapter,
-): CloudThreadOwnership | undefined => cloudThreadOwnership.get(adapter);
-
-export const setCloudThreadOwnership = (
-  adapter: RemoteThreadListAdapter,
-  ownership: MutableCloudThreadOwnership,
-): void => {
-  cloudThreadOwnership.set(adapter, ownership);
-};
-
 export type CloudThreadListAdapterOptions = {
   cloud?: AssistantCloud | undefined;
   /**
@@ -93,37 +74,15 @@ const createCommittedScopeRef = (initialScope: unknown): CommittedScopeRef => {
 export const useCloudRuntimeAdapters = (
   cloudRef: RefObject<AssistantCloud>,
   scopeRef?: RefObject<unknown>,
-  ownership?: CloudThreadOwnership,
 ): RuntimeAdapters => {
   const scope = scopeRef?.current ?? DEFAULT_CLOUD_SCOPE;
   const [committedScopeRef] = useState(() => createCommittedScopeRef(scope));
-  const [ownershipState] = useState(() => ({
-    required: scope !== DEFAULT_CLOUD_SCOPE,
-  }));
-  const [committedOwnershipRef] = useState<{
-    current: CloudThreadOwnership | undefined;
-  }>(() => ({
-    current: ownershipState.required ? ownership : undefined,
-  }));
   useInsertionEffect(() => {
-    if (!Object.is(committedScopeRef.current, scope)) {
-      ownershipState.required = true;
-    }
-    committedOwnershipRef.current = ownershipState.required
-      ? ownership
-      : undefined;
     committedScopeRef.update(scope);
-  }, [
-    committedOwnershipRef,
-    committedScopeRef,
-    ownership,
-    ownershipState,
-    scope,
-  ]);
+  }, [committedScopeRef, scope]);
   const history = useScopedAssistantCloudThreadHistoryAdapter(
     cloudRef,
     committedScopeRef,
-    committedOwnershipRef,
   );
   const [attachments] = useState(() =>
     createScopedCloudFileAttachmentAdapter(
@@ -204,22 +163,17 @@ export const createCloudThreadListAdapter = (
     return inMemory;
   }
 
-  const ownedRemoteIds = new Set<string>();
-  let adapter: RemoteThreadListAdapter;
-
-  const getOwnership = () => cloudThreadOwnership.get(adapter)!;
-
   const unstable_useAdapters = function useCloudAdapters(): RuntimeAdapters {
     const cloudRef = { current: cloud };
     const scopeRef = { current: scopeId };
-    return useCloudRuntimeAdapters(cloudRef, scopeRef, getOwnership());
+    return useCloudRuntimeAdapters(cloudRef, scopeRef);
   };
 
   cloud.registerSdk?.(CORE_SDK);
   const sdk = getOptions().sdk;
   if (sdk) cloud.registerSdk?.(sdk);
 
-  adapter = {
+  return {
     list: async ({ after } = {}) => {
       const {
         activeCursor,
@@ -252,8 +206,6 @@ export const createCloudThreadListAdapter = (
           ? archivedThreads.at(-1)?.id
           : undefined;
       const threads = [...activeThreads, ...archivedThreads];
-      const ownership = getOwnership();
-      for (const thread of threads) ownership.add(thread.id);
       return {
         threads: threads.map((t) => ({
           status: t.is_archived ? ("archived" as const) : ("regular" as const),
@@ -285,8 +237,6 @@ export const createCloudThreadListAdapter = (
         last_message_at: new Date(),
         external_id,
       });
-      const ownership = getOwnership();
-      ownership.add(remoteId);
 
       return { externalId: external_id, remoteId: remoteId };
     },
@@ -305,10 +255,7 @@ export const createCloudThreadListAdapter = (
     },
     delete: async (threadId) => {
       await getOptions().delete?.(threadId);
-      const result = await cloud.threads.delete(threadId);
-      const ownership = getOwnership();
-      ownership.delete(threadId);
-      return result;
+      return cloud.threads.delete(threadId);
     },
 
     generateTitle: async (threadId, messages) => {
@@ -328,8 +275,6 @@ export const createCloudThreadListAdapter = (
 
     fetch: async (threadId: string) => {
       const thread = await cloud.threads.get(threadId);
-      const ownership = getOwnership();
-      ownership.add(thread.id);
       return {
         status: thread.is_archived
           ? ("archived" as const)
@@ -346,6 +291,4 @@ export const createCloudThreadListAdapter = (
 
     unstable_useAdapters,
   };
-  cloudThreadOwnership.set(adapter, ownedRemoteIds);
-  return adapter;
 };

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -20,8 +20,8 @@ export type CloudThreadListAdapterOptions = {
   cloud?: AssistantCloud | undefined;
   /**
    * Stable identity for the account or workspace owning Cloud runtime state.
-   * Change it when that scope changes. When omitted, the Cloud client instance
-   * is used as the scope identity.
+   * Change it when that scope changes. When omitted, replacing the Cloud client
+   * preserves cached runtime state for backward compatibility.
    */
   scopeId?: string | undefined;
   sdk?: SdkIdentity | undefined;
@@ -66,9 +66,10 @@ const createCommittedScopeRef = (initialScope: unknown): CommittedScopeRef => {
 
 export const useCloudRuntimeAdapters = (
   cloudRef: RefObject<AssistantCloud>,
-  scopeRef: RefObject<unknown> = cloudRef,
+  scopeRef?: RefObject<unknown>,
 ): RuntimeAdapters => {
-  const scope = scopeRef.current;
+  const [defaultScope] = useState(() => ({}));
+  const scope = scopeRef?.current ?? defaultScope;
   const [committedScopeRef] = useState(() => createCommittedScopeRef(scope));
   useInsertionEffect(() => {
     committedScopeRef.update(scope);
@@ -151,8 +152,7 @@ export const createCloudThreadListAdapter = (
     };
     const scopeRef = {
       get current() {
-        const current = getOptions();
-        return current.scopeId ?? current.cloud ?? autoCloud!;
+        return getOptions().scopeId;
       },
     };
     return useCloudRuntimeAdapters(cloudRef, scopeRef);

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -7,7 +7,10 @@ import type {
   RuntimeAdapters,
 } from "../../../runtimes/remote-thread-list/types";
 import { InMemoryThreadListAdapter } from "../../../runtimes/remote-thread-list/adapter/in-memory";
-import { useScopedAssistantCloudThreadHistoryAdapter } from "./AssistantCloudThreadHistoryAdapter";
+import {
+  DEFAULT_CLOUD_SCOPE,
+  useScopedAssistantCloudThreadHistoryAdapter,
+} from "./AssistantCloudThreadHistoryAdapter";
 import { createScopedCloudFileAttachmentAdapter } from "./CloudFileAttachmentAdapter";
 import { isRecord } from "../../../utils/json/is-json";
 import { CORE_SDK } from "./sdkIdentity";
@@ -68,8 +71,7 @@ export const useCloudRuntimeAdapters = (
   cloudRef: RefObject<AssistantCloud>,
   scopeRef?: RefObject<unknown>,
 ): RuntimeAdapters => {
-  const [defaultScope] = useState(() => ({}));
-  const scope = scopeRef?.current ?? defaultScope;
+  const scope = scopeRef?.current ?? DEFAULT_CLOUD_SCOPE;
   const [committedScopeRef] = useState(() => createCommittedScopeRef(scope));
   useInsertionEffect(() => {
     committedScopeRef.update(scope);

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -26,35 +26,6 @@ const cloudThreadOwnership = new WeakMap<
   RemoteThreadListAdapter,
   MutableCloudThreadOwnership
 >();
-const pendingCloudThreadReads = new WeakMap<
-  MutableCloudThreadOwnership,
-  Set<Set<string>>
->();
-
-const beginCloudThreadRead = (
-  ownership: MutableCloudThreadOwnership,
-): { blockedIds: Set<string>; finish(): void } => {
-  let pending = pendingCloudThreadReads.get(ownership);
-  if (!pending) {
-    pending = new Set();
-    pendingCloudThreadReads.set(ownership, pending);
-  }
-  const blockedIds = new Set<string>();
-  pending.add(blockedIds);
-  return {
-    blockedIds,
-    finish: () => pending.delete(blockedIds),
-  };
-};
-
-const blockPendingCloudThreadReads = (
-  ownership: MutableCloudThreadOwnership,
-  threadId: string,
-): void => {
-  for (const blockedIds of pendingCloudThreadReads.get(ownership) ?? []) {
-    blockedIds.add(threadId);
-  }
-};
 
 export const getCloudThreadOwnership = (
   adapter: RemoteThreadListAdapter,
@@ -71,8 +42,9 @@ export type CloudThreadListAdapterOptions = {
   cloud?: AssistantCloud | undefined;
   /**
    * Stable identity for the account or workspace owning Cloud runtime state.
-   * Change it when that scope changes. `useCloudThreadListRuntime` reloads the
-   * list after the hook returns a replacement adapter; lower-level
+   * Provide it from the runtime's first render and change it when that scope
+   * changes. `useCloudThreadListRuntime` reloads the list after the hook
+   * returns a replacement adapter; lower-level
    * `RemoteThreadList` compositions must call their thread-list `reload()`
    * method after publishing that replacement. When omitted, replacing the
    * Cloud client preserves cached runtime state for backward compatibility.
@@ -249,70 +221,60 @@ export const createCloudThreadListAdapter = (
 
   adapter = {
     list: async ({ after } = {}) => {
-      const ownership = getOwnership();
-      const read = beginCloudThreadRead(ownership);
       const {
         activeCursor,
         archivedCursor,
         activeExhausted,
         archivedExhausted,
       } = parseListCursor(after);
-      try {
-        const [{ threads: activeThreads }, { threads: archivedThreads }] =
-          await Promise.all([
-            activeExhausted
-              ? Promise.resolve({ threads: [] })
-              : cloud.threads.list({
-                  limit: CLOUD_THREAD_PAGE_SIZE,
-                  ...(activeCursor ? { after: activeCursor } : {}),
-                }),
-            archivedExhausted
-              ? Promise.resolve({ threads: [] })
-              : cloud.threads.list({
-                  is_archived: true,
-                  limit: CLOUD_THREAD_PAGE_SIZE,
-                  ...(archivedCursor ? { after: archivedCursor } : {}),
-                }),
-          ]);
-        const activeNext =
-          !activeExhausted && activeThreads.length === CLOUD_THREAD_PAGE_SIZE
-            ? activeThreads.at(-1)?.id
-            : undefined;
-        const archivedNext =
-          !archivedExhausted &&
-          archivedThreads.length === CLOUD_THREAD_PAGE_SIZE
-            ? archivedThreads.at(-1)?.id
-            : undefined;
-        const threads = [...activeThreads, ...archivedThreads];
-        for (const thread of threads) {
-          if (!read.blockedIds.has(thread.id)) ownership.add(thread.id);
-        }
-        return {
-          threads: threads.map((t) => ({
-            status: t.is_archived
-              ? ("archived" as const)
-              : ("regular" as const),
-            remoteId: t.id,
-            title: t.title,
-            lastMessageAt: t.last_message_at
-              ? new Date(t.last_message_at)
-              : undefined,
-            externalId: t.external_id ?? undefined,
-            custom: toCustom(t.metadata),
-          })),
-          nextCursor:
-            activeNext || archivedNext
-              ? JSON.stringify({
-                  a: activeNext,
-                  r: archivedNext,
-                  ...(activeNext === undefined ? { ae: true } : {}),
-                  ...(archivedNext === undefined ? { re: true } : {}),
-                })
-              : undefined,
-        };
-      } finally {
-        read.finish();
-      }
+      const [{ threads: activeThreads }, { threads: archivedThreads }] =
+        await Promise.all([
+          activeExhausted
+            ? Promise.resolve({ threads: [] })
+            : cloud.threads.list({
+                limit: CLOUD_THREAD_PAGE_SIZE,
+                ...(activeCursor ? { after: activeCursor } : {}),
+              }),
+          archivedExhausted
+            ? Promise.resolve({ threads: [] })
+            : cloud.threads.list({
+                is_archived: true,
+                limit: CLOUD_THREAD_PAGE_SIZE,
+                ...(archivedCursor ? { after: archivedCursor } : {}),
+              }),
+        ]);
+      const activeNext =
+        !activeExhausted && activeThreads.length === CLOUD_THREAD_PAGE_SIZE
+          ? activeThreads.at(-1)?.id
+          : undefined;
+      const archivedNext =
+        !archivedExhausted && archivedThreads.length === CLOUD_THREAD_PAGE_SIZE
+          ? archivedThreads.at(-1)?.id
+          : undefined;
+      const threads = [...activeThreads, ...archivedThreads];
+      const ownership = getOwnership();
+      for (const thread of threads) ownership.add(thread.id);
+      return {
+        threads: threads.map((t) => ({
+          status: t.is_archived ? ("archived" as const) : ("regular" as const),
+          remoteId: t.id,
+          title: t.title,
+          lastMessageAt: t.last_message_at
+            ? new Date(t.last_message_at)
+            : undefined,
+          externalId: t.external_id ?? undefined,
+          custom: toCustom(t.metadata),
+        })),
+        nextCursor:
+          activeNext || archivedNext
+            ? JSON.stringify({
+                a: activeNext,
+                r: archivedNext,
+                ...(activeNext === undefined ? { ae: true } : {}),
+                ...(archivedNext === undefined ? { re: true } : {}),
+              })
+            : undefined,
+      };
     },
 
     initialize: async () => {
@@ -346,7 +308,6 @@ export const createCloudThreadListAdapter = (
       const result = await cloud.threads.delete(threadId);
       const ownership = getOwnership();
       ownership.delete(threadId);
-      blockPendingCloudThreadReads(ownership, threadId);
       return result;
     },
 
@@ -366,26 +327,21 @@ export const createCloudThreadListAdapter = (
     },
 
     fetch: async (threadId: string) => {
+      const thread = await cloud.threads.get(threadId);
       const ownership = getOwnership();
-      const read = beginCloudThreadRead(ownership);
-      try {
-        const thread = await cloud.threads.get(threadId);
-        if (!read.blockedIds.has(thread.id)) ownership.add(thread.id);
-        return {
-          status: thread.is_archived
-            ? ("archived" as const)
-            : ("regular" as const),
-          remoteId: thread.id,
-          title: thread.title,
-          lastMessageAt: thread.last_message_at
-            ? new Date(thread.last_message_at)
-            : undefined,
-          externalId: thread.external_id ?? undefined,
-          custom: toCustom(thread.metadata),
-        };
-      } finally {
-        read.finish();
-      }
+      ownership.add(thread.id);
+      return {
+        status: thread.is_archived
+          ? ("archived" as const)
+          : ("regular" as const),
+        remoteId: thread.id,
+        title: thread.title,
+        lastMessageAt: thread.last_message_at
+          ? new Date(thread.last_message_at)
+          : undefined,
+        externalId: thread.external_id ?? undefined,
+        custom: toCustom(thread.metadata),
+      };
     },
 
     unstable_useAdapters,

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -25,6 +25,7 @@ const cloudThreadOwnership = new WeakMap<
   RemoteThreadListAdapter,
   Set<string>
 >();
+const defaultCloudThreadOwnership = new Set<string>();
 
 export const getCloudThreadOwnership = (
   adapter: RemoteThreadListAdapter,
@@ -179,7 +180,8 @@ export const createCloudThreadListAdapter = (
     return inMemory;
   }
 
-  const ownedRemoteIds = scopeId === undefined ? undefined : new Set<string>();
+  const ownedRemoteIds =
+    scopeId === undefined ? defaultCloudThreadOwnership : new Set<string>();
 
   const unstable_useAdapters = function useCloudAdapters(): RuntimeAdapters {
     const cloudRef = { current: cloud };
@@ -224,7 +226,7 @@ export const createCloudThreadListAdapter = (
           ? archivedThreads.at(-1)?.id
           : undefined;
       const threads = [...activeThreads, ...archivedThreads];
-      for (const thread of threads) ownedRemoteIds?.add(thread.id);
+      for (const thread of threads) ownedRemoteIds.add(thread.id);
       return {
         threads: threads.map((t) => ({
           status: t.is_archived ? ("archived" as const) : ("regular" as const),
@@ -256,7 +258,7 @@ export const createCloudThreadListAdapter = (
         last_message_at: new Date(),
         external_id,
       });
-      ownedRemoteIds?.add(remoteId);
+      ownedRemoteIds.add(remoteId);
 
       return { externalId: external_id, remoteId: remoteId };
     },
@@ -295,7 +297,7 @@ export const createCloudThreadListAdapter = (
 
     fetch: async (threadId: string) => {
       const thread = await cloud.threads.get(threadId);
-      ownedRemoteIds?.add(thread.id);
+      ownedRemoteIds.add(thread.id);
       return {
         status: thread.is_archived
           ? ("archived" as const)
@@ -312,6 +314,6 @@ export const createCloudThreadListAdapter = (
 
     unstable_useAdapters,
   };
-  if (ownedRemoteIds) cloudThreadOwnership.set(adapter, ownedRemoteIds);
+  cloudThreadOwnership.set(adapter, ownedRemoteIds);
   return adapter;
 };

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -131,11 +131,11 @@ const parseListCursor = (after: string | undefined): CloudListCursor => {
  * requiring a hook call site, so plain code (a Vue or Svelte setup function,
  * a module-level config) can construct it. Options are read through the
  * getter on every call, so a stable adapter can follow changing `create` and
- * `delete` callbacks; swapping to a different `cloud` instance requires a new
- * adapter (and `reload()` on the list). Without a `cloud` instance (and
- * without `NEXT_PUBLIC_ASSISTANT_BASE_URL`), the adapter falls back to an
- * in-memory list. `useCloudThreadListAdapter` wraps this for the React
- * hook signature.
+ * `delete` callbacks. Swapping to a different `cloud` instance or `scopeId`
+ * requires a new adapter so the remote list and its scoped runtime adapters
+ * reset together. Without a `cloud` instance (and without
+ * `NEXT_PUBLIC_ASSISTANT_BASE_URL`), the adapter falls back to an in-memory
+ * list. `useCloudThreadListAdapter` wraps this for the React hook signature.
  */
 export const createCloudThreadListAdapter = (
   options:
@@ -143,22 +143,10 @@ export const createCloudThreadListAdapter = (
     | (() => CloudThreadListAdapterOptions),
 ): RemoteThreadListAdapter => {
   const getOptions = typeof options === "function" ? options : () => options;
+  const initialOptions = getOptions();
+  const cloud = initialOptions.cloud ?? autoCloud;
+  const scopeId = initialOptions.scopeId;
 
-  const unstable_useAdapters = function useCloudAdapters(): RuntimeAdapters {
-    const cloudRef = {
-      get current() {
-        return getOptions().cloud ?? autoCloud!;
-      },
-    };
-    const scopeRef = {
-      get current() {
-        return getOptions().scopeId;
-      },
-    };
-    return useCloudRuntimeAdapters(cloudRef, scopeRef);
-  };
-
-  const cloud = getOptions().cloud ?? autoCloud;
   if (!cloud) {
     const inMemory = new InMemoryThreadListAdapter();
     inMemory.initialize = async (threadId: string) => {
@@ -167,6 +155,12 @@ export const createCloudThreadListAdapter = (
     };
     return inMemory;
   }
+
+  const unstable_useAdapters = function useCloudAdapters(): RuntimeAdapters {
+    const cloudRef = { current: cloud };
+    const scopeRef = { current: scopeId };
+    return useCloudRuntimeAdapters(cloudRef, scopeRef);
+  };
 
   cloud.registerSdk?.(CORE_SDK);
   const sdk = getOptions().sdk;

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -20,11 +20,27 @@ type ThreadData = {
 };
 
 type CloudThreadOwnership = Pick<ReadonlySet<string>, "has">;
+type MutableCloudThreadOwnership = Set<string>;
 
 const cloudThreadOwnership = new WeakMap<
   RemoteThreadListAdapter,
-  CloudThreadOwnership
+  MutableCloudThreadOwnership
 >();
+const deletedCloudThreads = new WeakMap<
+  MutableCloudThreadOwnership,
+  Set<string>
+>();
+
+const getDeletedCloudThreads = (
+  ownership: MutableCloudThreadOwnership,
+): Set<string> => {
+  let deleted = deletedCloudThreads.get(ownership);
+  if (!deleted) {
+    deleted = new Set();
+    deletedCloudThreads.set(ownership, deleted);
+  }
+  return deleted;
+};
 
 export const getCloudThreadOwnership = (
   adapter: RemoteThreadListAdapter,
@@ -32,7 +48,7 @@ export const getCloudThreadOwnership = (
 
 export const setCloudThreadOwnership = (
   adapter: RemoteThreadListAdapter,
-  ownership: CloudThreadOwnership,
+  ownership: MutableCloudThreadOwnership,
 ): void => {
   cloudThreadOwnership.set(adapter, ownership);
 };
@@ -203,18 +219,21 @@ export const createCloudThreadListAdapter = (
   }
 
   const ownedRemoteIds = new Set<string>();
+  let adapter: RemoteThreadListAdapter;
+
+  const getOwnership = () => cloudThreadOwnership.get(adapter)!;
 
   const unstable_useAdapters = function useCloudAdapters(): RuntimeAdapters {
     const cloudRef = { current: cloud };
     const scopeRef = { current: scopeId };
-    return useCloudRuntimeAdapters(cloudRef, scopeRef, ownedRemoteIds);
+    return useCloudRuntimeAdapters(cloudRef, scopeRef, getOwnership());
   };
 
   cloud.registerSdk?.(CORE_SDK);
   const sdk = getOptions().sdk;
   if (sdk) cloud.registerSdk?.(sdk);
 
-  const adapter: RemoteThreadListAdapter = {
+  adapter = {
     list: async ({ after } = {}) => {
       const {
         activeCursor,
@@ -247,7 +266,11 @@ export const createCloudThreadListAdapter = (
           ? archivedThreads.at(-1)?.id
           : undefined;
       const threads = [...activeThreads, ...archivedThreads];
-      for (const thread of threads) ownedRemoteIds.add(thread.id);
+      const ownership = getOwnership();
+      const deleted = getDeletedCloudThreads(ownership);
+      for (const thread of threads) {
+        if (!deleted.has(thread.id)) ownership.add(thread.id);
+      }
       return {
         threads: threads.map((t) => ({
           status: t.is_archived ? ("archived" as const) : ("regular" as const),
@@ -279,7 +302,9 @@ export const createCloudThreadListAdapter = (
         last_message_at: new Date(),
         external_id,
       });
-      ownedRemoteIds.add(remoteId);
+      const ownership = getOwnership();
+      getDeletedCloudThreads(ownership).delete(remoteId);
+      ownership.add(remoteId);
 
       return { externalId: external_id, remoteId: remoteId };
     },
@@ -299,7 +324,9 @@ export const createCloudThreadListAdapter = (
     delete: async (threadId) => {
       await getOptions().delete?.(threadId);
       const result = await cloud.threads.delete(threadId);
-      ownedRemoteIds.delete(threadId);
+      const ownership = getOwnership();
+      ownership.delete(threadId);
+      getDeletedCloudThreads(ownership).add(threadId);
       return result;
     },
 
@@ -320,7 +347,10 @@ export const createCloudThreadListAdapter = (
 
     fetch: async (threadId: string) => {
       const thread = await cloud.threads.get(threadId);
-      ownedRemoteIds.add(thread.id);
+      const ownership = getOwnership();
+      if (!getDeletedCloudThreads(ownership).has(thread.id)) {
+        ownership.add(thread.id);
+      }
       return {
         status: thread.is_archived
           ? ("archived" as const)

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -26,20 +26,34 @@ const cloudThreadOwnership = new WeakMap<
   RemoteThreadListAdapter,
   MutableCloudThreadOwnership
 >();
-const deletedCloudThreads = new WeakMap<
+const pendingCloudThreadReads = new WeakMap<
   MutableCloudThreadOwnership,
-  Set<string>
+  Set<Set<string>>
 >();
 
-const getDeletedCloudThreads = (
+const beginCloudThreadRead = (
   ownership: MutableCloudThreadOwnership,
-): Set<string> => {
-  let deleted = deletedCloudThreads.get(ownership);
-  if (!deleted) {
-    deleted = new Set();
-    deletedCloudThreads.set(ownership, deleted);
+): { blockedIds: Set<string>; finish(): void } => {
+  let pending = pendingCloudThreadReads.get(ownership);
+  if (!pending) {
+    pending = new Set();
+    pendingCloudThreadReads.set(ownership, pending);
   }
-  return deleted;
+  const blockedIds = new Set<string>();
+  pending.add(blockedIds);
+  return {
+    blockedIds,
+    finish: () => pending.delete(blockedIds),
+  };
+};
+
+const blockPendingCloudThreadReads = (
+  ownership: MutableCloudThreadOwnership,
+  threadId: string,
+): void => {
+  for (const blockedIds of pendingCloudThreadReads.get(ownership) ?? []) {
+    blockedIds.add(threadId);
+  }
 };
 
 export const getCloudThreadOwnership = (
@@ -235,63 +249,70 @@ export const createCloudThreadListAdapter = (
 
   adapter = {
     list: async ({ after } = {}) => {
+      const ownership = getOwnership();
+      const read = beginCloudThreadRead(ownership);
       const {
         activeCursor,
         archivedCursor,
         activeExhausted,
         archivedExhausted,
       } = parseListCursor(after);
-      const [{ threads: activeThreads }, { threads: archivedThreads }] =
-        await Promise.all([
-          activeExhausted
-            ? Promise.resolve({ threads: [] })
-            : cloud.threads.list({
-                limit: CLOUD_THREAD_PAGE_SIZE,
-                ...(activeCursor ? { after: activeCursor } : {}),
-              }),
-          archivedExhausted
-            ? Promise.resolve({ threads: [] })
-            : cloud.threads.list({
-                is_archived: true,
-                limit: CLOUD_THREAD_PAGE_SIZE,
-                ...(archivedCursor ? { after: archivedCursor } : {}),
-              }),
-        ]);
-      const activeNext =
-        !activeExhausted && activeThreads.length === CLOUD_THREAD_PAGE_SIZE
-          ? activeThreads.at(-1)?.id
-          : undefined;
-      const archivedNext =
-        !archivedExhausted && archivedThreads.length === CLOUD_THREAD_PAGE_SIZE
-          ? archivedThreads.at(-1)?.id
-          : undefined;
-      const threads = [...activeThreads, ...archivedThreads];
-      const ownership = getOwnership();
-      const deleted = getDeletedCloudThreads(ownership);
-      for (const thread of threads) {
-        if (!deleted.has(thread.id)) ownership.add(thread.id);
+      try {
+        const [{ threads: activeThreads }, { threads: archivedThreads }] =
+          await Promise.all([
+            activeExhausted
+              ? Promise.resolve({ threads: [] })
+              : cloud.threads.list({
+                  limit: CLOUD_THREAD_PAGE_SIZE,
+                  ...(activeCursor ? { after: activeCursor } : {}),
+                }),
+            archivedExhausted
+              ? Promise.resolve({ threads: [] })
+              : cloud.threads.list({
+                  is_archived: true,
+                  limit: CLOUD_THREAD_PAGE_SIZE,
+                  ...(archivedCursor ? { after: archivedCursor } : {}),
+                }),
+          ]);
+        const activeNext =
+          !activeExhausted && activeThreads.length === CLOUD_THREAD_PAGE_SIZE
+            ? activeThreads.at(-1)?.id
+            : undefined;
+        const archivedNext =
+          !archivedExhausted &&
+          archivedThreads.length === CLOUD_THREAD_PAGE_SIZE
+            ? archivedThreads.at(-1)?.id
+            : undefined;
+        const threads = [...activeThreads, ...archivedThreads];
+        for (const thread of threads) {
+          if (!read.blockedIds.has(thread.id)) ownership.add(thread.id);
+        }
+        return {
+          threads: threads.map((t) => ({
+            status: t.is_archived
+              ? ("archived" as const)
+              : ("regular" as const),
+            remoteId: t.id,
+            title: t.title,
+            lastMessageAt: t.last_message_at
+              ? new Date(t.last_message_at)
+              : undefined,
+            externalId: t.external_id ?? undefined,
+            custom: toCustom(t.metadata),
+          })),
+          nextCursor:
+            activeNext || archivedNext
+              ? JSON.stringify({
+                  a: activeNext,
+                  r: archivedNext,
+                  ...(activeNext === undefined ? { ae: true } : {}),
+                  ...(archivedNext === undefined ? { re: true } : {}),
+                })
+              : undefined,
+        };
+      } finally {
+        read.finish();
       }
-      return {
-        threads: threads.map((t) => ({
-          status: t.is_archived ? ("archived" as const) : ("regular" as const),
-          remoteId: t.id,
-          title: t.title,
-          lastMessageAt: t.last_message_at
-            ? new Date(t.last_message_at)
-            : undefined,
-          externalId: t.external_id ?? undefined,
-          custom: toCustom(t.metadata),
-        })),
-        nextCursor:
-          activeNext || archivedNext
-            ? JSON.stringify({
-                a: activeNext,
-                r: archivedNext,
-                ...(activeNext === undefined ? { ae: true } : {}),
-                ...(archivedNext === undefined ? { re: true } : {}),
-              })
-            : undefined,
-      };
     },
 
     initialize: async () => {
@@ -303,7 +324,6 @@ export const createCloudThreadListAdapter = (
         external_id,
       });
       const ownership = getOwnership();
-      getDeletedCloudThreads(ownership).delete(remoteId);
       ownership.add(remoteId);
 
       return { externalId: external_id, remoteId: remoteId };
@@ -326,7 +346,7 @@ export const createCloudThreadListAdapter = (
       const result = await cloud.threads.delete(threadId);
       const ownership = getOwnership();
       ownership.delete(threadId);
-      getDeletedCloudThreads(ownership).add(threadId);
+      blockPendingCloudThreadReads(ownership, threadId);
       return result;
     },
 
@@ -346,23 +366,26 @@ export const createCloudThreadListAdapter = (
     },
 
     fetch: async (threadId: string) => {
-      const thread = await cloud.threads.get(threadId);
       const ownership = getOwnership();
-      if (!getDeletedCloudThreads(ownership).has(thread.id)) {
-        ownership.add(thread.id);
+      const read = beginCloudThreadRead(ownership);
+      try {
+        const thread = await cloud.threads.get(threadId);
+        if (!read.blockedIds.has(thread.id)) ownership.add(thread.id);
+        return {
+          status: thread.is_archived
+            ? ("archived" as const)
+            : ("regular" as const),
+          remoteId: thread.id,
+          title: thread.title,
+          lastMessageAt: thread.last_message_at
+            ? new Date(thread.last_message_at)
+            : undefined,
+          externalId: thread.external_id ?? undefined,
+          custom: toCustom(thread.metadata),
+        };
+      } finally {
+        read.finish();
       }
-      return {
-        status: thread.is_archived
-          ? ("archived" as const)
-          : ("regular" as const),
-        remoteId: thread.id,
-        title: thread.title,
-        lastMessageAt: thread.last_message_at
-          ? new Date(thread.last_message_at)
-          : undefined,
-        externalId: thread.external_id ?? undefined,
-        custom: toCustom(thread.metadata),
-      };
     },
 
     unstable_useAdapters,

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -19,6 +19,17 @@ type ThreadData = {
   externalId: string | undefined;
 };
 
+type CloudThreadOwnership = Pick<ReadonlySet<string>, "has">;
+
+const cloudThreadOwnership = new WeakMap<
+  RemoteThreadListAdapter,
+  Set<string>
+>();
+
+export const getCloudThreadOwnership = (
+  adapter: RemoteThreadListAdapter,
+): CloudThreadOwnership | undefined => cloudThreadOwnership.get(adapter);
+
 export type CloudThreadListAdapterOptions = {
   cloud?: AssistantCloud | undefined;
   /**
@@ -73,15 +84,21 @@ const createCommittedScopeRef = (initialScope: unknown): CommittedScopeRef => {
 export const useCloudRuntimeAdapters = (
   cloudRef: RefObject<AssistantCloud>,
   scopeRef?: RefObject<unknown>,
+  ownership?: CloudThreadOwnership,
 ): RuntimeAdapters => {
   const scope = scopeRef?.current ?? DEFAULT_CLOUD_SCOPE;
   const [committedScopeRef] = useState(() => createCommittedScopeRef(scope));
+  const [committedOwnershipRef] = useState<{
+    current: CloudThreadOwnership | undefined;
+  }>(() => ({ current: ownership }));
   useInsertionEffect(() => {
+    committedOwnershipRef.current = ownership;
     committedScopeRef.update(scope);
-  }, [committedScopeRef, scope]);
+  }, [committedOwnershipRef, committedScopeRef, ownership, scope]);
   const history = useScopedAssistantCloudThreadHistoryAdapter(
     cloudRef,
     committedScopeRef,
+    committedOwnershipRef,
   );
   const [attachments] = useState(() =>
     createScopedCloudFileAttachmentAdapter(
@@ -162,17 +179,19 @@ export const createCloudThreadListAdapter = (
     return inMemory;
   }
 
+  const ownedRemoteIds = scopeId === undefined ? undefined : new Set<string>();
+
   const unstable_useAdapters = function useCloudAdapters(): RuntimeAdapters {
     const cloudRef = { current: cloud };
     const scopeRef = { current: scopeId };
-    return useCloudRuntimeAdapters(cloudRef, scopeRef);
+    return useCloudRuntimeAdapters(cloudRef, scopeRef, ownedRemoteIds);
   };
 
   cloud.registerSdk?.(CORE_SDK);
   const sdk = getOptions().sdk;
   if (sdk) cloud.registerSdk?.(sdk);
 
-  return {
+  const adapter: RemoteThreadListAdapter = {
     list: async ({ after } = {}) => {
       const {
         activeCursor,
@@ -205,6 +224,7 @@ export const createCloudThreadListAdapter = (
           ? archivedThreads.at(-1)?.id
           : undefined;
       const threads = [...activeThreads, ...archivedThreads];
+      for (const thread of threads) ownedRemoteIds?.add(thread.id);
       return {
         threads: threads.map((t) => ({
           status: t.is_archived ? ("archived" as const) : ("regular" as const),
@@ -236,6 +256,7 @@ export const createCloudThreadListAdapter = (
         last_message_at: new Date(),
         external_id,
       });
+      ownedRemoteIds?.add(remoteId);
 
       return { externalId: external_id, remoteId: remoteId };
     },
@@ -274,6 +295,7 @@ export const createCloudThreadListAdapter = (
 
     fetch: async (threadId: string) => {
       const thread = await cloud.threads.get(threadId);
+      ownedRemoteIds?.add(thread.id);
       return {
         status: thread.is_archived
           ? ("archived" as const)
@@ -290,4 +312,6 @@ export const createCloudThreadListAdapter = (
 
     unstable_useAdapters,
   };
+  if (ownedRemoteIds) cloudThreadOwnership.set(adapter, ownedRemoteIds);
+  return adapter;
 };

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -23,13 +23,19 @@ type CloudThreadOwnership = Pick<ReadonlySet<string>, "has">;
 
 const cloudThreadOwnership = new WeakMap<
   RemoteThreadListAdapter,
-  Set<string>
+  CloudThreadOwnership
 >();
-const defaultCloudThreadOwnership = new Set<string>();
 
 export const getCloudThreadOwnership = (
   adapter: RemoteThreadListAdapter,
 ): CloudThreadOwnership | undefined => cloudThreadOwnership.get(adapter);
+
+export const setCloudThreadOwnership = (
+  adapter: RemoteThreadListAdapter,
+  ownership: CloudThreadOwnership,
+): void => {
+  cloudThreadOwnership.set(adapter, ownership);
+};
 
 export type CloudThreadListAdapterOptions = {
   cloud?: AssistantCloud | undefined;
@@ -89,13 +95,29 @@ export const useCloudRuntimeAdapters = (
 ): RuntimeAdapters => {
   const scope = scopeRef?.current ?? DEFAULT_CLOUD_SCOPE;
   const [committedScopeRef] = useState(() => createCommittedScopeRef(scope));
+  const [ownershipState] = useState(() => ({
+    required: scope !== DEFAULT_CLOUD_SCOPE,
+  }));
   const [committedOwnershipRef] = useState<{
     current: CloudThreadOwnership | undefined;
-  }>(() => ({ current: ownership }));
+  }>(() => ({
+    current: ownershipState.required ? ownership : undefined,
+  }));
   useInsertionEffect(() => {
-    committedOwnershipRef.current = ownership;
+    if (!Object.is(committedScopeRef.current, scope)) {
+      ownershipState.required = true;
+    }
+    committedOwnershipRef.current = ownershipState.required
+      ? ownership
+      : undefined;
     committedScopeRef.update(scope);
-  }, [committedOwnershipRef, committedScopeRef, ownership, scope]);
+  }, [
+    committedOwnershipRef,
+    committedScopeRef,
+    ownership,
+    ownershipState,
+    scope,
+  ]);
   const history = useScopedAssistantCloudThreadHistoryAdapter(
     cloudRef,
     committedScopeRef,
@@ -180,8 +202,7 @@ export const createCloudThreadListAdapter = (
     return inMemory;
   }
 
-  const ownedRemoteIds =
-    scopeId === undefined ? defaultCloudThreadOwnership : new Set<string>();
+  const ownedRemoteIds = new Set<string>();
 
   const unstable_useAdapters = function useCloudAdapters(): RuntimeAdapters {
     const cloudRef = { current: cloud };
@@ -277,7 +298,9 @@ export const createCloudThreadListAdapter = (
     },
     delete: async (threadId) => {
       await getOptions().delete?.(threadId);
-      return cloud.threads.delete(threadId);
+      const result = await cloud.threads.delete(threadId);
+      ownedRemoteIds.delete(threadId);
+      return result;
     },
 
     generateTitle: async (threadId, messages) => {

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -23,8 +23,11 @@ export type CloudThreadListAdapterOptions = {
   cloud?: AssistantCloud | undefined;
   /**
    * Stable identity for the account or workspace owning Cloud runtime state.
-   * Change it when that scope changes. When omitted, replacing the Cloud client
-   * preserves cached runtime state for backward compatibility.
+   * Change it when that scope changes. `useCloudThreadListRuntime` reloads the
+   * list after the hook returns a replacement adapter; lower-level
+   * `RemoteThreadList` compositions must call their thread-list `reload()`
+   * method after publishing that replacement. When omitted, replacing the
+   * Cloud client preserves cached runtime state for backward compatibility.
    */
   scopeId?: string | undefined;
   sdk?: SdkIdentity | undefined;
@@ -134,8 +137,9 @@ const parseListCursor = (after: string | undefined): CloudListCursor => {
  * a module-level config) can construct it. Options are read through the
  * getter on every call, so a stable adapter can follow changing `create` and
  * `delete` callbacks. Swapping to a different `cloud` instance or `scopeId`
- * requires a new adapter so the remote list and its scoped runtime adapters
- * reset together. Without a `cloud` instance (and without
+ * requires a new adapter. The consumer must then reload its remote list as
+ * required by the `RemoteThreadList` adapter replacement contract. Without a
+ * `cloud` instance (and without
  * `NEXT_PUBLIC_ASSISTANT_BASE_URL`), the adapter falls back to an in-memory
  * list. `useCloudThreadListAdapter` wraps this for the React hook signature.
  */

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -28,7 +28,9 @@ export type CloudThreadListAdapterOptions = {
    * returns a replacement adapter; lower-level
    * `RemoteThreadList` compositions must call their thread-list `reload()`
    * method after publishing that replacement. When omitted, replacing the
-   * Cloud client preserves cached runtime state for backward compatibility.
+   * Cloud client preserves attachment URLs and message mappings for backward
+   * compatibility, but still replaces and reloads the thread-list adapter.
+   * History operations attempted before that reload settles are skipped.
    */
   scopeId?: string | undefined;
   sdk?: SdkIdentity | undefined;

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
@@ -10,7 +10,6 @@ import {
 } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { RemoteThreadListAdapter } from "../../../runtimes/remote-thread-list/types";
-import { getCloudThreadOwnership } from "./createCloudThreadListAdapter";
 import { useCloudThreadListAdapter } from "./useCloudThreadListAdapter";
 
 const makeThread = (id: string) => ({
@@ -48,64 +47,6 @@ describe("useCloudThreadListAdapter", () => {
     rerender({ scopeId: "workspace-b" });
     expect(result.current).not.toBe(first);
   });
-
-  it("preserves thread ownership when the Cloud client changes within a scope", async () => {
-    const cloudA = {
-      registerSdk: vi.fn(),
-      threads: {
-        list: vi
-          .fn()
-          .mockResolvedValueOnce({ threads: [makeThread("thread-a")] })
-          .mockResolvedValueOnce({ threads: [] }),
-      },
-    } as unknown as AssistantCloud;
-    const cloudB = {
-      registerSdk: vi.fn(),
-      threads: {},
-    } as unknown as AssistantCloud;
-    const { result, rerender } = renderHook(
-      ({ cloud }) =>
-        useCloudThreadListAdapter({ cloud, scopeId: "workspace-a" }),
-      { initialProps: { cloud: cloudA } },
-    );
-    await result.current.list();
-
-    rerender({ cloud: cloudB });
-
-    expect(getCloudThreadOwnership(result.current)!.has("thread-a")).toBe(true);
-  });
-
-  it.each([
-    ["default to explicit", undefined, "workspace-a"],
-    ["explicit to default", "workspace-a", undefined],
-  ] as const)(
-    "does not transfer thread ownership from %s scope",
-    async (_label, initialScope, nextScope) => {
-      const list = vi
-        .fn()
-        .mockResolvedValueOnce({ threads: [makeThread("thread-a")] })
-        .mockResolvedValueOnce({ threads: [] });
-      const cloud = {
-        registerSdk: vi.fn(),
-        threads: { list },
-      } as unknown as AssistantCloud;
-      const { result, rerender } = renderHook(
-        ({ scopeId }: { scopeId: string | undefined }) =>
-          useCloudThreadListAdapter({ cloud, scopeId }),
-        { initialProps: { scopeId: initialScope } },
-      );
-      await result.current.list();
-      expect(getCloudThreadOwnership(result.current)!.has("thread-a")).toBe(
-        true,
-      );
-
-      rerender({ scopeId: nextScope });
-
-      expect(getCloudThreadOwnership(result.current)!.has("thread-a")).toBe(
-        false,
-      );
-    },
-  );
 
   it("keeps operations scoped to the committed Cloud options", async () => {
     const deleteA = vi.fn(async () => {});

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
@@ -30,6 +30,24 @@ const Suspend = ({ pending }: { pending: Promise<never> }) => {
 };
 
 describe("useCloudThreadListAdapter", () => {
+  it("replaces the list adapter when its scope changes", () => {
+    const cloud = {
+      registerSdk: vi.fn(),
+      threads: {},
+    } as unknown as AssistantCloud;
+    const { result, rerender } = renderHook(
+      ({ scopeId }) => useCloudThreadListAdapter({ cloud, scopeId }),
+      { initialProps: { scopeId: "workspace-a" } },
+    );
+    const first = result.current;
+
+    rerender({ scopeId: "workspace-a" });
+    expect(result.current).toBe(first);
+
+    rerender({ scopeId: "workspace-b" });
+    expect(result.current).not.toBe(first);
+  });
+
   it("keeps operations scoped to the committed Cloud options", async () => {
     const deleteA = vi.fn(async () => {});
     const deleteB = vi.fn(async () => {});

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
@@ -49,6 +49,32 @@ describe("useCloudThreadListAdapter", () => {
     expect(result.current).not.toBe(first);
   });
 
+  it("preserves thread ownership when the Cloud client changes within a scope", async () => {
+    const cloudA = {
+      registerSdk: vi.fn(),
+      threads: {
+        list: vi
+          .fn()
+          .mockResolvedValueOnce({ threads: [makeThread("thread-a")] })
+          .mockResolvedValueOnce({ threads: [] }),
+      },
+    } as unknown as AssistantCloud;
+    const cloudB = {
+      registerSdk: vi.fn(),
+      threads: {},
+    } as unknown as AssistantCloud;
+    const { result, rerender } = renderHook(
+      ({ cloud }) =>
+        useCloudThreadListAdapter({ cloud, scopeId: "workspace-a" }),
+      { initialProps: { cloud: cloudA } },
+    );
+    await result.current.list();
+
+    rerender({ cloud: cloudB });
+
+    expect(getCloudThreadOwnership(result.current)!.has("thread-a")).toBe(true);
+  });
+
   it.each([
     ["default to explicit", undefined, "workspace-a"],
     ["explicit to default", "workspace-a", undefined],

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { RemoteThreadListAdapter } from "../../../runtimes/remote-thread-list/types";
+import { getCloudThreadOwnership } from "./createCloudThreadListAdapter";
 import { useCloudThreadListAdapter } from "./useCloudThreadListAdapter";
 
 const makeThread = (id: string) => ({
@@ -47,6 +48,38 @@ describe("useCloudThreadListAdapter", () => {
     rerender({ scopeId: "workspace-b" });
     expect(result.current).not.toBe(first);
   });
+
+  it.each([
+    ["default to explicit", undefined, "workspace-a"],
+    ["explicit to default", "workspace-a", undefined],
+  ] as const)(
+    "does not transfer thread ownership from %s scope",
+    async (_label, initialScope, nextScope) => {
+      const list = vi
+        .fn()
+        .mockResolvedValueOnce({ threads: [makeThread("thread-a")] })
+        .mockResolvedValueOnce({ threads: [] });
+      const cloud = {
+        registerSdk: vi.fn(),
+        threads: { list },
+      } as unknown as AssistantCloud;
+      const { result, rerender } = renderHook(
+        ({ scopeId }: { scopeId: string | undefined }) =>
+          useCloudThreadListAdapter({ cloud, scopeId }),
+        { initialProps: { scopeId: initialScope } },
+      );
+      await result.current.list();
+      expect(getCloudThreadOwnership(result.current)!.has("thread-a")).toBe(
+        true,
+      );
+
+      rerender({ scopeId: nextScope });
+
+      expect(getCloudThreadOwnership(result.current)!.has("thread-a")).toBe(
+        false,
+      );
+    },
+  );
 
   it("keeps operations scoped to the committed Cloud options", async () => {
     const deleteA = vi.fn(async () => {});

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -3,6 +3,7 @@ import type { RemoteThreadListAdapter } from "../../../runtimes/remote-thread-li
 import {
   autoCloud,
   createCloudThreadListAdapter,
+  getCloudThreadOwnership,
   type CloudThreadListAdapterOptions,
   useCloudRuntimeAdapters,
 } from "./createCloudThreadListAdapter";
@@ -36,12 +37,13 @@ export const useCloudThreadListAdapter = (
     [],
   );
   const scopeRef = useMemo(() => ({ current: scope }), [scope]);
+  const ownership = getCloudThreadOwnership(base);
 
   const unstable_useAdapters = useCallback(
     function useCloudAdapters() {
-      return useCloudRuntimeAdapters(cloudRef, scopeRef);
+      return useCloudRuntimeAdapters(cloudRef, scopeRef, ownership);
     },
-    [cloudRef, scopeRef],
+    [cloudRef, ownership, scopeRef],
   );
 
   return useMemo<RemoteThreadListAdapter>(() => {

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -1,15 +1,8 @@
-import {
-  useCallback,
-  useInsertionEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useInsertionEffect, useMemo, useRef } from "react";
 import type { RemoteThreadListAdapter } from "../../../runtimes/remote-thread-list/types";
 import {
   autoCloud,
   createCloudThreadListAdapter,
-  setCloudThreadOwnership,
   type CloudThreadListAdapterOptions,
   useCloudRuntimeAdapters,
 } from "./createCloudThreadListAdapter";
@@ -24,33 +17,15 @@ export const useCloudThreadListAdapter = (
 
   const cloud = adapter.cloud ?? autoCloud;
   const scope = adapter.scopeId;
-  const [ownershipState] = useState(() => ({
-    scope,
-    ids: new Set<string>(),
-  }));
-  const ownership = useMemo(
-    () =>
-      Object.is(ownershipState.scope, scope)
-        ? ownershipState.ids
-        : new Set<string>(),
-    [ownershipState, scope],
-  );
-  useInsertionEffect(() => {
-    ownershipState.scope = scope;
-    ownershipState.ids = ownership;
-  }, [ownership, ownershipState, scope]);
   const base = useMemo(
-    () => {
-      const created = createCloudThreadListAdapter(() => ({
+    () =>
+      createCloudThreadListAdapter(() => ({
         ...adapterRef.current,
         cloud,
         scopeId: scope,
-      }));
-      setCloudThreadOwnership(created, ownership);
-      return created;
-    },
+      })),
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- the factory pins the cloud instance; changing callbacks are read from the committed ref
-    [cloud, ownership],
+    [cloud, scope],
   );
 
   const cloudRef = useMemo(
@@ -65,18 +40,16 @@ export const useCloudThreadListAdapter = (
 
   const unstable_useAdapters = useCallback(
     function useCloudAdapters() {
-      return useCloudRuntimeAdapters(cloudRef, scopeRef, ownership);
+      return useCloudRuntimeAdapters(cloudRef, scopeRef);
     },
-    [cloudRef, ownership, scopeRef],
+    [cloudRef, scopeRef],
   );
 
   return useMemo<RemoteThreadListAdapter>(() => {
     if (base.unstable_useAdapters === undefined) return base;
-    const adapter = {
+    return {
       ...base,
       unstable_useAdapters,
     };
-    setCloudThreadOwnership(adapter, ownership);
-    return adapter;
-  }, [base, ownership, unstable_useAdapters]);
+  }, [base, unstable_useAdapters]);
 };

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -16,6 +16,7 @@ export const useCloudThreadListAdapter = (
   }, [adapter]);
 
   const cloud = adapter.cloud ?? autoCloud;
+  const scope = adapter.scopeId ?? cloud;
   const base = useMemo(
     () =>
       createCloudThreadListAdapter(() => ({
@@ -23,7 +24,7 @@ export const useCloudThreadListAdapter = (
         cloud,
       })),
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- the factory pins the cloud instance; changing callbacks are read from the committed ref
-    [cloud],
+    [cloud, scope],
   );
 
   const cloudRef = useMemo(
@@ -34,16 +35,7 @@ export const useCloudThreadListAdapter = (
     }),
     [],
   );
-  const scopeRef = useMemo(
-    () => ({
-      get current() {
-        return (
-          adapterRef.current.scopeId ?? adapterRef.current.cloud ?? autoCloud!
-        );
-      },
-    }),
-    [],
-  );
+  const scopeRef = useMemo(() => ({ current: scope }), [scope]);
 
   const unstable_useAdapters = useCallback(
     function useCloudAdapters() {

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useInsertionEffect, useMemo, useRef } from "react";
+import {
+  useCallback,
+  useInsertionEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { RemoteThreadListAdapter } from "../../../runtimes/remote-thread-list/types";
 import {
   autoCloud,
@@ -18,10 +24,21 @@ export const useCloudThreadListAdapter = (
 
   const cloud = adapter.cloud ?? autoCloud;
   const scope = adapter.scopeId;
+  const [ownershipState] = useState(() => ({
+    scope,
+    ids: new Set<string>(),
+  }));
   const ownership = useMemo(
-    () => ({ scope, ids: new Set<string>() }),
-    [scope],
-  ).ids;
+    () =>
+      Object.is(ownershipState.scope, scope)
+        ? ownershipState.ids
+        : new Set<string>(),
+    [ownershipState, scope],
+  );
+  useInsertionEffect(() => {
+    ownershipState.scope = scope;
+    ownershipState.ids = ownership;
+  }, [ownership, ownershipState, scope]);
   const base = useMemo(
     () => {
       const created = createCloudThreadListAdapter(() => ({

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -4,6 +4,7 @@ import {
   autoCloud,
   createCloudThreadListAdapter,
   getCloudThreadOwnership,
+  setCloudThreadOwnership,
   type CloudThreadListAdapterOptions,
   useCloudRuntimeAdapters,
 } from "./createCloudThreadListAdapter";
@@ -23,6 +24,7 @@ export const useCloudThreadListAdapter = (
       createCloudThreadListAdapter(() => ({
         ...adapterRef.current,
         cloud,
+        scopeId: scope,
       })),
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- the factory pins the cloud instance; changing callbacks are read from the committed ref
     [cloud, scope],
@@ -48,9 +50,11 @@ export const useCloudThreadListAdapter = (
 
   return useMemo<RemoteThreadListAdapter>(() => {
     if (base.unstable_useAdapters === undefined) return base;
-    return {
+    const adapter = {
       ...base,
       unstable_useAdapters,
     };
-  }, [base, unstable_useAdapters]);
+    if (ownership) setCloudThreadOwnership(adapter, ownership);
+    return adapter;
+  }, [base, ownership, unstable_useAdapters]);
 };

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -34,12 +34,22 @@ export const useCloudThreadListAdapter = (
     }),
     [],
   );
+  const scopeRef = useMemo(
+    () => ({
+      get current() {
+        return (
+          adapterRef.current.scopeId ?? adapterRef.current.cloud ?? autoCloud!
+        );
+      },
+    }),
+    [],
+  );
 
   const unstable_useAdapters = useCallback(
     function useCloudAdapters() {
-      return useCloudRuntimeAdapters(cloudRef);
+      return useCloudRuntimeAdapters(cloudRef, scopeRef);
     },
-    [cloudRef],
+    [cloudRef, scopeRef],
   );
 
   return useMemo<RemoteThreadListAdapter>(() => {

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -3,7 +3,6 @@ import type { RemoteThreadListAdapter } from "../../../runtimes/remote-thread-li
 import {
   autoCloud,
   createCloudThreadListAdapter,
-  getCloudThreadOwnership,
   setCloudThreadOwnership,
   type CloudThreadListAdapterOptions,
   useCloudRuntimeAdapters,
@@ -19,15 +18,22 @@ export const useCloudThreadListAdapter = (
 
   const cloud = adapter.cloud ?? autoCloud;
   const scope = adapter.scopeId;
+  const ownership = useMemo(
+    () => ({ scope, ids: new Set<string>() }),
+    [scope],
+  ).ids;
   const base = useMemo(
-    () =>
-      createCloudThreadListAdapter(() => ({
+    () => {
+      const created = createCloudThreadListAdapter(() => ({
         ...adapterRef.current,
         cloud,
         scopeId: scope,
-      })),
+      }));
+      setCloudThreadOwnership(created, ownership);
+      return created;
+    },
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- the factory pins the cloud instance; changing callbacks are read from the committed ref
-    [cloud, scope],
+    [cloud, ownership],
   );
 
   const cloudRef = useMemo(
@@ -39,7 +45,6 @@ export const useCloudThreadListAdapter = (
     [],
   );
   const scopeRef = useMemo(() => ({ current: scope }), [scope]);
-  const ownership = getCloudThreadOwnership(base);
 
   const unstable_useAdapters = useCallback(
     function useCloudAdapters() {
@@ -54,7 +59,7 @@ export const useCloudThreadListAdapter = (
       ...base,
       unstable_useAdapters,
     };
-    if (ownership) setCloudThreadOwnership(adapter, ownership);
+    setCloudThreadOwnership(adapter, ownership);
     return adapter;
   }, [base, ownership, unstable_useAdapters]);
 };

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -16,7 +16,7 @@ export const useCloudThreadListAdapter = (
   }, [adapter]);
 
   const cloud = adapter.cloud ?? autoCloud;
-  const scope = adapter.scopeId ?? cloud;
+  const scope = adapter.scopeId;
   const base = useMemo(
     () =>
       createCloudThreadListAdapter(() => ({

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListRuntime.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListRuntime.test.tsx
@@ -27,6 +27,7 @@ describe("useCloudThreadListRuntime", () => {
     const runtimeHook = () => ({}) as AssistantRuntime;
     const create = vi.fn();
     const del = vi.fn();
+    const scopeId = "workspace-1";
     const adapter = { list: vi.fn() };
     const runtime = { kind: "runtime" };
     mocks.useCloudThreadListAdapter.mockReturnValue(adapter);
@@ -35,6 +36,7 @@ describe("useCloudThreadListRuntime", () => {
     const { result } = renderHook(() =>
       useCloudThreadListRuntime({
         cloud,
+        scopeId,
         runtimeHook,
         create,
         delete: del,
@@ -43,6 +45,7 @@ describe("useCloudThreadListRuntime", () => {
 
     expect(mocks.useCloudThreadListAdapter).toHaveBeenCalledWith({
       cloud,
+      scopeId,
       create,
       delete: del,
     });

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListRuntime.ts
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListRuntime.ts
@@ -11,7 +11,7 @@ type ThreadData = {
 
 type CloudThreadListAdapter = {
   cloud: AssistantCloud;
-  scopeId?: string;
+  scopeId?: string | undefined;
 
   runtimeHook: () => AssistantRuntime;
 

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListRuntime.ts
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListRuntime.ts
@@ -11,6 +11,7 @@ type ThreadData = {
 
 type CloudThreadListAdapter = {
   cloud: AssistantCloud;
+  scopeId?: string;
 
   runtimeHook: () => AssistantRuntime;
 

--- a/packages/core/src/react/runtimes/useLocalRuntime.cloud-options.test.tsx
+++ b/packages/core/src/react/runtimes/useLocalRuntime.cloud-options.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantCloud } from "assistant-cloud";
+import type { AssistantRuntime, ChatModelAdapter } from "../../index";
+
+const mocks = vi.hoisted(() => ({
+  cloudAdapter: {},
+  runtime: {},
+  useCloudThreadListAdapter: vi.fn(() => ({})),
+  useRemoteThreadListRuntime: vi.fn(() => ({})),
+}));
+
+vi.mock("./cloud/useCloudThreadListAdapter", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("./cloud/useCloudThreadListAdapter")
+  >()),
+  useCloudThreadListAdapter: mocks.useCloudThreadListAdapter,
+}));
+
+vi.mock("./useRemoteThreadListRuntime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./useRemoteThreadListRuntime")>()),
+  useRemoteThreadListRuntime: mocks.useRemoteThreadListRuntime,
+}));
+
+import { useLocalRuntime } from "./useLocalRuntime";
+
+describe("useLocalRuntime Cloud options", () => {
+  it("forwards the Cloud scope to the thread-list adapter", () => {
+    const cloud = {} as AssistantCloud;
+    const chatModel: ChatModelAdapter = {
+      run: async () => ({ content: [] }),
+    };
+    mocks.useCloudThreadListAdapter.mockReturnValue(mocks.cloudAdapter);
+    mocks.useRemoteThreadListRuntime.mockReturnValue(
+      mocks.runtime as AssistantRuntime,
+    );
+
+    renderHook(() =>
+      useLocalRuntime(chatModel, { cloud, scopeId: "workspace-1" }),
+    );
+
+    expect(mocks.useCloudThreadListAdapter).toHaveBeenCalledWith({
+      cloud,
+      scopeId: "workspace-1",
+    });
+  });
+});

--- a/packages/core/src/react/runtimes/useLocalRuntime.ts
+++ b/packages/core/src/react/runtimes/useLocalRuntime.ts
@@ -14,6 +14,11 @@ import type { AssistantCloud } from "assistant-cloud";
 
 export type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
   cloud?: AssistantCloud | undefined;
+  /**
+   * Stable identity for the account or workspace owning Cloud runtime state.
+   * Provide it from the first render and change it when that scope changes.
+   */
+  scopeId?: string | undefined;
   initialMessages?: readonly ThreadMessageLike[] | undefined;
   adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
 };
@@ -79,6 +84,7 @@ export const splitLocalRuntimeOptions = <T extends LocalRuntimeOptions>(
 ) => {
   const {
     cloud,
+    scopeId,
     initialMessages,
     maxSteps,
     adapters,
@@ -92,6 +98,7 @@ export const splitLocalRuntimeOptions = <T extends LocalRuntimeOptions>(
   return {
     localRuntimeOptions: {
       cloud,
+      scopeId,
       initialMessages,
       maxSteps,
       adapters,
@@ -106,9 +113,9 @@ export const splitLocalRuntimeOptions = <T extends LocalRuntimeOptions>(
 
 export const useLocalRuntime = (
   chatModel: ChatModelAdapter,
-  { cloud, ...options }: LocalRuntimeOptions = {},
+  { cloud, scopeId, ...options }: LocalRuntimeOptions = {},
 ): AssistantRuntime => {
-  const cloudAdapter = useCloudThreadListAdapter({ cloud });
+  const cloudAdapter = useCloudThreadListAdapter({ cloud, scopeId });
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
       return useLocalThreadRuntime(chatModel, options);

--- a/packages/react-google-adk/src/useAdkRuntime.cloud-options.test.tsx
+++ b/packages/react-google-adk/src/useAdkRuntime.cloud-options.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantCloud } from "assistant-cloud";
+import type { AssistantRuntime } from "@assistant-ui/core";
+
+const mocks = vi.hoisted(() => ({
+  cloudAdapter: {},
+  runtime: {},
+  useCloudThreadListAdapter: vi.fn(() => ({})),
+  useRemoteThreadListRuntime: vi.fn(() => ({})),
+}));
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/core/react")>()),
+  useCloudThreadListAdapter: mocks.useCloudThreadListAdapter,
+  useRemoteThreadListRuntime: mocks.useRemoteThreadListRuntime,
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => ({
+    threadListItem: {
+      source: null,
+      getState: () => ({ externalId: undefined }),
+      initialize: vi.fn(),
+    },
+  }),
+}));
+
+import { ADK_SDK } from "./sdkIdentity";
+import { useAdkRuntime } from "./useAdkRuntime";
+
+describe("useAdkRuntime Cloud options", () => {
+  it("forwards the Cloud scope to the thread-list adapter", () => {
+    const cloud = {} as AssistantCloud;
+    mocks.useCloudThreadListAdapter.mockReturnValue(mocks.cloudAdapter);
+    mocks.useRemoteThreadListRuntime.mockReturnValue(
+      mocks.runtime as AssistantRuntime,
+    );
+
+    renderHook(() =>
+      useAdkRuntime({
+        stream: vi.fn(),
+        cloud,
+        scopeId: "workspace-1",
+      }),
+    );
+
+    expect(mocks.useCloudThreadListAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloud,
+        scopeId: "workspace-1",
+        sdk: ADK_SDK,
+      }),
+    );
+  });
+});

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -106,6 +106,11 @@ export type UseAdkRuntimeOptions = ExternalStoreSharedOptions & {
     | undefined;
   cloud?: AssistantCloud | undefined;
   /**
+   * Stable identity for the account or workspace owning Cloud runtime state.
+   * Provide it from the first render and change it when that scope changes.
+   */
+  scopeId?: string | undefined;
+  /**
    * A `RemoteThreadListAdapter` to use instead of the cloud adapter.
    * Use with `createAdkSessionAdapter` for ADK session-backed persistence.
    */
@@ -497,6 +502,7 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
 
 export const useAdkRuntime = ({
   cloud,
+  scopeId,
   sessionAdapter,
   create,
   delete: deleteFn,
@@ -507,6 +513,7 @@ export const useAdkRuntime = ({
   const cloudAdapter = useCloudThreadListAdapter({
     sdk: ADK_SDK,
     cloud,
+    scopeId,
     create: createCloudThreadListAdapterCreateFallback(
       create,
       aui.threadListItem,

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -118,6 +118,11 @@ export type LangChainRuntimeExtraOptions = ExternalStoreSharedOptions & {
    */
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   cloud?: AssistantCloud | undefined;
+  /**
+   * Stable identity for the account or workspace owning Cloud runtime state.
+   * Provide it from the first render and change it when that scope changes.
+   */
+  scopeId?: string | undefined;
   adapters?:
     | {
         attachments?: AttachmentAdapter | undefined;

--- a/packages/react-langchain/src/useStreamRuntime.cloud-options.test.tsx
+++ b/packages/react-langchain/src/useStreamRuntime.cloud-options.test.tsx
@@ -4,6 +4,7 @@ import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { AssistantCloud } from "assistant-cloud";
 import type { AssistantRuntime } from "@assistant-ui/core";
+import type { UseStreamRuntimeOptions } from "./types";
 
 const mocks = vi.hoisted(() => ({
   cloudAdapter: {},
@@ -40,13 +41,13 @@ describe("useStreamRuntime Cloud options", () => {
       mocks.runtime as AssistantRuntime,
     );
 
-    renderHook(() =>
-      useStreamRuntime({
-        apiUrl: "/api",
-        cloud,
-        scopeId: "workspace-1",
-      } as never),
-    );
+    const options = {
+      apiUrl: "/api",
+      cloud,
+      scopeId: "workspace-1",
+    } satisfies UseStreamRuntimeOptions;
+
+    renderHook(() => useStreamRuntime(options));
 
     expect(mocks.useCloudThreadListAdapter).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/react-langchain/src/useStreamRuntime.cloud-options.test.tsx
+++ b/packages/react-langchain/src/useStreamRuntime.cloud-options.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantCloud } from "assistant-cloud";
+import type { AssistantRuntime } from "@assistant-ui/core";
+
+const mocks = vi.hoisted(() => ({
+  cloudAdapter: {},
+  runtime: {},
+  useCloudThreadListAdapter: vi.fn(() => ({})),
+  useRemoteThreadListRuntime: vi.fn(() => ({})),
+}));
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/core/react")>()),
+  useCloudThreadListAdapter: mocks.useCloudThreadListAdapter,
+  useRemoteThreadListRuntime: mocks.useRemoteThreadListRuntime,
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => ({
+    threadListItem: {
+      source: null,
+      getState: () => ({ externalId: undefined }),
+      initialize: vi.fn(),
+    },
+  }),
+}));
+
+import { LANGCHAIN_SDK } from "./sdkIdentity";
+import { useStreamRuntime } from "./useStreamRuntime";
+
+describe("useStreamRuntime Cloud options", () => {
+  it("forwards the Cloud scope to the thread-list adapter", () => {
+    const cloud = {} as AssistantCloud;
+    mocks.useCloudThreadListAdapter.mockReturnValue(mocks.cloudAdapter);
+    mocks.useRemoteThreadListRuntime.mockReturnValue(
+      mocks.runtime as AssistantRuntime,
+    );
+
+    renderHook(() =>
+      useStreamRuntime({
+        apiUrl: "/api",
+        cloud,
+        scopeId: "workspace-1",
+      } as never),
+    );
+
+    expect(mocks.useCloudThreadListAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloud,
+        scopeId: "workspace-1",
+        sdk: LANGCHAIN_SDK,
+      }),
+    );
+  });
+});

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -130,7 +130,7 @@ type DistributiveOmit<T, K extends keyof any> = T extends unknown
 const useStreamThreadRuntime = (
   options: DistributiveOmit<
     UseStreamRuntimeOptions,
-    "cloud" | "unstable_threadListAdapter" | "create" | "delete"
+    "cloud" | "scopeId" | "unstable_threadListAdapter" | "create" | "delete"
   >,
 ) => {
   const { adapters, autoCancelPendingToolCalls, unstable_allowCancellation } =
@@ -599,7 +599,7 @@ const useStreamThreadRuntime = (
 /**
  * Creates an assistant-ui runtime backed by LangChain's `useStream` hook.
  * Accepts the same options as `useStream` from `@langchain/react`, plus
- * `cloud` and `adapters`.
+ * `cloud`, `scopeId`, and `adapters`.
  *
  * @example
  * ```tsx
@@ -623,6 +623,7 @@ const useStreamThreadRuntime = (
 export const useStreamRuntime = (rawOptions: UseStreamRuntimeOptions) => {
   const {
     cloud,
+    scopeId,
     unstable_threadListAdapter,
     create,
     delete: deleteFn,
@@ -634,6 +635,7 @@ export const useStreamRuntime = (rawOptions: UseStreamRuntimeOptions) => {
   const cloudAdapter = useCloudThreadListAdapter({
     sdk: LANGCHAIN_SDK,
     cloud,
+    scopeId,
     create: createCloudThreadListAdapterCreateFallback(
       create,
       aui.threadListItem,

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -440,6 +440,11 @@ export type UseLangGraphRuntimeOptions = ExternalStoreSharedOptions & {
     | undefined;
   cloud?: AssistantCloud | undefined;
   /**
+   * Stable identity for the account or workspace owning Cloud runtime state.
+   * Provide it from the first render and change it when that scope changes.
+   */
+  scopeId?: string | undefined;
+  /**
    * A `RemoteThreadListAdapter` to use instead of the cloud adapter. Provide
    * this to back the thread list with a custom store (e.g. LangGraph
    * `client.threads.search()`) so pre-existing LangGraph thread ids appear in

--- a/packages/react-langgraph/src/useLangGraphRuntime.cloud-options.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.cloud-options.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantCloud } from "assistant-cloud";
+import type { AssistantRuntime } from "@assistant-ui/core";
+
+const mocks = vi.hoisted(() => ({
+  cloudAdapter: {},
+  runtime: {},
+  useCloudThreadListAdapter: vi.fn(() => ({})),
+  useRemoteThreadListRuntime: vi.fn(() => ({})),
+}));
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/core/react")>()),
+  useCloudThreadListAdapter: mocks.useCloudThreadListAdapter,
+  useRemoteThreadListRuntime: mocks.useRemoteThreadListRuntime,
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => ({
+    threadListItem: {
+      source: null,
+      getState: () => ({ externalId: undefined }),
+      initialize: vi.fn(),
+    },
+  }),
+}));
+
+import { LANGGRAPH_SDK } from "./sdkIdentity";
+import { useLangGraphRuntime } from "./useLangGraphRuntime";
+
+describe("useLangGraphRuntime Cloud options", () => {
+  it("forwards the Cloud scope to the thread-list adapter", () => {
+    const cloud = {} as AssistantCloud;
+    mocks.useCloudThreadListAdapter.mockReturnValue(mocks.cloudAdapter);
+    mocks.useRemoteThreadListRuntime.mockReturnValue(
+      mocks.runtime as AssistantRuntime,
+    );
+
+    renderHook(() =>
+      useLangGraphRuntime({
+        stream: vi.fn(),
+        cloud,
+        scopeId: "workspace-1",
+      }),
+    );
+
+    expect(mocks.useCloudThreadListAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloud,
+        scopeId: "workspace-1",
+        sdk: LANGGRAPH_SDK,
+      }),
+    );
+  });
+});

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -875,6 +875,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
 
 export const useLangGraphRuntime = ({
   cloud,
+  scopeId,
   unstable_threadListAdapter,
   create,
   delete: deleteFn,
@@ -887,6 +888,7 @@ export const useLangGraphRuntime = ({
   const cloudAdapter = useCloudThreadListAdapter({
     sdk: LANGGRAPH_SDK,
     cloud,
+    scopeId,
     create: createCloudThreadListAdapterCreateFallback(
       create,
       aui.threadListItem,


### PR DESCRIPTION
## Problem

Cloud runtime attachment URLs and local-to-remote message ID mappings can survive an account or workspace switch. On `main` at `bd7e8fa9f79ffea10fab0741026d53cdba4cfa70`, an attachment uploaded through Cloud A can therefore be sent while Cloud B is active, and stale message mappings can target IDs owned by the previous scope. This closes #7203.

The focused reproduction mounts the Cloud adapter in `workspace-a`, completes an upload, switches the same runtime to `workspace-b`, and calls `send()` on the attachment. Before the fix, it returns Cloud A's URL. The retained regression is `packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts`, test `does not send an uploaded URL after the Cloud scope changes`; reverting the implementation while keeping that test makes it fail.

## Root cause

The runtime follows the current Cloud client through a committed ref, but its long-lived attachment and persistence adapters had no account or workspace identity. Their caches were keyed only by attachment or message ID. The lower-level fix also needed a public path: the canonical runtime wrappers did not expose or forward a scope identity.

## Change

Add an optional `scopeId` to Cloud thread-list adapter options and forward it through `useLocalRuntime`, `useDataStreamRuntime`, AI SDK's `useChatRuntime` and `AISDKThreads`, Google ADK's `useAdkRuntime`, LangChain's `useStreamRuntime`, and `useLangGraphRuntime`. Applications that switch accounts or workspaces provide the stable owning ID from the runtime's first render. The documentation calls out that an asynchronously resolved ID should be available before mounting the runtime.

Changing `scopeId` creates a new message-persistence boundary, cancels in-flight uploads, and invalidates attachment URLs from the previous scope. When `scopeId` is omitted, attachment URLs and message mappings remain in the shared default scope for backward compatibility. Replacing `cloud` still replaces and reloads the thread-list adapter, so history operations attempted before that reload settles are skipped.

Uploads capture their starting Cloud client and scope. A committed scope change aborts an in-flight upload, produces an incomplete attachment, and prevents a completed URL from being sent from another scope. Message persistence uses a separate mapping instance per thread item and scope. Existing-thread history, feedback, engagement, and run-report operations resolve through the thread-list item’s existing adapter-generation guard before accessing Cloud; delayed work from a replaced adapter cannot write through the new scope. Each operation also captures its starting scope so work that outlives a committed scope switch is discarded.

The standalone factory captures its initial client and scope together; callers create a new adapter when either changes. `useCloudThreadListRuntime` resets and reloads its list when the React hook publishes that replacement. Lower-level `RemoteThreadList` compositions reload after publishing a replacement adapter, consistent with that API contract.

## Verification

- Focused core Cloud tests: 46 passed
- Full `@assistant-ui/core` suite: 1,896 passed
- Focused AI SDK wrapper tests: 14 passed
- Full `@assistant-ui/ai-sdk` suite: 279 passed
- Full `@assistant-ui/react-google-adk` suite: 340 passed
- Full `@assistant-ui/react-langchain` suite: 142 passed
- Full `@assistant-ui/react-langgraph` suite: 328 passed
- Builds for core, AI SDK, Google ADK, LangChain, and LangGraph
- `pnpm api-surface:check`
- `pnpm -C apps/docs generate:api-reference --strict`
- Size audit: every package changed by this PR remains within budget; the tool preserved an unrelated existing `assistant-cloud` mainline drift
- `pnpm workspace-ranges:check`
- `pnpm changesets:check`
- `pnpm changeset-semver:check`
- `pnpm lint`
- `git diff --check`

## Public surface

- `@assistant-ui/core`: adds optional `CloudThreadListAdapterOptions.scopeId` and `LocalRuntimeOptions.scopeId`.
- `@assistant-ui/ai-sdk`: adds optional `scopeId` to `UseChatRuntimeOptions` and `AISDKThreadsOptions`.
- `@assistant-ui/react-google-adk`: adds optional `UseAdkRuntimeOptions.scopeId`.
- `@assistant-ui/react-langchain`: adds optional `LangChainRuntimeExtraOptions.scopeId`.
- `@assistant-ui/react-langgraph`: adds optional `UseLangGraphRuntimeOptions.scopeId`.
- Cloud setup documentation and generated API-surface baselines are updated.
- No exports are removed or renamed.
- Includes patch changesets for all five directly affected packages.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Vz0kbzsBy963UNVVGjtkndovcbUHoF7vX1vRFznDTFKMQZgk7I7xDy-a1RI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->


