### PR TITLE
fix(core): preserve complete interim dictation text

### DIFF
--- a/.changeset/complete-dictation-preview.md
+++ b/.changeset/complete-dictation-preview.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve the complete interim dictation transcript and clear retracted browser results without duplicating finalized words.

--- a/packages/core/src/adapters/speech.test.ts
+++ b/packages/core/src/adapters/speech.test.ts
@@ -236,6 +236,33 @@ describe("WebSpeechDictationAdapter", () => {
     });
   });
 
+  it("does not drop an unconsumed final when resultIndex skips it", () => {
+    const listeners = stubSpeechRecognition();
+    const session = new WebSpeechDictationAdapter().listen();
+    const onSpeech = vi.fn();
+    const onEnd = vi.fn();
+    session.onSpeech(onSpeech);
+    session.onSpeechEnd(onEnd);
+
+    emitResults(listeners, [["hello ", false]]);
+    emitResults(
+      listeners,
+      [
+        ["hello ", true],
+        ["world", false],
+      ],
+      1,
+    );
+    listeners.get("end")!(new Event("end"));
+
+    expect(onSpeech.mock.calls).toEqual([
+      [{ transcript: "hello ", isFinal: false }],
+      [{ transcript: "hello ", isFinal: true }],
+      [{ transcript: "world", isFinal: false }],
+    ]);
+    expect(onEnd).toHaveBeenCalledExactlyOnceWith({ transcript: "hello " });
+  });
+
   it("does not reread historical finalized results during interim updates", () => {
     const listeners = stubSpeechRecognition();
     new WebSpeechDictationAdapter().listen();

--- a/packages/core/src/adapters/speech.test.ts
+++ b/packages/core/src/adapters/speech.test.ts
@@ -236,6 +236,32 @@ describe("WebSpeechDictationAdapter", () => {
     });
   });
 
+  it("does not reread historical finalized results during interim updates", () => {
+    const listeners = stubSpeechRecognition();
+    new WebSpeechDictationAdapter().listen();
+    const readFinal = vi.fn(() => ({ transcript: "word " }));
+    const finals = Array.from({ length: 1_000 }, () => ({
+      get 0() {
+        return readFinal();
+      },
+      isFinal: true,
+    }));
+    listeners.get("result")!({
+      resultIndex: 0,
+      results: finals,
+    } as unknown as Event);
+    expect(readFinal).toHaveBeenCalledTimes(1_000);
+
+    for (const transcript of ["hel", "hello", "hello world"]) {
+      listeners.get("result")!({
+        resultIndex: finals.length,
+        results: [...finals, { 0: { transcript }, isFinal: false }],
+      } as unknown as Event);
+    }
+
+    expect(readFinal).toHaveBeenCalledTimes(1_000);
+  });
+
   it("continues notifying dictation listeners when one throws", () => {
     const listeners = stubSpeechRecognition();
     const listenerError = new Error("listener failed");

--- a/packages/core/src/adapters/speech.test.ts
+++ b/packages/core/src/adapters/speech.test.ts
@@ -109,6 +109,133 @@ describe("WebSpeechDictationAdapter", () => {
     return listeners;
   };
 
+  const emitResults = (
+    listeners: Map<string, EventListener>,
+    results: [transcript: string, isFinal: boolean][],
+    resultIndex = 0,
+  ) => {
+    listeners.get("result")!({
+      resultIndex,
+      results: results.map(([transcript, isFinal]) => ({
+        0: { transcript },
+        isFinal,
+      })),
+    } as unknown as Event);
+  };
+
+  it("publishes the entire interim suffix when only its last result changes", () => {
+    const listeners = stubSpeechRecognition();
+    const session = new WebSpeechDictationAdapter().listen();
+    const onSpeech = vi.fn();
+    session.onSpeech(onSpeech);
+
+    emitResults(listeners, [
+      ["hello ", false],
+      ["world", false],
+    ]);
+    emitResults(
+      listeners,
+      [
+        ["hello ", false],
+        ["there", false],
+      ],
+      1,
+    );
+
+    expect(onSpeech.mock.calls).toEqual([
+      [{ transcript: "hello world", isFinal: false }],
+      [{ transcript: "hello there", isFinal: false }],
+    ]);
+  });
+
+  it("publishes partial and complete retractions with no changed results", () => {
+    const listeners = stubSpeechRecognition();
+    const session = new WebSpeechDictationAdapter().listen();
+    const onSpeech = vi.fn();
+    session.onSpeech(onSpeech);
+
+    emitResults(listeners, [
+      ["hello ", false],
+      ["world", false],
+    ]);
+    emitResults(listeners, [["hello ", false]], 1);
+    emitResults(listeners, []);
+    emitResults(listeners, []);
+
+    expect(onSpeech.mock.calls).toEqual([
+      [{ transcript: "hello world", isFinal: false }],
+      [{ transcript: "hello ", isFinal: false }],
+      [{ transcript: "", isFinal: false }],
+    ]);
+  });
+
+  it("delivers changed final results once before the remaining interim suffix", () => {
+    const listeners = stubSpeechRecognition();
+    const session = new WebSpeechDictationAdapter().listen();
+    const onSpeech = vi.fn();
+    const onEnd = vi.fn();
+    session.onSpeech(onSpeech);
+    session.onSpeechEnd(onEnd);
+
+    emitResults(listeners, [
+      ["hello ", true],
+      ["wor", false],
+      ["ld", false],
+    ]);
+    emitResults(
+      listeners,
+      [
+        ["hello ", true],
+        ["world", true],
+      ],
+      1,
+    );
+    listeners.get("end")!(new Event("end"));
+
+    expect(onSpeech.mock.calls).toEqual([
+      [{ transcript: "hello ", isFinal: true }],
+      [{ transcript: "world", isFinal: false }],
+      [{ transcript: "world", isFinal: true }],
+    ]);
+    expect(onEnd).toHaveBeenCalledExactlyOnceWith({
+      transcript: "hello world",
+    });
+  });
+
+  it("clears an interim suffix while retaining earlier final results", () => {
+    const listeners = stubSpeechRecognition();
+    const session = new WebSpeechDictationAdapter().listen();
+    const onSpeech = vi.fn();
+    session.onSpeech(onSpeech);
+
+    emitResults(listeners, [
+      ["hello ", true],
+      ["world", false],
+    ]);
+    emitResults(listeners, [["hello ", true]], 1);
+
+    expect(onSpeech.mock.calls).toEqual([
+      [{ transcript: "hello ", isFinal: true }],
+      [{ transcript: "world", isFinal: false }],
+      [{ transcript: "", isFinal: false }],
+    ]);
+  });
+
+  it("keeps final-only delivery free of empty interim updates", () => {
+    const listeners = stubSpeechRecognition();
+    const session = new WebSpeechDictationAdapter().listen();
+    const onSpeech = vi.fn();
+    session.onSpeech(onSpeech);
+
+    emitResults(listeners, [["hello", true]]);
+    emitResults(listeners, [["hello", true]], 1);
+
+    expect(onSpeech).toHaveBeenCalledExactlyOnceWith({
+      transcript: "hello",
+      isFinal: true,
+    });
+  });
+
   it("continues notifying dictation listeners when one throws", () => {
     const listeners = stubSpeechRecognition();
     const listenerError = new Error("listener failed");

--- a/packages/core/src/adapters/speech.ts
+++ b/packages/core/src/adapters/speech.ts
@@ -206,6 +206,7 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
 
     let finalTranscript = "";
     let hasInterimTranscript = false;
+    let firstInterimIndex = 0;
 
     const session: DictationAdapter.Session = {
       status: { type: "starting" },
@@ -270,13 +271,14 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
       const speechEvent = event as unknown as SpeechRecognitionEvent;
       let interimTranscript = "";
 
-      for (let i = 0; i < speechEvent.results.length; i++) {
+      for (let i = firstInterimIndex; i < speechEvent.results.length; i++) {
         const result = speechEvent.results[i];
         if (!result) continue;
 
         const transcript = result[0]?.transcript ?? "";
 
         if (result.isFinal) {
+          firstInterimIndex = i + 1;
           if (i < speechEvent.resultIndex) continue;
           finalTranscript += transcript;
           hasInterimTranscript = false;

--- a/packages/core/src/adapters/speech.ts
+++ b/packages/core/src/adapters/speech.ts
@@ -205,6 +205,7 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
     >();
 
     let finalTranscript = "";
+    let hasInterimTranscript = false;
 
     const session: DictationAdapter.Session = {
       status: { type: "starting" },
@@ -267,31 +268,35 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
 
     recognition.addEventListener("result", (event) => {
       const speechEvent = event as unknown as SpeechRecognitionEvent;
+      let interimTranscript = "";
 
-      for (
-        let i = speechEvent.resultIndex;
-        i < speechEvent.results.length;
-        i++
-      ) {
+      for (let i = 0; i < speechEvent.results.length; i++) {
         const result = speechEvent.results[i];
         if (!result) continue;
 
         const transcript = result[0]?.transcript ?? "";
 
         if (result.isFinal) {
+          if (i < speechEvent.resultIndex) continue;
           finalTranscript += transcript;
+          hasInterimTranscript = false;
           notifyEventListeners(
             speechCallbacks,
             () => ({ transcript, isFinal: true }),
             "Dictation",
           );
         } else {
-          notifyEventListeners(
-            speechCallbacks,
-            () => ({ transcript, isFinal: false }),
-            "Dictation",
-          );
+          interimTranscript += transcript;
         }
+      }
+
+      if (interimTranscript || hasInterimTranscript) {
+        hasInterimTranscript = interimTranscript.length > 0;
+        notifyEventListeners(
+          speechCallbacks,
+          () => ({ transcript: interimTranscript, isFinal: false }),
+          "Dictation",
+        );
       }
     });
 

--- a/packages/core/src/adapters/speech.ts
+++ b/packages/core/src/adapters/speech.ts
@@ -279,7 +279,6 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
 
         if (result.isFinal) {
           firstInterimIndex = i + 1;
-          if (i < speechEvent.resultIndex) continue;
           finalTranscript += transcript;
           hasInterimTranscript = false;
           notifyEventListeners(

--- a/packages/core/src/tests/base-composer-runtime-core.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { BaseComposerRuntimeCore } from "../runtime/base/base-composer-runtime-core";
 import type { AttachmentAdapter } from "../adapters/attachment";
 import type { DictationAdapter } from "../adapters/speech";
+import { WebSpeechDictationAdapter } from "../adapters/speech";
 import type { CreateAttachment, PendingAttachment } from "../types/attachment";
 import type { AppendMessage } from "../types/message";
 import type { SendOptions } from "../runtime/interfaces/composer-runtime-core";
@@ -74,6 +75,71 @@ describe("BaseComposerRuntimeCore", () => {
     composer.setText("same");
     expect(listener).not.toHaveBeenCalled();
   });
+
+  it.each(["", "Existing text"])(
+    "replaces the complete browser dictation preview after %j",
+    async (baseText) => {
+      vi.useFakeTimers();
+      onTestFinished(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+      });
+      const listeners = new Map<string, EventListener>();
+      class Recognition {
+        addEventListener(type: string, listener: EventListener) {
+          listeners.set(type, listener);
+        }
+        start() {}
+        stop() {
+          listeners.get("end")!(new Event("end"));
+        }
+        abort() {
+          this.stop();
+        }
+      }
+      vi.stubGlobal("window", { SpeechRecognition: Recognition });
+      composer.setDictationAdapter(new WebSpeechDictationAdapter());
+      composer.setText(baseText);
+      composer.startDictation();
+      onTestFinished(() => composer.stopDictation());
+      const emit = (results: [string, boolean][], resultIndex = 0) => {
+        listeners.get("result")!({
+          resultIndex,
+          results: results.map(([transcript, isFinal]) => ({
+            0: { transcript },
+            isFinal,
+          })),
+        } as unknown as Event);
+      };
+      const prefix = baseText ? `${baseText} ` : "";
+
+      emit([
+        ["hello ", false],
+        ["world", false],
+      ]);
+      expect(composer.text).toBe(`${prefix}hello world`);
+      emit([["hello ", false]], 1);
+      expect(composer.text).toBe(`${prefix}hello `);
+      emit([]);
+      expect(composer.text).toBe(baseText);
+      emit([
+        ["hello ", true],
+        ["world", false],
+      ]);
+      expect(composer.text).toBe(`${prefix}hello world`);
+      emit(
+        [
+          ["hello ", true],
+          ["world", true],
+        ],
+        1,
+      );
+      expect(composer.text).toBe(`${prefix}hello world`);
+      expect(composer.dictation?.transcript).toBeUndefined();
+      composer.stopDictation();
+      await Promise.resolve();
+    },
+  );
 
   it("isEmpty returns true for whitespace-only text", () => {
     composer.setText("   ");

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -13,8 +13,8 @@
   },
   "@assistant-ui/core": {
     ".": {
-      "min": 33935,
-      "gzip": 11394
+      "min": 33252,
+      "gzip": 11134
     },
     "./internal": {
       "min": 123266,

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -13,8 +13,8 @@
   },
   "@assistant-ui/core": {
     ".": {
-      "min": 33252,
-      "gzip": 11134
+      "min": 33935,
+      "gzip": 11394
     },
     "./internal": {
       "min": 123266,


### PR DESCRIPTION
## Problem

Browser dictation can drop earlier unfinished words or keep words the browser retracted. Two interim fragments, `"hello "` and `"world"`, show only `"world"` in the composer. Removing the result list leaves the old preview visible.

Reproduced on main `bd7e8fa9f79ffea10fab0741026d53cdba4cfa70`, with `@assistant-ui/core` 0.3.18. The executable reproduction is in #7299, where triage confirmed the bug and intended behavior.

## Root cause

The browser adapter emits each interim fragment separately, but the composer correctly treats each callback as a replacement for its whole unfinished suffix. A retraction may contain no changed entries, so the previous loop emitted nothing.

## Change

Publish one complete interim suffix from the current result list. Include unchanged interim entries before `resultIndex`, and clear a previously published suffix when it retracts. Keep final callbacks incremental, and do not send an extra empty preview when a final callback already cleared it.

Remember the start of the interim suffix so each update skips historical finalized results. This cursor is the sole final-result deduplication mechanism. A 1,000-result contract checks that three interim updates do not reread finalized transcripts.

The composer and public adapter types stay unchanged.

## Verification

- The six original reproduction cases (four adapter cases and two composer cases) fail without the production fix and pass with it. They cover multiple fragments, indexed updates, partial/full retractions, mixed final/interim results and existing composer text. A final-only control passes both ways.
- The PR adds nine test cases in total: seven adapter cases, including the final-only control and two cursor regressions, plus two composer cases.
- `pnpm -C packages/core exec vitest run src/adapters/speech.test.ts src/tests/base-composer-runtime-core.test.ts`: 51 passed.
- `pnpm -C packages/core test`: 173 files, 1,887 tests passed.
- `pnpm exec turbo build --filter=@assistant-ui/core --output-logs=errors-only`: passed.
- `pnpm lint`, `pnpm changesets:check`, and `git diff --check`: passed. Lint reports existing warnings elsewhere.
- Reverting the historical-result cursor makes its regression test read 4,000 finalized results instead of 1,000. Restoring it passes.
- A regression test fails when a second resultIndex guard skips an unconsumed final after advancing the cursor. Removing the redundant guard preserves the final callback and final transcript.
- Clean base build at `bd7e8fa9f`: core main entry 33,860 minified / 11,355 gzip bytes. Current PR build: 33,900 / 11,384, a difference of 40 minified / 29 gzip bytes. Both use a frozen lockfile and forced core build with the same toolchain.
- Removed the earlier size-budget update. `size-budgets.json` now matches main exactly, and `pnpm size:check` passes for all built entries against the original budgets. Unbuilt entries are skipped by the tool.
- Tests use mocked browser events and the real adapter/composer, not a microphone or speech service.

Checks ran with Node 24.21.0 and pnpm 12.3.4.

## Public surface

`@assistant-ui/core` internal behavior and regression tests, with a patch changeset. No export, type, documentation, API-reference, template or UI layout changes.

Fixes #7299.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.FQEW86Wt-ERLNj05REci-HWyy2yARrCLQ5TdZRNRDARQLqWayXTltD5MEiU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->


