### PR TITLE
fix(ui): count non-base64 data URL bytes correctly

### DIFF
--- a/packages/ui/src/components/react/assistant-ui/elements/file.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/file.test.tsx
@@ -57,6 +57,7 @@ describe("File inline size", () => {
     "data:text/plain;base64,Y=Q=",
     "data:text/plain;base64,YQ%ZZ",
     "data:text/plain;base64,YQ\u2028",
+    "data:application/octet-stream;base64,-_8=",
   ])("uses a zero-byte fallback for malformed data URL %s", (data) => {
     render(
       <File

--- a/packages/ui/src/components/react/assistant-ui/elements/file.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/file.test.tsx
@@ -8,6 +8,8 @@ afterEach(cleanup);
 describe("File inline size", () => {
   it.each([
     ["data:text/plain,hello%20world", "11 B"],
+    ["data:text/plain,hello%20world#section", "11 B"],
+    ["data:text/plain,hello%23world#section", "11 B"],
     ["data:text/plain,hello", "5 B"],
     ["data:,", "0 B"],
     ["data:text/plain,caf%C3%A9", "5 B"],
@@ -17,6 +19,9 @@ describe("File inline size", () => {
     ["data:text/plain,100%", "4 B"],
     ["data:text/plain,a,b=c", "5 B"],
     ["data:text/plain;base64,aGVsbG8=", "5 B"],
+    ["data:text/plain;base64,aGVsbG8%3D", "5 B"],
+    ["data:text/plain;base64,aGVsbG8%3D#section", "5 B"],
+    ["data:text/plain;base64,aGVs%20bG8%3D", "5 B"],
     ["data:text/plain;BASE64,aGVsbG8=", "5 B"],
     ["aGVsbG8=", "5 B"],
   ])("counts decoded bytes for %s", (data, size) => {

--- a/packages/ui/src/components/react/assistant-ui/elements/file.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/file.test.tsx
@@ -22,6 +22,13 @@ describe("File inline size", () => {
     ["data:text/plain;base64,aGVsbG8%3D", "5 B"],
     ["data:text/plain;base64,aGVsbG8%3D#section", "5 B"],
     ["data:text/plain;base64,aGVs%20bG8%3D", "5 B"],
+    ["data:text/plain;base64,%59%51%3d%3d", "1 B"],
+    ["data:text/plain;base64,aGVs\tbG8=\n", "5 B"],
+    ["data:text/plain;base64,", "0 B"],
+    ["data:text/plain;base64,YQ", "1 B"],
+    ["data:text/plain;base64,YWI", "2 B"],
+    ["data:text/plain;base64,YWJj", "3 B"],
+    ["data:application/octet-stream;base64,+/8=", "2 B"],
     ["data:text/plain;BASE64,aGVsbG8=", "5 B"],
     ["aGVsbG8=", "5 B"],
   ])("counts decoded bytes for %s", (data, size) => {
@@ -34,6 +41,32 @@ describe("File inline size", () => {
       />,
     );
     expect(screen.getByText(size)).toBeTruthy();
+  });
+
+  it.each([
+    "data:text/plain",
+    "data:text/plain#section,hello",
+    "data:text/plain;base64,aGVsbG8%2C=",
+    "data:text/plain;base64,aGVsbG8,=",
+    "data:text/plain;base64,=",
+    "data:text/plain;base64,==",
+    "data:text/plain;base64,Y===",
+    "data:text/plain;base64,YQ=",
+    "data:text/plain;base64,YQ===",
+    "data:text/plain;base64,Y",
+    "data:text/plain;base64,Y=Q=",
+    "data:text/plain;base64,YQ%ZZ",
+    "data:text/plain;base64,YQ\u2028",
+  ])("uses a zero-byte fallback for malformed data URL %s", (data) => {
+    render(
+      <File
+        type="file"
+        status={{ type: "complete" }}
+        data={data}
+        mimeType="text/plain"
+      />,
+    );
+    expect(screen.getByText("0 B")).toBeTruthy();
   });
 
   it("recognizes a data URL explicitly marked as a URL", () => {

--- a/packages/ui/src/components/react/assistant-ui/elements/file.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/file.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { File } from "./file";
+
+afterEach(cleanup);
+
+describe("File inline size", () => {
+  it.each([
+    ["data:text/plain,hello%20world", "11 B"],
+    ["data:text/plain,hello", "5 B"],
+    ["data:,", "0 B"],
+    ["data:text/plain,caf%C3%A9", "5 B"],
+    ["data:text/plain,café🙂", "9 B"],
+    ["data:application/octet-stream,%00%FF%80", "3 B"],
+    ["data:text/plain,bad%ZZ%20ok", "9 B"],
+    ["data:text/plain,100%", "4 B"],
+    ["data:text/plain,a,b=c", "5 B"],
+    ["data:text/plain;base64,aGVsbG8=", "5 B"],
+    ["data:text/plain;BASE64,aGVsbG8=", "5 B"],
+    ["aGVsbG8=", "5 B"],
+  ])("counts decoded bytes for %s", (data, size) => {
+    render(
+      <File
+        type="file"
+        status={{ type: "complete" }}
+        data={data}
+        mimeType="text/plain"
+      />,
+    );
+    expect(screen.getByText(size)).toBeTruthy();
+  });
+
+  it("recognizes a data URL explicitly marked as a URL", () => {
+    render(
+      <File
+        type="file"
+        status={{ type: "complete" }}
+        data="data:text/plain,hello%20world"
+        mimeType="text/plain"
+        sourceType="url"
+      />,
+    );
+    expect(screen.getByText("11 B")).toBeTruthy();
+  });
+
+  it.each(["url", "id"] as const)(
+    "does not guess the size of a %s",
+    (sourceType) => {
+      const { container } = render(
+        <File
+          type="file"
+          status={{ type: "complete" }}
+          data="https://example.com/file.txt"
+          mimeType="text/plain"
+          sourceType={sourceType}
+        />,
+      );
+      expect(container.querySelector('[data-slot="file-size"]')).toBeNull();
+    },
+  );
+});

--- a/packages/ui/src/components/react/assistant-ui/elements/file.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/file.tsx
@@ -80,14 +80,22 @@ function getBase64Size(base64: string): number {
 }
 
 function getDataUrlSize(data: string): number {
-  const comma = data.indexOf(",");
-  if (comma < 0 || /;base64$/i.test(data.slice(0, comma))) {
+  const withoutFragment = data.split("#", 1)[0]!;
+  const comma = withoutFragment.indexOf(",");
+  if (comma < 0) {
     return getBase64Size(data);
+  }
+  const payload = withoutFragment.slice(comma + 1);
+  if (/;base64$/i.test(withoutFragment.slice(0, comma))) {
+    const decoded = payload.replace(/%([\da-f]{2})/gi, (_match, hex: string) =>
+      String.fromCharCode(Number.parseInt(hex, 16)),
+    );
+    return getBase64Size(decoded.replace(/[\t\n\f\r ]/g, ""));
   }
 
   // Each percent escape is one byte, including octets that are not valid UTF-8.
-  const payload = data.slice(comma + 1).replace(/%[\da-f]{2}/gi, "_");
-  return new TextEncoder().encode(payload).byteLength;
+  return new TextEncoder().encode(payload.replace(/%[\da-f]{2}/gi, "_"))
+    .byteLength;
 }
 
 function formatFileSize(bytes: number): string {

--- a/packages/ui/src/components/react/assistant-ui/elements/file.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/file.tsx
@@ -79,6 +79,17 @@ function getBase64Size(base64: string): number {
   return Math.floor((base64Data.length * 3) / 4) - padding;
 }
 
+function getDataUrlSize(data: string): number {
+  const comma = data.indexOf(",");
+  if (comma < 0 || /;base64$/i.test(data.slice(0, comma))) {
+    return getBase64Size(data);
+  }
+
+  // Each percent escape is one byte, including octets that are not valid UTF-8.
+  const payload = data.slice(comma + 1).replace(/%[\da-f]{2}/gi, "_");
+  return new TextEncoder().encode(payload).byteLength;
+}
+
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) {
     return `${bytes} B`;
@@ -223,7 +234,12 @@ const FileImpl: FileMessagePartComponent = ({
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <FileName>{filename}</FileName>
         {showSize && (
-          <FileSize bytes={getBase64Size(data)} className="text-xs" />
+          <FileSize
+            bytes={
+              kind === "data-uri" ? getDataUrlSize(data) : getBase64Size(data)
+            }
+            className="text-xs"
+          />
         )}
       </div>
       <FileDownload

--- a/packages/ui/src/components/react/assistant-ui/elements/file.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/file.tsx
@@ -80,17 +80,30 @@ function getBase64Size(base64: string): number {
 }
 
 function getDataUrlSize(data: string): number {
-  const withoutFragment = data.split("#", 1)[0]!;
-  const comma = withoutFragment.indexOf(",");
-  if (comma < 0) {
-    return getBase64Size(data);
+  const fragment = data.indexOf("#");
+  const end = fragment < 0 ? data.length : fragment;
+  const comma = data.indexOf(",");
+  if (comma < 0 || comma >= end) {
+    return 0;
   }
-  const payload = withoutFragment.slice(comma + 1);
-  if (/;base64$/i.test(withoutFragment.slice(0, comma))) {
-    const decoded = payload.replace(/%([\da-f]{2})/gi, (_match, hex: string) =>
-      String.fromCharCode(Number.parseInt(hex, 16)),
-    );
-    return getBase64Size(decoded.replace(/[\t\n\f\r ]/g, ""));
+  let payload = data.slice(comma + 1, end);
+  if (/;base64$/i.test(data.slice(0, comma))) {
+    if (/[%\t\n\f\r ]/.test(payload)) {
+      payload = payload
+        .replace(/%([\da-f]{2})/gi, (_match, hex: string) =>
+          String.fromCharCode(Number.parseInt(hex, 16)),
+        )
+        .replace(/[\t\n\f\r ]/g, "");
+    }
+    const padding = payload.endsWith("==") ? 2 : payload.endsWith("=") ? 1 : 0;
+    if (
+      /[^A-Za-z\d+/]/.test(payload.slice(0, payload.length - padding)) ||
+      payload.length % 4 === 1 ||
+      (padding > 0 && payload.length % 4 !== 0)
+    ) {
+      return 0;
+    }
+    return Math.floor((payload.length * 3) / 4) - padding;
   }
 
   // Each percent escape is one byte, including octets that are not valid UTF-8.

--- a/packages/ui/src/components/react/assistant-ui/elements/file.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/file.tsx
@@ -96,8 +96,9 @@ function getDataUrlSize(data: string): number {
         .replace(/[\t\n\f\r ]/g, "");
     }
     const padding = payload.endsWith("==") ? 2 : payload.endsWith("=") ? 1 : 0;
+    const firstNonBase64 = payload.search(/[^A-Za-z\d+/]/);
     if (
-      /[^A-Za-z\d+/]/.test(payload.slice(0, payload.length - padding)) ||
+      (firstNonBase64 !== -1 && firstNonBase64 !== payload.length - padding) ||
       payload.length % 4 === 1 ||
       (padding > 0 && payload.length % 4 !== 0)
     ) {


### PR DESCRIPTION
## Problem

On main at de6d6b766, the File element shows `9 B` for a data URL containing `hello%20world`, although the decoded file is 11 bytes.

Minimal reproduction:

```tsx
<File
  type="file"
  status={{ type: "complete" }}
  data="data:text/plain,hello%20world"
  mimeType="text/plain"
/>
```

Fixes #7279.

## Root cause

All inline data URLs went through the base64 length formula, regardless of their encoding. A follow-up review also caught decoded commas being mistaken for a second URL separator.

## Change

Read the encoding from the metadata before the first comma and exclude the URL fragment.

For non-base64 data URLs, count each valid percent escape as one byte and measure unescaped text as UTF-8. This handles binary octets such as `%FF` without decoding them as Unicode. Malformed percent escapes stay literal.

For base64 data URLs, normalize percent escapes and ASCII whitespace only when present, validate the payload, then calculate its size directly. Validation scans the payload without making an unpadded substring. Valid padded and unpadded base64 remain supported. Raw base64 input keeps the existing helper.

Malformed data URLs use `0 B` as a rendering fallback, not an estimate of an unknown remote file. This includes a missing separator, invalid base64 characters, or invalid padding. Base64url characters `-` and `_` are not valid in a `;base64` data URL; a native Fetch check rejects that example rather than returning a downloadable body.

Download links, styles, and size visibility for remote URLs and file IDs are unchanged.

## Verification

- The original percent-encoded text reproduction failed before the fix.
- Follow-up regression tests reproduced the missing-separator size and negative size caused by a decoded comma before the corrections.
- `cd packages/ui && ./node_modules/.bin/vitest run src/components/react/assistant-ui/elements/file.test.tsx src/components/react/assistant-ui/tests/elements.test.tsx`: 598 passed, 16 skipped.
- Scoped oxlint, oxfmt, and `git diff --check` passed.
- The package-wide local typecheck still reports unrelated errors outside the changed files. Local checks used Node 23.11.0; the repository requires Node 24 or newer, so CI remains the supported-environment check.

## Public surface

No exported signatures changed. This updates the private UI kit's File element and its colocated tests. No changeset is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.M3Aq7MOGgp68LO9D2rmjkcOGhoZj65DPthb7KJpxtf6K9vhHx1ircZ6G-BA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->