### PR TITLE
fix(react-lexical): label the editable textbox

### DIFF
--- a/.changeset/lexical-textbox-labels.md
+++ b/.changeset/lexical-textbox-labels.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-lexical": patch
 ---
 
-fix: forward accessibility labels to the Lexical composer textbox instead of its wrapper.
+fix: forward accessibility labels and description references to the Lexical composer textbox instead of its wrapper.

--- a/.changeset/lexical-textbox-labels.md
+++ b/.changeset/lexical-textbox-labels.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-lexical": patch
+---
+
+fix: forward accessibility labels to the Lexical composer textbox instead of its wrapper.

--- a/packages/react-lexical/README.md
+++ b/packages/react-lexical/README.md
@@ -17,12 +17,14 @@ import { LexicalComposerInput } from "@assistant-ui/react-lexical";
 export function Composer() {
   return (
     <ComposerPrimitive.Root>
-      <LexicalComposerInput placeholder="Ask anything..." />
+      <LexicalComposerInput aria-label="Message" placeholder="Ask anything..." />
       <ComposerPrimitive.Send />
     </ComposerPrimitive.Root>
   );
 }
 ```
+
+Use `aria-label` or `aria-labelledby` to name the editable textbox. Other HTML props and the forwarded ref apply to the outer wrapper.
 
 For custom chip rendering, pass a `directiveChip` render prop. Directives (e.g. `@user`, `/command`) survive cursor navigation, selection, and copy/paste as a single unit.
 

--- a/packages/react-lexical/README.md
+++ b/packages/react-lexical/README.md
@@ -24,7 +24,7 @@ export function Composer() {
 }
 ```
 
-Use `aria-label` or `aria-labelledby` to name the editable textbox. Other HTML props and the forwarded ref apply to the outer wrapper.
+Use `aria-label` or `aria-labelledby` to name the editable textbox, and `aria-describedby` to reference hint or error text. Other HTML props and the forwarded ref apply to the outer wrapper.
 
 For custom chip rendering, pass a `directiveChip` render prop. Directives (e.g. `@user`, `/command`) survive cursor navigation, selection, and copy/paste as a single unit.
 

--- a/packages/react-lexical/src/LexicalComposerInput.accessibility.test.tsx
+++ b/packages/react-lexical/src/LexicalComposerInput.accessibility.test.tsx
@@ -1,0 +1,119 @@
+/** @vitest-environment jsdom */
+import { act, createRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LexicalComposerInput } from "./LexicalComposerInput";
+
+const { aui } = vi.hoisted(() => ({
+  aui: { composer: { setText: () => {} }, on: () => () => {} },
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => aui,
+  useAuiState: () => false,
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("LexicalComposerInput accessibility", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const textbox = () => container.querySelector('[role="textbox"]')!;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("forwards the accessible label to the editable textbox", async () => {
+    await act(async () => {
+      root.render(
+        <LexicalComposerInput
+          aria-label="Message"
+          placeholder="Write a message"
+        />,
+      );
+    });
+    expect(textbox().getAttribute("aria-label")).toBe("Message");
+    expect(
+      container
+        .querySelector(".aui-lexical-editor")!
+        .hasAttribute("aria-label"),
+    ).toBe(false);
+  });
+
+  it("forwards referenced labels to the textbox", async () => {
+    await act(async () => {
+      root.render(
+        <>
+          <span id="message-label">Your message</span>
+          <LexicalComposerInput
+            aria-label="Fallback"
+            aria-labelledby="message-label"
+          />
+        </>,
+      );
+    });
+    expect(textbox().getAttribute("aria-label")).toBe("Fallback");
+    expect(textbox().getAttribute("aria-labelledby")).toBe("message-label");
+    expect(
+      document.getElementById(textbox().getAttribute("aria-labelledby")!)!
+        .textContent,
+    ).toBe("Your message");
+  });
+
+  it("updates and removes labels without replacing the textbox", async () => {
+    await act(async () =>
+      root.render(<LexicalComposerInput aria-label="Message" />),
+    );
+    const original = textbox();
+    await act(async () =>
+      root.render(<LexicalComposerInput aria-label="Edit message" />),
+    );
+    expect(textbox()).toBe(original);
+    expect(textbox().getAttribute("aria-label")).toBe("Edit message");
+    await act(async () =>
+      root.render(<LexicalComposerInput aria-labelledby="external-label" />),
+    );
+    expect(textbox()).toBe(original);
+    expect(textbox().hasAttribute("aria-label")).toBe(false);
+    expect(textbox().getAttribute("aria-labelledby")).toBe("external-label");
+    await act(async () => root.render(<LexicalComposerInput />));
+    expect(textbox().hasAttribute("aria-labelledby")).toBe(false);
+  });
+
+  it("keeps refs, styling, identifiers, and event handlers on the wrapper", async () => {
+    const ref = createRef<HTMLDivElement>();
+    const onClick = vi.fn();
+    await act(async () => {
+      root.render(
+        <LexicalComposerInput
+          ref={ref}
+          id="composer-shell"
+          className="custom"
+          style={{ maxHeight: 200 }}
+          onClick={onClick}
+          aria-label="Message"
+        />,
+      );
+    });
+    const wrapper = container.querySelector(".aui-lexical-editor")!;
+    expect(ref.current).toBe(wrapper);
+    expect(wrapper.id).toBe("composer-shell");
+    expect(wrapper.classList.contains("custom")).toBe(true);
+    expect(ref.current!.style.maxHeight).toBe("200px");
+    expect(ref.current!.style.overflowY).toBe("auto");
+    await act(async () => {
+      textbox().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react-lexical/src/LexicalComposerInput.accessibility.test.tsx
+++ b/packages/react-lexical/src/LexicalComposerInput.accessibility.test.tsx
@@ -116,4 +116,32 @@ describe("LexicalComposerInput accessibility", () => {
     });
     expect(onClick).toHaveBeenCalledOnce();
   });
+
+  it("connects hint text to the textbox and updates the description reference", async () => {
+    const renderDescription = async (id?: string) => {
+      await act(async () => {
+        root.render(
+          <>
+            <span id="composer-hint">Press Enter to send</span>
+            <span id="composer-error">Message is required</span>
+            <LexicalComposerInput aria-describedby={id} />
+          </>,
+        );
+      });
+    };
+    await renderDescription("composer-hint");
+    const original = textbox();
+    expect(textbox().getAttribute("aria-describedby")).toBe("composer-hint");
+    expect(
+      container
+        .querySelector(".aui-lexical-editor")!
+        .hasAttribute("aria-describedby"),
+    ).toBe(false);
+    await renderDescription("composer-error");
+    expect(textbox()).toBe(original);
+    expect(textbox().getAttribute("aria-describedby")).toBe("composer-error");
+    await renderDescription();
+    expect(textbox()).toBe(original);
+    expect(textbox().hasAttribute("aria-describedby")).toBe(false);
+  });
 });

--- a/packages/react-lexical/src/LexicalComposerInput.tsx
+++ b/packages/react-lexical/src/LexicalComposerInput.tsx
@@ -283,6 +283,7 @@ export const LexicalComposerInput = forwardRef<
       formatter: formatterProp,
       "aria-label": ariaLabel,
       "aria-labelledby": ariaLabelledBy,
+      "aria-describedby": ariaDescribedBy,
       className,
       children,
       ...rest
@@ -325,6 +326,7 @@ export const LexicalComposerInput = forwardRef<
                   className="aui-lexical-input"
                   aria-label={ariaLabel}
                   aria-labelledby={ariaLabelledBy}
+                  aria-describedby={ariaDescribedBy}
                 />
               }
               placeholder={

--- a/packages/react-lexical/src/LexicalComposerInput.tsx
+++ b/packages/react-lexical/src/LexicalComposerInput.tsx
@@ -281,6 +281,8 @@ export const LexicalComposerInput = forwardRef<
       directivePluginProps,
       directiveChip,
       formatter: formatterProp,
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledBy,
       className,
       children,
       ...rest
@@ -319,7 +321,11 @@ export const LexicalComposerInput = forwardRef<
           >
             <PlainTextPlugin
               contentEditable={
-                <ContentEditable className="aui-lexical-input" />
+                <ContentEditable
+                  className="aui-lexical-input"
+                  aria-label={ariaLabel}
+                  aria-labelledby={ariaLabelledBy}
+                />
               }
               placeholder={
                 placeholder ? (


### PR DESCRIPTION
## Problem

`<LexicalComposerInput aria-label="Message" />` leaves the editable textbox unnamed because the label is placed on its wrapper instead.

Reproduced on main `370dcdecea426a4e35fd5a5fdfd9b410fe58e318` (`@assistant-ui/react-lexical` 0.2.12). [#7293](https://github.com/assistant-ui/assistant-ui/issues/7293) contains the minimal JSX reproduction.

## Root cause

All consumer HTML props are forwarded to the outer div, while the nested `ContentEditable` receives only a class name.

## Change

Forward the existing `aria-label`, `aria-labelledby`, and `aria-describedby` props to the textbox. Keep the wrapper ref, ID, class, style, and event handlers where they already are.

Update the existing README example to provide a label and explain where the naming attributes go. There is no visual layout change or new prop.

## Verification

- `cd packages/react-lexical && ./node_modules/.bin/vitest run`: 55 tests passed.
- Four new accessibility regression tests fail before the fix and pass afterwards. The wrapper compatibility test passes in both versions.
- Tests cover direct labels, referenced labels, hint/error description references, updates and removal, stable textbox identity, and wrapper compatibility.
- `cd packages/react-lexical && ./node_modules/.bin/aui-build`: passed.
- Focused `oxlint`, `oxfmt --check`, and `lint-staged`: passed.
- `node scripts/check-changesets.mjs`: passed.
- Shared bundle-size checker: 5,155 gzip bytes against a 5,119-byte baseline, within tolerance.
- Package typecheck still reports the same 16 errors in the existing `SyncPlugin.test.tsx`, with byte-identical diagnostics before and after the production fix. No new diagnostics from these files.

Local checks used Node 23.11.0. GitHub CI remains the check for the repository's supported Node environment.

## Public surface

`@assistant-ui/react-lexical`: existing naming and description props now target the editable textbox. No export or prop-type changes, and no API-reference or template changes. README usage and a patch changeset are included.

Fixes #7293.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.EeVWhd06R1XeMU9TFFdG9bxdm0PSrbOiYL4qV0Hjz79ki3-jofz0LKGAx0o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->