### PR TITLE
fix(react-lexical): resync plugin cursors after selection changes

### DIFF
--- a/.changeset/lexical-cursor-invalidation.md
+++ b/.changeset/lexical-cursor-invalidation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-lexical": patch
+---
+
+fix: keep composer plugin cursor positions in sync after selection changes and edits before the caret.

--- a/packages/react-lexical/src/LexicalComposerInput.cursor.test.tsx
+++ b/packages/react-lexical/src/LexicalComposerInput.cursor.test.tsx
@@ -10,7 +10,11 @@ import {
   $getSelection,
   $isRangeSelection,
   $setSelection,
+  HISTORY_PUSH_TAG,
+  HISTORIC_TAG,
+  REDO_COMMAND,
   SKIP_DOM_SELECTION_TAG,
+  UNDO_COMMAND,
   type LexicalEditor,
   type TextNode,
 } from "lexical";
@@ -154,5 +158,73 @@ describe("LexicalComposerInput cursor tracking", () => {
       }
     });
     expect(setCursorPosition.mock.calls.length).toBe(calls);
+  });
+
+  it("resynchronizes the cursor when saved editor states replace each other", async () => {
+    let earlier: TextNode;
+    await update(() => {
+      earlier = $createTextNode("a");
+      $getRoot()
+        .getFirstChildOrThrow()
+        .insertBefore($createParagraphNode().append(earlier));
+      textNode.select(3, 3);
+    });
+    const before = editor.getEditorState();
+    await update(() => {
+      earlier.setTextContent("abcdef");
+      textNode.select(3, 3);
+    });
+    const after = editor.getEditorState();
+    expect(setCursorPosition).toHaveBeenLastCalledWith(10);
+    await act(async () =>
+      editor.setEditorState(before, { tag: SKIP_DOM_SELECTION_TAG }),
+    );
+    expect(setCursorPosition).toHaveBeenLastCalledWith(5);
+    await act(async () =>
+      editor.setEditorState(after, { tag: SKIP_DOM_SELECTION_TAG }),
+    );
+    expect(setCursorPosition).toHaveBeenLastCalledWith(10);
+  });
+
+  it("resynchronizes the absolute cursor on undo and redo", async () => {
+    let earlier: TextNode;
+    await update(() => {
+      earlier = $createTextNode("a");
+      $getRoot()
+        .getFirstChildOrThrow()
+        .insertBefore($createParagraphNode().append(earlier));
+      textNode.select(3, 3);
+    });
+    await act(async () => {
+      editor.update(
+        () => {
+          earlier.setTextContent("abcdef");
+          textNode.select(3, 3);
+        },
+        { discrete: true, tag: [HISTORY_PUSH_TAG, SKIP_DOM_SELECTION_TAG] },
+      );
+    });
+    expect(setCursorPosition).toHaveBeenLastCalledWith(10);
+    let historyText = editor
+      .getEditorState()
+      .read(() => $getRoot().getTextContent());
+    const restoredPositions: number[] = [];
+    const unsubscribe = editor.registerUpdateListener(
+      ({ editorState, tags }) => {
+        if (!tags.has(HISTORIC_TAG)) return;
+        const text = editorState.read(() => $getRoot().getTextContent());
+        if (text === historyText) return;
+        historyText = text;
+        restoredPositions.push(setCursorPosition.mock.lastCall![0]);
+      },
+    );
+    await update(() => {
+      editor.dispatchCommand(UNDO_COMMAND, undefined);
+    });
+    await update(() => {
+      editor.dispatchCommand(REDO_COMMAND, undefined);
+    });
+    unsubscribe();
+    expect(restoredPositions).toEqual([5, 10]);
   });
 });

--- a/packages/react-lexical/src/LexicalComposerInput.cursor.test.tsx
+++ b/packages/react-lexical/src/LexicalComposerInput.cursor.test.tsx
@@ -1,0 +1,158 @@
+/** @vitest-environment jsdom */
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $setSelection,
+  SKIP_DOM_SELECTION_TAG,
+  type LexicalEditor,
+  type TextNode,
+} from "lexical";
+import { LexicalComposerInput } from "./LexicalComposerInput";
+
+const { setCursorPosition, registry, aui } = vi.hoisted(() => {
+  const setCursorPosition = vi.fn<(position: number) => void>();
+  return {
+    setCursorPosition,
+    registry: {
+      getPlugins: () => [{ setCursorPosition, handleKeyDown: () => false }],
+      registerInput: () => () => {},
+    },
+    aui: { composer: { setText: () => {} }, on: () => () => {} },
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => aui,
+  useAuiState: () => false,
+}));
+
+vi.mock("@assistant-ui/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/react")>();
+  return {
+    ...actual,
+    INTERNAL: {
+      ...actual.INTERNAL,
+      useComposerInputPluginRegistryOptional: () => registry,
+    },
+  };
+});
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+function EditorProbe({
+  onEditor,
+}: {
+  onEditor: (editor: LexicalEditor) => void;
+}) {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => onEditor(editor), [editor, onEditor]);
+  return null;
+}
+
+describe("LexicalComposerInput cursor tracking", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let editor: LexicalEditor;
+  let textNode: TextNode;
+
+  const update = async (callback: () => void) => {
+    await act(async () => {
+      editor.update(callback, { discrete: true, tag: SKIP_DOM_SELECTION_TAG });
+    });
+  };
+
+  beforeEach(async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <LexicalComposerInput>
+          <EditorProbe
+            onEditor={(value) => {
+              editor = value;
+            }}
+          />
+        </LexicalComposerInput>,
+      );
+    });
+    await update(() => {
+      $getRoot().clear();
+      textNode = $createTextNode("@help");
+      $getRoot().append($createParagraphNode().append(textNode));
+      textNode.select(5, 5);
+    });
+    expect(setCursorPosition).toHaveBeenLastCalledWith(5);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("restores the cursor after a range selection collapses at the same anchor", async () => {
+    await update(() => textNode.select(2, 5));
+    expect(setCursorPosition).toHaveBeenLastCalledWith(0);
+    await update(() => textNode.select(5, 5));
+    editor.getEditorState().read(() => {
+      const selection = $getSelection();
+      expect($isRangeSelection(selection) && selection.isCollapsed()).toBe(
+        true,
+      );
+    });
+    expect(setCursorPosition).toHaveBeenLastCalledWith(5);
+  });
+
+  it("restores the cursor after the editor loses its selection", async () => {
+    await update(() => $setSelection(null));
+    expect(setCursorPosition).toHaveBeenLastCalledWith(0);
+    await update(() => textNode.select(5, 5));
+    expect(setCursorPosition).toHaveBeenLastCalledWith(5);
+  });
+
+  it("recalculates the absolute cursor after earlier text changes", async () => {
+    let earlier: TextNode;
+    await update(() => {
+      earlier = $createTextNode("a");
+      $getRoot()
+        .getFirstChildOrThrow()
+        .insertBefore($createParagraphNode().append(earlier));
+      textNode.select(3, 3);
+    });
+    expect(setCursorPosition).toHaveBeenLastCalledWith(5);
+    await update(() => {
+      earlier.setTextContent("abcdef");
+      textNode.select(3, 3);
+    });
+    expect(setCursorPosition).toHaveBeenLastCalledWith(10);
+  });
+
+  it("recalculates the absolute cursor after an earlier paragraph is inserted", async () => {
+    await update(() => {
+      $getRoot().getFirstChildOrThrow().insertBefore($createParagraphNode());
+      textNode.select(5, 5);
+    });
+    expect(setCursorPosition).toHaveBeenLastCalledWith(6);
+  });
+
+  it("does not rebroadcast an unchanged caret on a clean selection-only update", async () => {
+    const calls = setCursorPosition.mock.calls.length;
+    await update(() => {
+      const selection = $getSelection();
+      if ($isRangeSelection(selection)) {
+        const next = selection.clone();
+        next.format = next.format === 0 ? 1 : 0;
+        $setSelection(next);
+      }
+    });
+    expect(setCursorPosition.mock.calls.length).toBe(calls);
+  });
+});

--- a/packages/react-lexical/src/LexicalComposerInput.tsx
+++ b/packages/react-lexical/src/LexicalComposerInput.tsx
@@ -192,27 +192,31 @@ function CursorPlugin() {
       }
     };
 
-    return editor.registerUpdateListener(({ editorState }) => {
+    return editor.registerUpdateListener((update) => {
+      const { editorState, dirtyElements, dirtyLeaves } = update;
+      if (dirtyElements.size > 0 || dirtyLeaves.size > 0) lastAnchorKey = null;
       editorState.read(() => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+          lastAnchorKey = null;
           broadcastCursor(0);
           return;
         }
 
         const anchor = selection.anchor;
         if (anchor.type !== "text") {
+          lastAnchorKey = null;
           broadcastCursor(0);
           return;
         }
 
         const anchorNode = anchor.getNode();
         if (!$isTextNode(anchorNode)) {
+          lastAnchorKey = null;
           broadcastCursor(0);
           return;
         }
 
-        // Skip expensive tree walk if selection hasn't moved
         if (anchor.key === lastAnchorKey && anchor.offset === lastAnchorOffset)
           return;
         lastAnchorKey = anchor.key;


### PR DESCRIPTION
## Problem

Composer input plugins can keep a stale cursor after a selection collapses back to its previous anchor, or after text before the caret changes. Mention and slash-command detection then uses the wrong part of the draft.

Reproduced on main `370dcdecea426a4e35fd5a5fdfd9b410fe58e318` (`@assistant-ui/react-lexical` 0.2.12). [#7292](https://github.com/assistant-ui/assistant-ui/issues/7292) has the minimal editor-update snippet.

## Root cause

The cursor shortcut only compares the anchor key and local offset. Neither a non-collapsed selection nor a content change before the anchor invalidates that cached pair.

## Change

Clear the cached anchor when Lexical reports dirty content, or when the selection is no longer a supported collapsed text caret. Keep the existing shortcut for clean, unchanged selections.

Add coverage for selection collapse, lost selection, earlier text edits, earlier paragraph insertion, unchanged selection-only updates, saved-state replacement, and HistoryPlugin undo/redo.

## Verification

- `cd packages/react-lexical && ./node_modules/.bin/vitest run`: 57 tests passed.
- The four new regression cases fail with the production change removed and pass with it restored. The unchanged-caret case passes in both versions.
- `cd packages/react-lexical && ./node_modules/.bin/aui-build`: passed.
- Focused `oxlint`, `oxfmt --check`, and the repository's `lint-staged` tasks: passed.
- `node scripts/check-changesets.mjs`: passed.
- Shared bundle-size checker: 5,172 gzip bytes against a 5,119-byte baseline, within tolerance.

- Package typecheck reports the same 16 existing errors in `SyncPlugin.test.tsx` as the main baseline. No new diagnostics from the changed files.

Local checks used Node 23.11.0. GitHub CI remains the check for the repository's supported Node environment.

## Public surface

Only `@assistant-ui/react-lexical` behavior changes. No export, prop, documentation claim, template, or API-reference change. A patch changeset is included.

Fixes #7292.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5_oDv0szp16VHfgCib4s3N3K7-XMAu1cFj-fkSXHCDzokpm7CIvbdfNLf2k?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

