### PR TITLE
fix(livekit): release rooms when voice setup ends

### DIFF
--- a/examples/with-livekit/lib/livekit-voice-adapter.test.ts
+++ b/examples/with-livekit/lib/livekit-voice-adapter.test.ts
@@ -48,11 +48,19 @@ const start = (token: string | (() => Promise<string>) = "test") => {
   return { controller, session };
 };
 
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
 describe("LiveKitVoiceAdapter cleanup", () => {
   it.each(["token", "connect", "microphone"] as const)(
     "releases the room after cancellation during %s setup",
     async (stage) => {
-      const pending = Promise.withResolvers<void>();
+      const pending = deferred();
       if (stage === "connect") mock.connect.mockReturnValue(pending.promise);
       if (stage === "microphone")
         mock.microphone.mockReturnValue(pending.promise);
@@ -135,7 +143,7 @@ describe("LiveKitVoiceAdapter cleanup", () => {
   });
 
   it("ignores late tracks while cancelled setup is still pending", async () => {
-    const pending = Promise.withResolvers<void>();
+    const pending = deferred();
     mock.connect.mockReturnValue(pending.promise);
     vi.stubGlobal("document", { body: { appendChild: vi.fn() } });
     const track = {

--- a/examples/with-livekit/lib/livekit-voice-adapter.test.ts
+++ b/examples/with-livekit/lib/livekit-voice-adapter.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RoomEvent, Track } from "livekit-client";
+import { LiveKitVoiceAdapter } from "./livekit-voice-adapter";
+
+const mock = vi.hoisted(() => ({
+  connect: vi.fn<() => Promise<void>>(),
+  disconnect: vi.fn<() => Promise<void>>(),
+  microphone: vi.fn<() => Promise<void>>(),
+  handlers: new Map<string, (...args: unknown[]) => void>(),
+}));
+
+vi.mock("livekit-client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("livekit-client")>()),
+  Room: class {
+    on(event: string, handler: (...args: unknown[]) => void) {
+      mock.handlers.set(event, handler);
+      return this;
+    }
+    connect = mock.connect;
+    disconnect = mock.disconnect;
+    localParticipant = { setMicrophoneEnabled: mock.microphone };
+    remoteParticipants = new Map();
+  },
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mock.handlers.clear();
+  mock.connect.mockResolvedValue(undefined);
+  mock.microphone.mockResolvedValue(undefined);
+  mock.disconnect.mockImplementation(async () => {
+    mock.handlers.get(RoomEvent.Disconnected)?.();
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const start = (token: string | (() => Promise<string>) = "test") => {
+  const controller = new AbortController();
+  const session = new LiveKitVoiceAdapter({
+    url: "wss://test.invalid",
+    token,
+  }).connect({ abortSignal: controller.signal });
+  return { controller, session };
+};
+
+describe("LiveKitVoiceAdapter cleanup", () => {
+  it.each(["token", "connect", "microphone"] as const)(
+    "releases the room after cancellation during %s setup",
+    async (stage) => {
+      const pending = Promise.withResolvers<void>();
+      if (stage === "connect") mock.connect.mockReturnValue(pending.promise);
+      if (stage === "microphone")
+        mock.microphone.mockReturnValue(pending.promise);
+      const { controller, session } = start(
+        stage === "token"
+          ? async () => {
+              await pending.promise;
+              return "test";
+            }
+          : "test",
+      );
+      if (stage === "microphone") {
+        await vi.waitFor(() => expect(mock.microphone).toHaveBeenCalledOnce());
+      }
+
+      controller.abort();
+      pending.resolve();
+      await vi.waitFor(() => expect(mock.disconnect).toHaveBeenCalledOnce());
+      session.disconnect();
+      expect(mock.disconnect).toHaveBeenCalledOnce();
+      expect(session.status).toMatchObject({
+        type: "ended",
+        reason: "cancelled",
+      });
+      if (stage !== "microphone")
+        expect(mock.microphone).not.toHaveBeenCalled();
+      if (stage === "token") expect(mock.connect).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["token", "connect", "microphone"] as const)(
+    "releases the room and preserves a %s setup error",
+    async (stage) => {
+      const error = new Error(`${stage} failed`);
+      if (stage === "connect") mock.connect.mockRejectedValue(error);
+      if (stage === "microphone") mock.microphone.mockRejectedValue(error);
+      const { controller, session } = start(
+        stage === "token"
+          ? async () => {
+              throw error;
+            }
+          : "test",
+      );
+
+      await vi.waitFor(() =>
+        expect(session.status).toEqual({
+          type: "ended",
+          reason: "error",
+          error,
+        }),
+      );
+      expect(mock.disconnect).toHaveBeenCalledOnce();
+      controller.abort();
+      expect(mock.disconnect).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("releases audio, timers and the room once on normal disconnect", async () => {
+    const appendChild = vi.fn();
+    vi.stubGlobal("document", { body: { appendChild } });
+    const element = { style: { display: "" }, remove: vi.fn() };
+    const track = { kind: Track.Kind.Audio, attach: vi.fn(() => element) };
+    const { session } = start();
+    await vi.waitFor(() => expect(mock.microphone).toHaveBeenCalledOnce());
+    mock.handlers.get(RoomEvent.Connected)!();
+    mock.handlers.get(RoomEvent.TrackSubscribed)!(track);
+    expect(vi.getTimerCount()).toBe(1);
+    expect(appendChild).toHaveBeenCalledWith(element);
+
+    session.disconnect();
+    session.disconnect();
+
+    expect(element.remove).toHaveBeenCalledOnce();
+    expect(mock.disconnect).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+    mock.handlers.get(RoomEvent.TrackSubscribed)!(track);
+    mock.handlers.get(RoomEvent.Connected)!();
+    expect(track.attach).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("ignores late tracks while cancelled setup is still pending", async () => {
+    const pending = Promise.withResolvers<void>();
+    mock.connect.mockReturnValue(pending.promise);
+    vi.stubGlobal("document", { body: { appendChild: vi.fn() } });
+    const track = {
+      kind: Track.Kind.Audio,
+      attach: vi.fn(() => ({ style: { display: "" }, remove: vi.fn() })),
+    };
+    const { controller } = start();
+    controller.abort();
+
+    mock.handlers.get(RoomEvent.TrackSubscribed)!(track);
+    expect(track.attach).not.toHaveBeenCalled();
+    pending.resolve();
+    await vi.waitFor(() => expect(mock.disconnect).toHaveBeenCalledOnce());
+  });
+
+  it("cleans up after a media-device error without replacing its reason", async () => {
+    const { session } = start();
+    await vi.waitFor(() => expect(mock.microphone).toHaveBeenCalledOnce());
+    const error = new Error("device lost");
+    mock.handlers.get(RoomEvent.MediaDevicesError)!(error);
+
+    expect(session.status).toEqual({ type: "ended", reason: "error", error });
+    expect(mock.disconnect).toHaveBeenCalledOnce();
+    session.disconnect();
+    expect(mock.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("preserves setup failures even if room cleanup throws", async () => {
+    const error = new Error("microphone denied");
+    mock.microphone.mockRejectedValue(error);
+    mock.disconnect.mockImplementation(() => {
+      throw new Error("cleanup failed");
+    });
+    const { session } = start();
+
+    await vi.waitFor(() =>
+      expect(session.status).toEqual({ type: "ended", reason: "error", error }),
+    );
+    expect(mock.disconnect).toHaveBeenCalledOnce();
+    expect(() => session.disconnect()).not.toThrow();
+    expect(mock.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("does not start setup when already aborted", () => {
+    const token = vi.fn(async () => "test");
+    const session = new LiveKitVoiceAdapter({
+      url: "wss://test.invalid",
+      token,
+    }).connect({
+      abortSignal: AbortSignal.abort(),
+    });
+    expect(session.status).toMatchObject({
+      type: "ended",
+      reason: "cancelled",
+    });
+    expect(token).not.toHaveBeenCalled();
+    expect(mock.connect).not.toHaveBeenCalled();
+    expect(mock.microphone).not.toHaveBeenCalled();
+  });
+
+  it("reports asynchronous teardown failures without retrying teardown", async () => {
+    const error = new Error("disconnect failed");
+    mock.disconnect.mockRejectedValue(error);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { session } = start();
+    await vi.waitFor(() => expect(mock.microphone).toHaveBeenCalledOnce());
+
+    session.disconnect();
+    await vi.waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        "Failed to disconnect LiveKit room:",
+        error,
+      ),
+    );
+    session.disconnect();
+    expect(mock.disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/examples/with-livekit/lib/livekit-voice-adapter.ts
+++ b/examples/with-livekit/lib/livekit-voice-adapter.ts
@@ -28,14 +28,19 @@ export class LiveKitVoiceAdapter implements RealtimeVoiceAdapter {
   connect(options: {
     abortSignal?: AbortSignal;
   }): RealtimeVoiceAdapter.Session {
-    const room = new Room(this._roomOptions);
-
     return createVoiceSession(options, async (session) => {
+      const room = new Room(this._roomOptions);
       let volumeInterval: ReturnType<typeof setInterval> | null = null;
       const attachedAudioElements = new Set<HTMLMediaElement>();
+      let disconnected = false;
 
       const attachRemoteAudio = (track: RemoteTrack) => {
-        if (track.kind !== Track.Kind.Audio) return;
+        if (
+          session.isDisposed() ||
+          disconnected ||
+          track.kind !== Track.Kind.Audio
+        )
+          return;
         const element = track.attach();
         element.style.display = "none";
         document.body.appendChild(element);
@@ -55,10 +60,34 @@ export class LiveKitVoiceAdapter implements RealtimeVoiceAdapter {
         attachedAudioElements.clear();
       };
 
+      const disconnect = () => {
+        if (disconnected) return;
+        disconnected = true;
+        if (volumeInterval) clearInterval(volumeInterval);
+        try {
+          cleanupAudioElements();
+        } finally {
+          room.disconnect().catch((error) => {
+            console.error("Failed to disconnect LiveKit room:", error);
+          });
+        }
+      };
+
+      const controls = {
+        disconnect,
+        mute: () => {
+          room.localParticipant.setMicrophoneEnabled(false).catch(() => {});
+        },
+        unmute: () => {
+          room.localParticipant.setMicrophoneEnabled(true).catch(() => {});
+        },
+      };
+
       room.on(RoomEvent.TrackSubscribed, attachRemoteAudio);
       room.on(RoomEvent.TrackUnsubscribed, detachRemoteAudio);
 
       room.on(RoomEvent.Connected, () => {
+        if (session.isDisposed() || disconnected) return;
         session.setStatus({ type: "running" });
         if (volumeInterval) clearInterval(volumeInterval);
         volumeInterval = setInterval(() => {
@@ -73,12 +102,12 @@ export class LiveKitVoiceAdapter implements RealtimeVoiceAdapter {
       });
 
       room.on(RoomEvent.Disconnected, () => {
-        if (volumeInterval) clearInterval(volumeInterval);
         session.end("finished");
+        disconnect();
       });
       room.on(RoomEvent.MediaDevicesError, (error) => {
-        if (volumeInterval) clearInterval(volumeInterval);
         session.end("error", error);
+        disconnect();
       });
 
       room.on(RoomEvent.ActiveSpeakersChanged, (speakers) => {
@@ -105,34 +134,21 @@ export class LiveKitVoiceAdapter implements RealtimeVoiceAdapter {
         },
       );
 
-      const token =
-        typeof this._token === "function" ? await this._token() : this._token;
-      if (session.isDisposed()) {
-        cleanupAudioElements();
-        return { disconnect: () => {}, mute: () => {}, unmute: () => {} };
+      try {
+        const token =
+          typeof this._token === "function" ? await this._token() : this._token;
+        if (session.isDisposed()) return controls;
+
+        await room.connect(this._url, token);
+        if (session.isDisposed()) return controls;
+
+        await room.localParticipant.setMicrophoneEnabled(true);
+        return controls;
+      } catch (error) {
+        session.end("error", error);
+        disconnect();
+        throw error;
       }
-
-      await room.connect(this._url, token);
-      if (session.isDisposed()) {
-        cleanupAudioElements();
-        return { disconnect: () => {}, mute: () => {}, unmute: () => {} };
-      }
-
-      await room.localParticipant.setMicrophoneEnabled(true);
-
-      return {
-        disconnect: () => {
-          if (volumeInterval) clearInterval(volumeInterval);
-          cleanupAudioElements();
-          room.disconnect();
-        },
-        mute: () => {
-          room.localParticipant.setMicrophoneEnabled(false).catch(() => {});
-        },
-        unmute: () => {
-          room.localParticipant.setMicrophoneEnabled(true).catch(() => {});
-        },
-      };
     });
   }
 }


### PR DESCRIPTION
## Problem

The LiveKit example can leave its room connected after voice setup is cancelled or fails. Cancel while `room.connect()` is pending and then let it resolve, or reject microphone initialization after connection. Before this fix neither path calls `room.disconnect()`.

Reproduced on main `bd7e8fa9f79ffea10fab0741026d53cdba4cfa70` using the checked-in example and LiveKit client 2.22.2. #7300 contains a minimal executable reproduction and confirms the intended cleanup behavior.

## Root cause

The adapter only exposes real cleanup after microphone setup succeeds. Earlier cancellation returns no-op controls, and setup rejection bypasses the returned controls entirely. Late room events can also attach audio elements or start timers after the session has ended.

## Change

Define one idempotent teardown before asynchronous setup and return its controls on cancellation. Use the same cleanup for setup failures, disconnect and terminal room events. Guard late audio/connection events, remove attached audio elements, clear volume polling, and release the room once.

Preserve the original setup or media-device error before room disconnection can emit another terminal event. Handle asynchronous room-disconnect failures without an unhandled rejection. Allocate the room inside session setup so an already-aborted session does not allocate one.

This stays inside the existing example adapter. It does not change the core voice-session contract or require another fix PR.

## Verification

- Removing the production change makes 10 of the 12 lifecycle tests fail. Restoring it passes all 12, including cancellation during token, connection and microphone setup, rejection at every stage, late events, repeated teardown, and cleanup failures.
- `pnpm -C examples/with-livekit test`: 17 tests passed, including the existing token-route tests.
- `pnpm exec turbo build --filter=@assistant-ui/react --output-logs=errors-only`: passed.
- `pnpm exec turbo build --filter=with-livekit --output-logs=errors-only`: all 18 tasks passed, including the Next.js production build and typecheck. Tests use a local deferred helper compatible with the example's existing ES2023 target.
- Focused `oxlint`, `oxfmt --check`, and `git diff --check`: passed.
- Inspected the installed LiveKit disconnect implementation, which aborts pending connection attempts and is safe for an already-disconnected room.
- Transport and browser media elements are mocked. No real microphone, credentials, paid room or deployed call was used.

Checks ran with Node 24.21.0 and pnpm 12.3.4.

## Public surface

Private LiveKit example only. No published package, changeset, exported API, documentation, API-reference or template changes.

Fixes #7300.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.DiET2FnCkuhbJq9YgPezBkUVh7oG4hhSQWONUcIII9rnKA2WPMxnTJZN-aE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
