### PR TITLE
fix(react-ink): defer highlighting hidden diff lines

### DIFF
--- a/.changeset/ink-visible-diff-highlighting.md
+++ b/.changeset/ink-visible-diff-highlighting.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix: calculate word-level diff highlighting only for visible line pairs and reuse it when a preview expands or shrinks.

--- a/packages/react-ink/package.json
+++ b/packages/react-ink/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@assistant-ui/x-performance": "workspace:*",
     "@types/node": "^26.4.1",
     "@types/react": "^19.2.18",
     "ink": "^7.1.1",

--- a/packages/react-ink/src/primitives/diff/DiffView.highlighting.test.tsx
+++ b/packages/react-ink/src/primitives/diff/DiffView.highlighting.test.tsx
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+import { createRenderCounter } from "@assistant-ui/x-performance";
+import { DiffView } from "./DiffView";
+
+const { recordHighlight } = vi.hoisted(() => ({ recordHighlight: vi.fn() }));
+vi.mock("./intra-line-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./intra-line-utils")>();
+  return {
+    ...actual,
+    buildIntraLineSegments: (
+      ...args: Parameters<typeof actual.buildIntraLineSegments>
+    ) => {
+      recordHighlight();
+      return actual.buildIntraLineSegments(...args);
+    },
+  };
+});
+
+const counter = createRenderCounter();
+
+const makePatch = (pairs: number) =>
+  [
+    "diff --git a/demo.txt b/demo.txt",
+    "--- a/demo.txt",
+    "+++ b/demo.txt",
+    `@@ -1,${pairs * 2} +1,${pairs * 2} @@`,
+    ...Array.from(
+      { length: pairs },
+      (_, i) => `-old ${i}\n+new ${i}\n context ${i}`,
+    ),
+    "",
+  ].join("\n");
+
+describe("DiffView highlighting work", () => {
+  beforeEach(() => {
+    counter.reset();
+    recordHighlight.mockImplementation(() => counter.useRender("word-diff"));
+  });
+
+  afterEach(() => cleanup());
+
+  it("highlights one visible replacement pair in a 1,000-pair preview", async () => {
+    const instance = render(<DiffView patch={makePatch(1000)} maxLines={2} />);
+    await vi.waitFor(() =>
+      expect(instance.lastFrame()).toContain("2998 more lines"),
+    );
+    expect(instance.lastFrame()).toContain("old 0");
+    expect(instance.lastFrame()).toContain("new 0");
+    expect(instance.lastFrame()).not.toContain("old 999");
+    expect(counter.renders("word-diff")).toBe(1);
+  });
+
+  it("reuses both sides of each pair as the preview expands and shrinks", async () => {
+    const patch = makePatch(3);
+    const instance = render(<DiffView patch={patch} maxLines={1} />);
+    await vi.waitFor(() =>
+      expect(instance.lastFrame()).toContain("8 more lines"),
+    );
+    expect(counter.renders("word-diff")).toBe(1);
+
+    for (const [maxLines, calls] of [
+      [2, 1],
+      [5, 2],
+      [8, 3],
+      [2, 3],
+      [8, 3],
+    ] as const) {
+      instance.rerender(<DiffView patch={patch} maxLines={maxLines} />);
+      await vi.waitFor(() =>
+        expect(instance.lastFrame()).toContain(`${9 - maxLines} more lines`),
+      );
+      expect(counter.renders("word-diff")).toBe(calls);
+    }
+  });
+
+  it("does not highlight a preview with no visible lines", async () => {
+    const instance = render(<DiffView patch={makePatch(3)} maxLines={0} />);
+    await vi.waitFor(() =>
+      expect(instance.lastFrame()).toContain("9 more lines"),
+    );
+    expect(counter.renders("word-diff")).toBe(0);
+  });
+
+  it("does not recalculate segments for unchanged input when display props change", async () => {
+    const patch = makePatch(3);
+    const instance = render(
+      <DiffView patch={patch} maxLines={2} showLineNumbers={false} />,
+    );
+    await vi.waitFor(() =>
+      expect(instance.lastFrame()).toContain("7 more lines"),
+    );
+    const firstFrame = instance.lastFrame();
+    instance.rerender(<DiffView patch={patch} maxLines={2} showLineNumbers />);
+    await vi.waitFor(() => expect(instance.lastFrame()).not.toBe(firstFrame));
+    expect(counter.renders("word-diff")).toBe(1);
+  });
+
+  it("discards old segments when the patch changes", async () => {
+    const patch = makePatch(3);
+    const instance = render(<DiffView patch={patch} maxLines={2} />);
+    await vi.waitFor(() => expect(instance.lastFrame()).toContain("old 0"));
+    expect(counter.renders("word-diff")).toBe(1);
+    instance.rerender(
+      <DiffView patch={patch.replace("old 0", "previous 0")} maxLines={2} />,
+    );
+    await vi.waitFor(() =>
+      expect(instance.lastFrame()).toContain("previous 0"),
+    );
+    expect(counter.renders("word-diff")).toBe(2);
+  });
+
+  it("preserves highlighting for an unlimited old/new file diff", async () => {
+    const instance = render(
+      <DiffView
+        oldFile={{ name: "demo", content: "old 0\nold 1\n" }}
+        newFile={{ name: "demo", content: "new 0\nnew 1\n" }}
+      />,
+    );
+    await vi.waitFor(() => expect(instance.lastFrame()).toContain("new 1"));
+    expect(instance.lastFrame()).toContain("old 0");
+    expect(instance.lastFrame()).toContain("old 1");
+    expect(instance.lastFrame()).toContain("new 0");
+    expect(counter.renders("word-diff")).toBe(2);
+  });
+
+  it("keeps unequal replacement runs unpaired", async () => {
+    const instance = render(
+      <DiffView
+        oldFile={{ content: "old\n" }}
+        newFile={{ content: "new 1\nnew 2\n" }}
+      />,
+    );
+    await vi.waitFor(() => expect(instance.lastFrame()).toContain("new 2"));
+    expect(instance.lastFrame()).toContain("old");
+    expect(counter.renders("word-diff")).toBe(0);
+  });
+});

--- a/packages/react-ink/src/primitives/diff/DiffView.tsx
+++ b/packages/react-ink/src/primitives/diff/DiffView.tsx
@@ -37,14 +37,30 @@ const INDICATOR: Record<string, string> = {
   normal: " ",
 };
 
-const EMPTY_SEGMENT_MAP = new Map<ParsedLine, StyledDiffSegment[]>();
+type SegmentReader = (line: ParsedLine) => StyledDiffSegment[] | undefined;
+
+const EMPTY_SEGMENT_READER: SegmentReader = () => undefined;
 
 const isDevNull = (n: string | undefined) => !n || n === "/dev/null";
 
-const buildSegmentMap = (lines: ParsedLine[]) => {
+const createSegmentReader = (lines: ParsedLine[]): SegmentReader => {
+  const partners = new Map<ParsedLine, ParsedLine>();
   const segmentMap = new Map<ParsedLine, StyledDiffSegment[]>();
 
   for (const [del, add] of buildLinePairMap(lines)) {
+    partners.set(del, add);
+    partners.set(add, del);
+  }
+
+  return (line) => {
+    const cached = segmentMap.get(line);
+    if (cached) return cached;
+
+    const partner = partners.get(line);
+    if (!partner) return undefined;
+
+    const del = line.type === "del" ? line : partner;
+    const add = line.type === "add" ? line : partner;
     const { delSegments, addSegments } = buildIntraLineSegments(
       del.content,
       add.content,
@@ -52,9 +68,8 @@ const buildSegmentMap = (lines: ParsedLine[]) => {
 
     segmentMap.set(del, delSegments);
     segmentMap.set(add, addSegments);
-  }
-
-  return segmentMap;
+    return segmentMap.get(line);
+  };
 };
 
 const renderSegmentedLine = (
@@ -82,11 +97,11 @@ const renderSegmentedLine = (
 const StyledLine = ({
   line,
   showLineNumbers,
-  segmentMap,
+  getSegments,
 }: {
   line: ParsedLine;
   showLineNumbers: boolean;
-  segmentMap: Map<ParsedLine, StyledDiffSegment[]>;
+  getSegments: SegmentReader;
 }) => {
   const lineNum =
     line.type === "del"
@@ -96,7 +111,7 @@ const StyledLine = ({
         : line.oldLineNumber;
   const numStr = lineNum !== undefined ? String(lineNum) : "";
   const padded = numStr.padStart(4);
-  const segments = segmentMap.get(line);
+  const segments = getSegments(line);
 
   return (
     <Box>
@@ -125,8 +140,8 @@ const DiffViewInner = ({
 }: DiffViewInnerProps) => {
   const { files } = useDiffContext();
   const shouldShowLineNumbers = showLineNumbers ?? true;
-  const segmentMaps = useMemo(
-    () => files.map((file) => buildSegmentMap(file.lines)),
+  const segmentReaders = useMemo(
+    () => files.map((file) => createSegmentReader(file.lines)),
     [files],
   );
 
@@ -170,7 +185,7 @@ const DiffViewInner = ({
                 <StyledLine
                   line={line}
                   showLineNumbers={shouldShowLineNumbers}
-                  segmentMap={segmentMaps[i] ?? EMPTY_SEGMENT_MAP}
+                  getSegments={segmentReaders[i] ?? EMPTY_SEGMENT_READER}
                 />
               )}
               renderFold={({ region }) => <StyledFold region={region} />}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4532,6 +4532,9 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
+      '@assistant-ui/x-performance':
+        specifier: workspace:*
+        version: link:../x-performance
       '@types/node':
         specifier: ^26.4.1
         version: 26.4.1


### PR DESCRIPTION
## Problem

A terminal diff preview with `maxLines={2}` still calculates word highlighting for every replacement pair. In the reproduction, one visible pair causes 1,000 calls.

Reproduced on main `370dcdecea426a4e35fd5a5fdfd9b410fe58e318` (`@assistant-ui/react-ink` 0.0.42). [#7294](https://github.com/assistant-ui/assistant-ui/issues/7294) includes the complete generated-patch snippet.

## Root cause

`DiffViewInner` eagerly builds every word-segment map before `DiffContent` decides which lines are visible.

## Change

Build the existing line-pair lookup eagerly, but calculate word segments only when a visible line needs them. Cache both sides of that pair within the current parsed file snapshot. Expanding or shrinking the preview reuses those segments, and changed input gets fresh readers.

Keep line pairing, colors, line numbers, folding, and truncation behavior unchanged. This does not make parsing or pairing constant-time; it removes unnecessary word-level diff work.

## Verification

- `cd packages/react-ink && ./node_modules/.bin/vitest run`: 300 tests passed.
- The 37 diff tests cover existing rendering behavior plus seven highlighting contracts.
- Five new regression cases fail before the production fix and pass afterwards.
- Exact measured highlighting calls for the 1,000-pair preview: **1,000 before, 1 after**. This is a call-count reduction, not a claimed wall-time speedup.
- Coverage includes preview expansion and shrinking, empty previews, display-only rerenders, changed patches, full old/new file diffs, and unequal replacement runs.
- `cd packages/react-ink && ./node_modules/.bin/aui-build`: passed.
- Focused `oxlint`, `oxfmt`, and `lint-staged`: passed.
- Changeset validation and both published entry size budgets pass.
- Package typecheck still reports the same two baseline errors in `useTextBuffer.cursor.test.ts` and `ThreadListItemScope.test.tsx`. Diagnostics match with and without the production change.

Local checks used Node 23.11.0. GitHub CI remains the check for the repository's supported Node environment.

## Public surface

Only `@assistant-ui/react-ink` implementation changes. No public exports, props, documentation claims, API-reference output, or templates change. Includes a patch changeset and the existing private performance helper as a devDependency, with its workspace lockfile entry. No new runtime dependency.

Fixes #7294.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.HjLJQCMJZfi4SuMzVKlOQtjD0LJz0JU30SvF6WLCl1Q0EpRD5YUX6KGcrYs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->