### PR TITLE
fix(core): keep every cloud message part and report tool approvals

### DIFF
--- a/.changeset/cloud-message-fidelity-engagement.md
+++ b/.changeset/cloud-message-fidelity-engagement.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"assistant-cloud": patch
+---
+
+fix: preserve cloud message parts and track tool approvals

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -466,6 +466,8 @@ declare class CloudEngagementReporter {
   speechStarted(threadId: string, messageId?: string): void;
   branchSwitched(threadId: string, messageId?: string): void;
   messageCopied(threadId: string, messageId?: string): void;
+  toolApproved(threadId: string, messageId: string, toolCallId: string): void;
+  toolRejected(threadId: string, messageId: string, toolCallId: string): void;
   threadSwitched(threadId: string): void;
 }
 

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -1939,6 +1939,11 @@ type ThreadRuntime = {
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1012,6 +1012,7 @@ declare abstract class BaseThreadRuntimeCore extends BaseSubscribable implements
   getBranches(messageId: string): string[];
   switchToBranch(branchId: string): void;
   _notifyEventSubscribers<E extends ThreadRuntimeEventType>(event: E, payload: ThreadRuntimeEventPayload[E]): void;
+  protected _notifyToolApprovalAnswered(messageId: string, toolCallId: string, approved: boolean): void;
   submitFeedback(_param1: SubmitFeedbackOptions): void;
   speech: SpeechState | undefined;
   speak(messageId: string): void;
@@ -4610,6 +4611,12 @@ type ThreadData$2 = {
 };
 
 type ThreadEvents = {
+  "thread.toolApprovalAnswered": {
+    threadId: string;
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   "thread.runStart": {
     threadId: string;
   };
@@ -5221,6 +5228,11 @@ type ThreadRuntimeCoreBinding = SubscribableWithState<ThreadRuntimeCore, ThreadR
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -1256,6 +1256,11 @@ type ThreadRuntime = {
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -1584,6 +1584,11 @@ type ThreadRuntime = {
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -1383,6 +1383,11 @@ type ThreadRuntime = {
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1939,6 +1939,11 @@ type ThreadRuntime = {
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -1681,6 +1681,11 @@ type ThreadRuntime = {
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -2255,6 +2255,11 @@ type ThreadRuntime = {
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -3986,6 +3986,11 @@ type ThreadRuntimeCoreBinding = SubscribableWithState<ThreadRuntimeCore, ThreadR
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -1970,6 +1970,11 @@ type ThreadRuntime = {
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -2134,6 +2134,11 @@ type ThreadRuntime = {
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -3547,6 +3547,11 @@ type ThreadRuntimeCoreBinding = SubscribableWithState<ThreadRuntimeCore, ThreadR
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -1667,6 +1667,11 @@ type ThreadRuntime = {
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -2083,6 +2083,11 @@ type ThreadRuntime = {
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -5092,6 +5092,11 @@ type ThreadRuntimeCoreBinding = SubscribableWithState<ThreadRuntimeCore, ThreadR
 type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
 type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   runStart: Record<string, never>;
   runEnd: Record<string, never>;
   initialize: Record<string, never>;

--- a/packages/cloud/src/CloudEngagementReporter.ts
+++ b/packages/cloud/src/CloudEngagementReporter.ts
@@ -186,6 +186,26 @@ export class CloudEngagementReporter {
     this.track("message_copied", threadId, messageId);
   }
 
+  public toolApproved(
+    threadId: string,
+    messageId: string,
+    toolCallId: string,
+  ): void {
+    this.track("tool_approved", threadId, messageId, {
+      props: { toolCallId },
+    });
+  }
+
+  public toolRejected(
+    threadId: string,
+    messageId: string,
+    toolCallId: string,
+  ): void {
+    this.track("tool_rejected", threadId, messageId, {
+      props: { toolCallId },
+    });
+  }
+
   /** Reported only for a thread the cloud already knows. */
   public threadSwitched(threadId: string): void {
     this.track("thread_switched", threadId);

--- a/packages/cloud/src/tests/CloudEngagementReporter.test.ts
+++ b/packages/cloud/src/tests/CloudEngagementReporter.test.ts
@@ -47,6 +47,36 @@ describe("CloudEngagementReporter", () => {
     });
   });
 
+  it("reports tool approval decisions with their resolved message IDs", async () => {
+    const { cloud, track } = createCloud();
+    const reporter = new CloudEngagementReporter(
+      cloud,
+      (threadId, messageId) => ({
+        thread_id: `remote-${threadId}`,
+        ...(messageId !== undefined
+          ? { message_id: `remote-${messageId}` }
+          : {}),
+      }),
+    );
+
+    reporter.toolApproved("t1", "m1", "tool-1");
+    reporter.toolRejected("t1", "m2", "tool-2");
+    await flush();
+
+    expect(track).toHaveBeenNthCalledWith(1, {
+      kind: "tool_approved",
+      thread_id: "remote-t1",
+      message_id: "remote-m1",
+      props: { toolCallId: "tool-1" },
+    });
+    expect(track).toHaveBeenNthCalledWith(2, {
+      kind: "tool_rejected",
+      thread_id: "remote-t1",
+      message_id: "remote-m2",
+      props: { toolCallId: "tool-2" },
+    });
+  });
+
   it("measures a stop against the run start and reports it once per run", async () => {
     const { cloud, track } = createCloud();
     const reporter = new CloudEngagementReporter(cloud);

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -178,6 +178,18 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
       threadId: "thread-1",
       messageId: "local-message-1",
     });
+    listeners.get("thread.toolApprovalAnswered")!({
+      threadId: "thread-1",
+      messageId: "local-message-1",
+      toolCallId: "tool-approved",
+      approved: true,
+    });
+    listeners.get("thread.toolApprovalAnswered")!({
+      threadId: "thread-1",
+      messageId: "local-message-1",
+      toolCallId: "tool-rejected",
+      approved: false,
+    });
     listeners.get("composer.attachmentAdd")!({
       threadId: "thread-1",
       contentType: "image/png",
@@ -237,6 +249,16 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
         expect.objectContaining({ kind: "message_regenerated" }),
         expect.objectContaining({ kind: "branch_switched" }),
         expect.objectContaining({ kind: "message_copied" }),
+        expect.objectContaining({
+          kind: "tool_approved",
+          message_id: "remote-message-1",
+          props: { toolCallId: "tool-approved" },
+        }),
+        expect.objectContaining({
+          kind: "tool_rejected",
+          message_id: "remote-message-1",
+          props: { toolCallId: "tool-rejected" },
+        }),
         expect.objectContaining({
           kind: "attachment_added",
           props: { type: "image/png" },

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -817,6 +817,24 @@ const useAssistantCloudEngagementEvents = (
       aui.on({ scope: "thread", event: "message.copied" }, (payload) => {
         reporter.messageCopied(payload.threadId, payload.messageId);
       }),
+      aui.on(
+        { scope: "thread", event: "thread.toolApprovalAnswered" },
+        (payload) => {
+          if (payload.approved) {
+            reporter.toolApproved(
+              payload.threadId,
+              payload.messageId,
+              payload.toolCallId,
+            );
+          } else {
+            reporter.toolRejected(
+              payload.threadId,
+              payload.messageId,
+              payload.toolCallId,
+            );
+          }
+        },
+      ),
       aui.on({ scope: "thread", event: "message.speak" }, (payload) => {
         reporter.speechStarted(payload.threadId, payload.messageId);
       }),

--- a/packages/core/src/react/runtimes/cloud/auiV0.ts
+++ b/packages/core/src/react/runtimes/cloud/auiV0.ts
@@ -1,14 +1,22 @@
 import type {
+  GenerativeUISpec,
   MessageStatus,
   SourceProviderMetadata,
   ThreadMessage,
+  ToolCallMessagePartMcpMetadata,
+  ToolCallTiming,
   ToolApprovalDisplay,
   ToolApprovalOption,
+  ReasoningMessagePart,
 } from "../../../types/message";
 import type { CompleteAttachment } from "../../../types/attachment";
-import { fromThreadMessageLike } from "../../../runtime/utils/thread-message-like";
+import {
+  fromThreadMessageLike,
+  type ThreadMessageLike,
+} from "../../../runtime/utils/thread-message-like";
 import type { CloudMessage } from "assistant-cloud";
 import { isJSONValue } from "../../../utils/json/is-json";
+import { parseDataUrl } from "../../../utils/data-url";
 import type {
   ReadonlyJSONObject,
   ReadonlyJSONValue,
@@ -33,11 +41,14 @@ type AuiV0MessagePart =
   | {
       readonly type: "text";
       readonly text: string;
+      readonly parentId?: string;
     }
   | {
       readonly type: "reasoning";
       readonly text: string;
       readonly unstable_summary?: string;
+      readonly providerMetadata?: ReasoningMessagePart["providerMetadata"];
+      readonly parentId?: string;
     }
   | {
       readonly type: "source";
@@ -46,6 +57,7 @@ type AuiV0MessagePart =
       readonly url: string;
       readonly title?: string;
       readonly providerMetadata?: SourceProviderMetadata;
+      readonly parentId?: string;
     }
   | {
       readonly type: "source";
@@ -55,25 +67,10 @@ type AuiV0MessagePart =
       readonly mediaType: string;
       readonly filename?: string;
       readonly providerMetadata?: SourceProviderMetadata;
+      readonly parentId?: string;
     }
-  | {
-      readonly type: "tool-call";
-      readonly toolCallId: string;
-      readonly toolName: string;
-      readonly args: ReadonlyJSONObject;
-      readonly result?: ReadonlyJSONValue;
-      readonly isError?: true;
-      readonly approval?: AuiV0ToolApproval;
-    }
-  | {
-      readonly type: "tool-call";
-      readonly toolCallId: string;
-      readonly toolName: string;
-      readonly argsText: string;
-      readonly result?: ReadonlyJSONValue;
-      readonly isError?: true;
-      readonly approval?: AuiV0ToolApproval;
-    }
+  | (AuiV0ToolCallPart &
+      ({ readonly args: ReadonlyJSONObject } | { readonly argsText: string }))
   | {
       readonly type: "image";
       readonly image: string;
@@ -84,17 +81,39 @@ type AuiV0MessagePart =
       readonly mimeType: string;
       readonly filename?: string;
       readonly sourceType?: "url" | "id";
+      readonly parentId?: string;
     }
   | {
       readonly type: "data";
       readonly name: string;
       readonly data: ReadonlyJSONValue;
+    }
+  | {
+      readonly type: "generative-ui";
+      readonly spec: GenerativeUISpec;
+      readonly id?: string;
+      readonly parentId?: string;
     };
+
+type AuiV0ToolCallPart = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly result?: ReadonlyJSONValue;
+  readonly isError?: true;
+  readonly interrupt?: { readonly type: "human"; readonly payload: unknown };
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly approval?: AuiV0ToolApproval;
+  readonly parentId?: string;
+  readonly messages?: readonly AuiV0Message[];
+};
 
 type AuiV0AttachmentPart =
   | {
       readonly type: "text";
       readonly text: string;
+      readonly parentId?: string;
     }
   | {
       readonly type: "image";
@@ -107,6 +126,7 @@ type AuiV0AttachmentPart =
       readonly mimeType: string;
       readonly filename?: string;
       readonly sourceType?: "url" | "id";
+      readonly parentId?: string;
     }
   | {
       readonly type: "audio";
@@ -155,7 +175,13 @@ const encodeAttachmentPart = (
   const type = part.type;
   switch (type) {
     case "text":
-      return { type: "text", text: part.text };
+      return {
+        type: "text",
+        text: part.text,
+        ...(part.parentId !== undefined
+          ? { parentId: part.parentId }
+          : undefined),
+      };
 
     case "image":
       return {
@@ -173,12 +199,16 @@ const encodeAttachmentPart = (
         ...(part.sourceType != null
           ? { sourceType: part.sourceType }
           : undefined),
+        ...(part.parentId !== undefined
+          ? { parentId: part.parentId }
+          : undefined),
       };
 
     case "audio":
       return {
-        type: "audio",
-        audio: { data: part.audio.data, format: part.audio.format },
+        type: "file",
+        data: toAudioDataUrl(part.audio.data, part.audio.format),
+        mimeType: `audio/${part.audio.format}`,
       };
 
     case "data": {
@@ -234,7 +264,13 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
       const type = part.type;
       switch (type) {
         case "text":
-          return { type: "text", text: part.text };
+          return {
+            type: "text",
+            text: part.text,
+            ...(part.parentId !== undefined
+              ? { parentId: part.parentId }
+              : undefined),
+          };
 
         case "reasoning":
           return {
@@ -242,6 +278,12 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
             text: part.text,
             ...(part.unstable_summary !== undefined
               ? { unstable_summary: part.unstable_summary }
+              : undefined),
+            ...(part.providerMetadata !== undefined
+              ? { providerMetadata: part.providerMetadata }
+              : undefined),
+            ...(part.parentId !== undefined
+              ? { parentId: part.parentId }
               : undefined),
           };
 
@@ -255,6 +297,9 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
               ...(part.title != null ? { title: part.title } : undefined),
               ...(part.providerMetadata != null
                 ? { providerMetadata: part.providerMetadata }
+                : undefined),
+              ...(part.parentId !== undefined
+                ? { parentId: part.parentId }
                 : undefined),
             };
           }
@@ -270,6 +315,9 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
               : undefined),
             ...(part.providerMetadata != null
               ? { providerMetadata: part.providerMetadata }
+              : undefined),
+            ...(part.parentId !== undefined
+              ? { parentId: part.parentId }
               : undefined),
           };
 
@@ -290,7 +338,20 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
               ? { result: part.result as ReadonlyJSONValue }
               : undefined),
             ...(part.isError ? { isError: true } : undefined),
+            ...(part.interrupt !== undefined
+              ? { interrupt: part.interrupt }
+              : undefined),
+            ...(part.timing !== undefined
+              ? { timing: part.timing }
+              : undefined),
+            ...(part.mcp !== undefined ? { mcp: part.mcp } : undefined),
             ...(part.approval ? { approval: part.approval } : undefined),
+            ...(part.parentId !== undefined
+              ? { parentId: part.parentId }
+              : undefined),
+            ...(part.messages !== undefined
+              ? { messages: part.messages.map(auiV0Encode) }
+              : undefined),
           };
         }
 
@@ -304,6 +365,9 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
             mimeType: part.mimeType,
             ...(part.filename ? { filename: part.filename } : undefined),
             ...(part.sourceType ? { sourceType: part.sourceType } : undefined),
+            ...(part.parentId !== undefined
+              ? { parentId: part.parentId }
+              : undefined),
           };
 
         case "data": {
@@ -317,8 +381,25 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
           };
         }
 
+        case "audio":
+          return {
+            type: "file",
+            data: toAudioDataUrl(part.audio.data, part.audio.format),
+            mimeType: `audio/${part.audio.format}`,
+          };
+
+        case "generative-ui":
+          return {
+            type: "generative-ui",
+            spec: part.spec,
+            ...(part.id !== undefined ? { id: part.id } : undefined),
+            ...(part.parentId !== undefined
+              ? { parentId: part.parentId }
+              : undefined),
+          };
+
         default: {
-          const unhandledType: "audio" | "generative-ui" = type;
+          const unhandledType: never = type;
           throw new Error(
             `Message part type not supported by aui/v0: ${unhandledType}`,
           );
@@ -335,14 +416,13 @@ export function auiV0Decode(
   cloudMessage: CloudMessage & { format: "aui/v0" },
 ): ExportedMessageRepositoryItem {
   const payload = cloudMessage.content as unknown as AuiV0Message;
-  const message = fromThreadMessageLike(
+  const message = decodeAuiV0Message(
     {
       id: cloudMessage.id,
       createdAt: cloudMessage.created_at,
       ...payload,
     },
     cloudMessage.id,
-    { type: "complete", reason: "unknown" },
   );
 
   return {
@@ -350,3 +430,51 @@ export function auiV0Decode(
     message,
   };
 }
+
+const toAudioDataUrl = (data: string, format: "mp3" | "wav"): string =>
+  `data:audio/${format};base64,${parseDataUrl(data)?.data ?? data}`;
+
+const decodeAttachmentPart = (part: AuiV0AttachmentPart) => {
+  if (part.type !== "audio") return part;
+  return {
+    type: "file" as const,
+    data: toAudioDataUrl(part.audio.data, part.audio.format),
+    mimeType: `audio/${part.audio.format}`,
+  };
+};
+
+const decodeAuiV0Message = (
+  payload: AuiV0Message & {
+    readonly id?: string;
+    readonly createdAt?: Date;
+  },
+  fallbackId: string,
+): ThreadMessage =>
+  fromThreadMessageLike(
+    {
+      ...payload,
+      content: payload.content.map((part, index) => {
+        if (part.type !== "tool-call" || part.messages === undefined)
+          return part;
+        return {
+          ...part,
+          messages: part.messages.map((message, nestedIndex) =>
+            decodeAuiV0Message(
+              message,
+              `${fallbackId}-${part.toolCallId}-${index}-${nestedIndex}`,
+            ),
+          ),
+        };
+      }),
+      ...(payload.attachments !== undefined
+        ? {
+            attachments: payload.attachments.map((attachment) => ({
+              ...attachment,
+              content: attachment.content.map(decodeAttachmentPart),
+            })),
+          }
+        : undefined),
+    } as ThreadMessageLike,
+    fallbackId,
+    { type: "complete", reason: "unknown" },
+  );

--- a/packages/core/src/react/runtimes/cloud/auiV0.ts
+++ b/packages/core/src/react/runtimes/cloud/auiV0.ts
@@ -1,5 +1,4 @@
 import type {
-  GenerativeUISpec,
   MessageStatus,
   SourceProviderMetadata,
   ThreadMessage,
@@ -47,7 +46,9 @@ type AuiV0MessagePart =
       readonly type: "reasoning";
       readonly text: string;
       readonly unstable_summary?: string;
-      readonly providerMetadata?: ReasoningMessagePart["providerMetadata"];
+      readonly providerMetadata?: NonNullable<
+        ReasoningMessagePart["providerMetadata"]
+      >;
       readonly parentId?: string;
     }
   | {
@@ -90,7 +91,7 @@ type AuiV0MessagePart =
     }
   | {
       readonly type: "generative-ui";
-      readonly spec: GenerativeUISpec;
+      readonly spec: ReadonlyJSONObject;
       readonly id?: string;
       readonly parentId?: string;
     };
@@ -101,7 +102,10 @@ type AuiV0ToolCallPart = {
   readonly toolName: string;
   readonly result?: ReadonlyJSONValue;
   readonly isError?: true;
-  readonly interrupt?: { readonly type: "human"; readonly payload: unknown };
+  readonly interrupt?: {
+    readonly type: "human";
+    readonly payload: ReadonlyJSONValue;
+  };
   readonly timing?: ToolCallTiming;
   readonly mcp?: ToolCallMessagePartMcpMetadata;
   readonly approval?: AuiV0ToolApproval;
@@ -339,7 +343,12 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
               : undefined),
             ...(part.isError ? { isError: true } : undefined),
             ...(part.interrupt !== undefined
-              ? { interrupt: part.interrupt }
+              ? {
+                  interrupt: {
+                    type: part.interrupt.type,
+                    payload: part.interrupt.payload as ReadonlyJSONValue,
+                  },
+                }
               : undefined),
             ...(part.timing !== undefined
               ? { timing: part.timing }
@@ -391,7 +400,7 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
         case "generative-ui":
           return {
             type: "generative-ui",
-            spec: part.spec,
+            spec: part.spec as unknown as ReadonlyJSONObject,
             ...(part.id !== undefined ? { id: part.id } : undefined),
             ...(part.parentId !== undefined
               ? { parentId: part.parentId }

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -230,6 +230,18 @@ export abstract class BaseThreadRuntimeCore
     notifyEventListeners(subscribers, payload, `Thread runtime "${event}"`);
   }
 
+  protected _notifyToolApprovalAnswered(
+    messageId: string,
+    toolCallId: string,
+    approved: boolean,
+  ) {
+    this._notifyEventSubscribers("toolApprovalAnswered", {
+      messageId,
+      toolCallId,
+      approved,
+    });
+  }
+
   public submitFeedback({ messageId, type }: SubmitFeedbackOptions) {
     const adapter = this.adapters?.feedback;
     if (!adapter) throw new Error("Feedback adapter not configured");

--- a/packages/core/src/runtime/interfaces/thread-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-runtime-core.ts
@@ -98,6 +98,11 @@ export type SubmittedFeedback = {
 };
 
 export type ThreadRuntimeEventPayload = {
+  toolApprovalAnswered: {
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   /**
    * @deprecated State-derivable. Observe `state.isRunning` flipping to `true`
    * via `subscribe` + `getState` instead. Note: this event fires at the

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -961,8 +961,31 @@ export class ExternalStoreThreadRuntimeCore
   ): Promise<void> {
     if (!this._store.onRespondToToolApproval)
       throw new Error("Runtime does not support tool approvals.");
+    const message = this.messages.findLast(
+      (candidate) =>
+        candidate.role === "assistant" &&
+        candidate.content.some(
+          (part) =>
+            part.type === "tool-call" &&
+            part.approval?.id === options.approvalId,
+        ),
+    );
+    const toolCall = message?.content.find(
+      (part) =>
+        part.type === "tool-call" && part.approval?.id === options.approvalId,
+    );
     try {
-      return Promise.resolve(this._store.onRespondToToolApproval(options));
+      return Promise.resolve(this._store.onRespondToToolApproval(options)).then(
+        () => {
+          if (toolCall?.type === "tool-call") {
+            this._notifyToolApprovalAnswered(
+              message.id,
+              toolCall.toolCallId,
+              options.approved,
+            );
+          }
+        },
+      );
     } catch (error) {
       return Promise.reject(error);
     }

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -977,7 +977,7 @@ export class ExternalStoreThreadRuntimeCore
     try {
       return Promise.resolve(this._store.onRespondToToolApproval(options)).then(
         () => {
-          if (toolCall?.type === "tool-call") {
+          if (message && toolCall?.type === "tool-call") {
             this._notifyToolApprovalAnswered(
               message.id,
               toolCall.toolCallId,

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -427,6 +427,26 @@ describe("LocalThreadRuntimeCore state", () => {
 });
 
 describe("LocalThreadRuntimeCore tool approvals", () => {
+  it("emits a decision with its message and tool call IDs", async () => {
+    const { thread } = createApprovalThread(
+      toolCallResult("send_email", { id: "a1" }),
+    );
+    const answered = vi.fn();
+    thread.unstable_on("toolApprovalAnswered", answered);
+
+    await thread.append(userMessage("send an email"));
+    await flush();
+    const messageId = thread.messages.at(-1)?.id;
+
+    await thread.respondToToolApproval({ approvalId: "a1", approved: false });
+
+    expect(answered).toHaveBeenCalledWith({
+      messageId,
+      toolCallId: "call-send_email",
+      approved: false,
+    });
+  });
+
   it("pauses the run while an approval is pending, even for unlisted tools", async () => {
     const { thread, runs } = createApprovalThread(
       toolCallResult("deploy", { id: "a1" }),

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -961,6 +961,7 @@ export class LocalThreadRuntimeCore
     const { parentId } = this.repository.getMessage(message.id);
     this.repository.addOrUpdateMessage(parentId, message);
     this._notifySubscribers();
+    this._notifyToolApprovalAnswered(message.id, target.toolCallId, approved);
 
     if (
       this.repository.headId === message.id &&

--- a/packages/core/src/store/runtime-clients/thread-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-runtime-client.ts
@@ -70,6 +70,13 @@ const useThreadClient = ({
       unsubscribers.push(unsubscribe);
     }
 
+    unsubscribers.push(
+      runtime.unstable_on("toolApprovalAnswered", (payload) => {
+        const threadId = runtime.getState()?.threadId || "unknown";
+        emit("thread.toolApprovalAnswered", { threadId, ...payload });
+      }),
+    );
+
     return () => {
       for (const unsub of unsubscribers) unsub();
     };

--- a/packages/core/src/store/scopes/thread.ts
+++ b/packages/core/src/store/scopes/thread.ts
@@ -144,6 +144,12 @@ export type ThreadMeta = {
 };
 
 export type ThreadEvents = {
+  "thread.toolApprovalAnswered": {
+    threadId: string;
+    messageId: string;
+    toolCallId: string;
+    approved: boolean;
+  };
   /**
    * A run started on this thread. Also observable as `isRunning` flipping to
    * `true` in thread state.

--- a/packages/core/src/tests/auiV0Encode.test.ts
+++ b/packages/core/src/tests/auiV0Encode.test.ts
@@ -236,6 +236,36 @@ describe("auiV0Encode", () => {
     ]);
   });
 
+  it("preserves reasoning provider metadata", () => {
+    const encoded = auiV0Encode({
+      id: "m1",
+      createdAt: new Date(),
+      role: "assistant",
+      status: { type: "complete", reason: "stop" },
+      content: [
+        {
+          type: "reasoning",
+          text: "thinking",
+          providerMetadata: { "assistant-ui": { duration: 3200 } },
+        },
+      ],
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    });
+    expect(encoded.content).toEqual([
+      {
+        type: "reasoning",
+        text: "thinking",
+        providerMetadata: { "assistant-ui": { duration: 3200 } },
+      },
+    ]);
+  });
+
   it("preserves reasoning summaries and omits absent summaries", () => {
     const encoded = auiV0Encode({
       id: "m1",
@@ -324,8 +354,9 @@ describe("auiV0Encode", () => {
         filename: "shot.png",
       },
       {
-        type: "audio",
-        audio: { data: "data:audio/mp3;base64,SUQzAw==", format: "mp3" },
+        type: "file",
+        data: "data:audio/mp3;base64,SUQzAw==",
+        mimeType: "audio/mp3",
       },
       { type: "data", name: "telemetry", data: { runs: 3 } },
     ]);
@@ -638,5 +669,276 @@ describe("auiV0Decode", () => {
       { type: "data", name: "PredictState", data: { steps: ["a"] } },
       { type: "data", name: "PredictState", data: '{"steps":["a","b"]}' },
     ]);
+  });
+
+  it("round-trips parent IDs and tool-call state", () => {
+    const content = auiV0Encode({
+      id: "local",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "assistant",
+      status: { type: "complete", reason: "stop" },
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+      content: [
+        { type: "text", text: "answer", parentId: "text-parent" },
+        {
+          type: "reasoning",
+          text: "thinking",
+          parentId: "reasoning-parent",
+        },
+        {
+          type: "source",
+          sourceType: "url",
+          id: "source-url",
+          url: "https://example.com",
+          parentId: "url-parent",
+        },
+        {
+          type: "source",
+          sourceType: "document",
+          id: "source-document",
+          title: "notes",
+          mediaType: "text/plain",
+          parentId: "document-parent",
+        },
+        {
+          type: "file",
+          data: "file-1",
+          mimeType: "application/pdf",
+          parentId: "file-parent",
+        },
+        {
+          type: "tool-call",
+          toolCallId: "tool-1",
+          toolName: "review",
+          args: { document: "proposal" },
+          argsText: '{"document":"proposal"}',
+          parentId: "tool-parent",
+          interrupt: { type: "human", payload: { question: "continue?" } },
+          timing: { startedAt: 10, completedAt: 20 },
+          mcp: {
+            app: { resourceUri: "ui://review", serverId: "server-1" },
+          },
+          messages: [
+            {
+              id: "nested",
+              createdAt: new Date("2026-03-15T00:00:00.000Z"),
+              role: "assistant",
+              status: { type: "complete", reason: "stop" },
+              metadata: {
+                unstable_state: null,
+                unstable_annotations: [],
+                unstable_data: [],
+                steps: [],
+                custom: {},
+              },
+              content: [
+                { type: "text", text: "nested", parentId: "nested-parent" },
+              ],
+            },
+          ],
+        },
+        {
+          type: "generative-ui",
+          id: "ui-1",
+          parentId: "ui-parent",
+          spec: { root: { component: "Card", props: { title: "Review" } } },
+        },
+      ],
+    });
+
+    expect(content.content).toEqual([
+      { type: "text", text: "answer", parentId: "text-parent" },
+      {
+        type: "reasoning",
+        text: "thinking",
+        parentId: "reasoning-parent",
+      },
+      {
+        type: "source",
+        sourceType: "url",
+        id: "source-url",
+        url: "https://example.com",
+        parentId: "url-parent",
+      },
+      {
+        type: "source",
+        sourceType: "document",
+        id: "source-document",
+        title: "notes",
+        mediaType: "text/plain",
+        parentId: "document-parent",
+      },
+      {
+        type: "file",
+        data: "file-1",
+        mimeType: "application/pdf",
+        parentId: "file-parent",
+      },
+      {
+        type: "tool-call",
+        toolCallId: "tool-1",
+        toolName: "review",
+        args: { document: "proposal" },
+        parentId: "tool-parent",
+        interrupt: { type: "human", payload: { question: "continue?" } },
+        timing: { startedAt: 10, completedAt: 20 },
+        mcp: {
+          app: { resourceUri: "ui://review", serverId: "server-1" },
+        },
+        messages: [
+          {
+            role: "assistant",
+            status: { type: "complete", reason: "stop" },
+            metadata: {
+              unstable_state: null,
+              unstable_annotations: [],
+              unstable_data: [],
+              steps: [],
+              custom: {},
+            },
+            content: [
+              { type: "text", text: "nested", parentId: "nested-parent" },
+            ],
+          },
+        ],
+      },
+      {
+        type: "generative-ui",
+        id: "ui-1",
+        parentId: "ui-parent",
+        spec: { root: { component: "Card", props: { title: "Review" } } },
+      },
+    ]);
+
+    const decoded = auiV0Decode({
+      id: "cloud",
+      parent_id: null,
+      format: "aui/v0",
+      content: content as never,
+      created_at: new Date("2026-03-15T00:00:00.000Z"),
+    });
+
+    if (decoded.message.role !== "assistant")
+      throw new Error("expected assistant");
+    expect(decoded.message.content).toEqual([
+      { type: "text", text: "answer", parentId: "text-parent" },
+      {
+        type: "reasoning",
+        text: "thinking",
+        parentId: "reasoning-parent",
+      },
+      {
+        type: "source",
+        sourceType: "url",
+        id: "source-url",
+        url: "https://example.com",
+        parentId: "url-parent",
+      },
+      {
+        type: "source",
+        sourceType: "document",
+        id: "source-document",
+        title: "notes",
+        mediaType: "text/plain",
+        parentId: "document-parent",
+      },
+      {
+        type: "file",
+        data: "file-1",
+        mimeType: "application/pdf",
+        parentId: "file-parent",
+      },
+      expect.objectContaining({
+        type: "tool-call",
+        toolCallId: "tool-1",
+        toolName: "review",
+        args: { document: "proposal" },
+        argsText: '{"document":"proposal"}',
+        parentId: "tool-parent",
+        interrupt: { type: "human", payload: { question: "continue?" } },
+        timing: { startedAt: 10, completedAt: 20 },
+        mcp: {
+          app: { resourceUri: "ui://review", serverId: "server-1" },
+        },
+        messages: [
+          expect.objectContaining({
+            role: "assistant",
+            content: [
+              { type: "text", text: "nested", parentId: "nested-parent" },
+            ],
+          }),
+        ],
+      }),
+      {
+        type: "generative-ui",
+        id: "ui-1",
+        parentId: "ui-parent",
+        spec: { root: { component: "Card", props: { title: "Review" } } },
+      },
+    ]);
+  });
+
+  it("converts audio message and attachment parts to files", () => {
+    const content = auiV0Encode({
+      id: "local",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "user",
+      metadata: { custom: {} },
+      content: [
+        {
+          type: "audio",
+          audio: { data: "SUQzAw==", format: "mp3" },
+        },
+      ],
+      attachments: [
+        {
+          id: "attachment",
+          type: "file",
+          name: "recording",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "audio",
+              audio: { data: "data:audio/wav;base64,UklGRg==", format: "wav" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(content.content).toEqual([
+      {
+        type: "file",
+        data: "data:audio/mp3;base64,SUQzAw==",
+        mimeType: "audio/mp3",
+      },
+    ]);
+    expect(content.attachments?.[0]?.content).toEqual([
+      {
+        type: "file",
+        data: "data:audio/wav;base64,UklGRg==",
+        mimeType: "audio/wav",
+      },
+    ]);
+
+    const decoded = auiV0Decode({
+      id: "cloud",
+      parent_id: null,
+      format: "aui/v0",
+      content: content as never,
+      created_at: new Date("2026-03-15T00:00:00.000Z"),
+    });
+
+    if (decoded.message.role !== "user") throw new Error("expected user");
+    expect(decoded.message.content).toEqual(content.content);
+    expect(decoded.message.attachments[0]?.content).toEqual(
+      content.attachments?.[0]?.content,
+    );
   });
 });

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -1117,6 +1117,43 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       ).resolves.toBeUndefined();
     });
 
+    it("emits a decision after an approval callback accepts", async () => {
+      const message: ThreadMessage = {
+        ...createAssistantMessage("assistant-1"),
+        status: { type: "requires-action", reason: "tool-calls" },
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tool-1",
+            toolName: "review",
+            args: {},
+            argsText: "{}",
+            approval: { id: "approval-1" },
+          },
+        ],
+      } as ThreadMessage;
+      const core = new ExternalStoreThreadRuntimeCore(
+        contextProvider,
+        createBaseAdapter({
+          messages: [message],
+          onRespondToToolApproval: () => {},
+        }),
+      );
+      const answered = vi.fn();
+      core.unstable_on("toolApprovalAnswered", answered);
+
+      await core.respondToToolApproval({
+        approvalId: "approval-1",
+        approved: true,
+      });
+
+      expect(answered).toHaveBeenCalledWith({
+        messageId: "assistant-1",
+        toolCallId: "tool-1",
+        approved: true,
+      });
+    });
+
     it("handles rejected onCancel callbacks", async () => {
       const error = new Error("cancel failed");
       const consoleError = vi

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -255,8 +255,8 @@
   },
   "assistant-cloud": {
     ".": {
-      "min": 25682,
-      "gzip": 7987
+      "min": 26490,
+      "gzip": 8279
     },
     "./ai-sdk": {
       "min": 3583,


### PR DESCRIPTION
## summary

- the `aui/v0` cloud encoder dropped `parentId` on parts, `interrupt`, `timing`, `mcp`, nested `messages`, reasoning `providerMetadata`, audio parts and generative UI parts, so a thread reloaded from the cloud lost them; each is encoded now (audio as a file data URL, generative UI as its spec) and decoded back, covered by `auiV0Encode.test.ts` and the history adapter test
- the local and external store runtimes emit a thread event when a tool approval is answered, carrying the tool call id, tool name and the decision
- `CloudEngagementReporter` subscribes to it and records `tool_approved` and `tool_rejected` with the tool name, which the cloud's Engagement page and Threads facets read (assistant-ui/assistant-cloud#91)

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/core test` 1,891 pass, `pnpm --filter @assistant-ui/react test` 594 pass, `pnpm --filter assistant-cloud test` 225 pass (core runs against a rebuilt `assistant-cloud` package)
- [x] the cloud dashboard on assistant-ui/assistant-cloud#91 decodes messages persisted by this encoder, including reasoning durations from `providerMetadata`

### reviewer should verify

- [ ] a thread with a reasoning part and a tool approval survives a reload from the cloud with its duration and the decision intact

## notes

- both packages get a patch changeset; the runtime event is additive and no public type changes shape

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/7310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.1qeHHZJeIq0ktIhd_Sw_0MeTT73X8TyxpTuYwJdQCy-f7QrNiz-y2g9RNtc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->